### PR TITLE
Configure Renovate automerge and dependency grouping

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,10 +2,50 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "labels": ["dependencies"],
+  "automerge": true,
+  "automergeType": "pr",
+  "platformAutomerge": true,
   "packageRules": [
     {
       "matchManagers": ["gradle", "gradle-wrapper"],
-      "groupName": "gradle"
+      "separateMajorMinor": true,
+      "separateMinorPatch": false
+    },
+    {
+      "description": "Major updates require manual review",
+      "matchUpdateTypes": ["major"],
+      "automerge": false,
+      "labels": ["dependencies", "major"]
+    },
+    {
+      "description": "Ignore pre-release and compat versions",
+      "matchPackagePatterns": ["*"],
+      "allowedVersions": "!/(-compat|-alpha|-beta|-rc|SNAPSHOT)/"
+    },
+    {
+      "description": "Group Kotlin dependencies",
+      "matchPackagePatterns": ["^org.jetbrains.kotlin"],
+      "groupName": "kotlin"
+    },
+    {
+      "description": "Group Compose dependencies",
+      "matchPackagePatterns": ["^org.jetbrains.compose", "^androidx.compose"],
+      "groupName": "compose"
+    },
+    {
+      "description": "Group AndroidX dependencies",
+      "matchPackagePatterns": ["^androidx\\.(?!compose)"],
+      "groupName": "androidx"
+    },
+    {
+      "description": "Group Ktor dependencies",
+      "matchPackagePatterns": ["^io.ktor"],
+      "groupName": "ktor"
+    },
+    {
+      "description": "Group Firebase dependencies",
+      "matchPackagePatterns": ["^com.google.firebase"],
+      "groupName": "firebase"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Enable automerge for minor/patch updates (with platformAutomerge)
- Require manual review for major updates (adds "major" label)
- Ignore pre-release and compat versions (`-alpha`, `-beta`, `-rc`, `SNAPSHOT`, `-compat`)
- Group dependencies by type: kotlin, compose, androidx, ktor, firebase

This should result in better-named PRs and automatic merging when CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)