### PR TITLE
Enable automerge for all updates except gradle-wrapper

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,15 +19,11 @@
       "separateMinorPatch": false
     },
     {
-      "description": "Major updates require manual review",
-      "matchUpdateTypes": [
-        "major"
+      "description": "Gradle wrapper requires manual update (run ./gradlew wrapper)",
+      "matchManagers": [
+        "gradle-wrapper"
       ],
-      "automerge": false,
-      "labels": [
-        "dependencies",
-        "major"
-      ]
+      "automerge": false
     },
     {
       "description": "Ignore pre-release and compat versions",


### PR DESCRIPTION
Gradle wrapper updates require running ./gradlew wrapper command manually.