### PR TITLE
Rename memos to memories in Russian localization

### DIFF
--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -55,15 +55,15 @@
     <string name="format_memos_db">Memos DB: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
     <string name="format_tooltip_habits">%1$s: привычек %2$d/%3$d</string>
-    <string name="format_tooltip_memos">%1$s: мемосов %2$d</string>
-    <string name="format_memos_count">%1$d мемосов</string>
-    <string name="format_memos_today">%1$d мемосов сегодня</string>
-    <string name="format_memos_this_week">%1$d мемосов за неделю</string>
-    <string name="format_memos_in_month">%1$d мемосов за %2$s</string>
-    <string name="format_memos_in_quarter">%1$d мемосов за %2$s</string>
-    <string name="format_memos_in_year">%1$d мемосов за %2$d</string>
-    <string name="action_show_memos">Показать мемосы</string>
-    <string name="action_hide_memos">Скрыть мемосы</string>
+    <string name="format_tooltip_memos">%1$s: воспоминаний %2$d</string>
+    <string name="format_memos_count">%1$d воспоминаний</string>
+    <string name="format_memos_today">%1$d воспоминаний сегодня</string>
+    <string name="format_memos_this_week">%1$d воспоминаний за неделю</string>
+    <string name="format_memos_in_month">%1$d воспоминаний за %2$s</string>
+    <string name="format_memos_in_quarter">%1$d воспоминаний за %2$s</string>
+    <string name="format_memos_in_year">%1$d воспоминаний за %2$d</string>
+    <string name="action_show_memos">Показать воспоминания</string>
+    <string name="action_hide_memos">Скрыть воспоминания</string>
     <string name="action_write">Написать</string>
 
     <!-- Hints -->
@@ -125,7 +125,7 @@
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>
     <string name="nav_habits">Привычки</string>
-    <string name="nav_memos">Мемосы</string>
+    <string name="nav_memos">Воспоминания</string>
     <string name="nav_settings">Настройки</string>
 
     <!-- Privacy -->


### PR DESCRIPTION
## Summary
- Rename "мемосы" to "воспоминания" in all Russian strings
- Better, more natural naming for the memos tab in Russian

🤖 Generated with [Claude Code](https://claude.com/claude-code)