### PR TITLE
Add auto-merge and copilot review to PR guidelines

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,8 +85,8 @@ Use `@Suppress` annotations only when the lint rule doesn't apply (e.g., `LongPa
 **All changes must go through pull requests** — never commit directly to `main`. This ensures CI checks pass before merging and keeps the main branch green.
 
 - Create a feature branch, push, and open a PR.
-- Wait for CI to pass before merging.
-- Use squash merge to keep history clean.
+- Request review from `@copilot` for automated code review.
+- Use auto-merge with squash (`gh pr merge --auto --squash --delete-branch`).
 - Commit messages: imperative, concise, single topic (e.g., "Simplify README").
 - PR titles: use English only (no Cyrillic or other non-ASCII characters).
 - Pre-commit hook runs `checkAll` automatically — no manual checks needed.


### PR DESCRIPTION
Add rules for requesting copilot review and using auto-merge.