### PR TITLE
Constrain web app to phone-like width on desktop

### DIFF
--- a/webApp/src/wasmJsMain/resources/index.html
+++ b/webApp/src/wasmJsMain/resources/index.html
@@ -14,7 +14,8 @@
       html, body { margin: 0; padding: 0; width: 100%; height: 100%; }
       body { overflow: hidden; background-color: #1C1B1F; }
       #root {
-        margin: 0;
+        max-width: 430px;
+        margin: 0 auto;
         width: 100%;
         height: 100%;
         padding-top: env(safe-area-inset-top);


### PR DESCRIPTION
Add max-width: 430px to make the web app look like a mobile app on desktop browsers.