### PR TITLE
Fix invalid regex in Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -28,14 +28,14 @@
       "groupName": "kotlin"
     },
     {
-      "description": "Group Compose dependencies",
-      "matchPackagePatterns": ["^org.jetbrains.compose", "^androidx.compose"],
-      "groupName": "compose"
+      "description": "Group AndroidX dependencies (non-compose)",
+      "matchPackagePatterns": ["^androidx\\."],
+      "groupName": "androidx"
     },
     {
-      "description": "Group AndroidX dependencies",
-      "matchPackagePatterns": ["^androidx\\.(?!compose)"],
-      "groupName": "androidx"
+      "description": "Group Compose dependencies (overrides androidx for compose packages)",
+      "matchPackagePatterns": ["^org.jetbrains.compose", "^androidx.compose"],
+      "groupName": "compose"
     },
     {
       "description": "Group Ktor dependencies",


### PR DESCRIPTION
## Summary
- Fix invalid regex for AndroidX pattern - negative lookahead `(?!compose)` is not supported
- Reorder rules so compose group comes after androidx, allowing it to override for compose packages

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)