### PR TITLE
Use aspect ratio for web app on desktop

### DIFF
--- a/webApp/src/wasmJsMain/resources/index.html
+++ b/webApp/src/wasmJsMain/resources/index.html
@@ -14,10 +14,11 @@
       html, body { margin: 0; padding: 0; width: 100%; height: 100%; }
       body { overflow: hidden; background-color: #1C1B1F; }
       #root {
-        max-width: 430px;
-        margin: 0 auto;
-        width: 100%;
+        aspect-ratio: 9 / 19.5;
+        max-height: 100vh;
+        max-width: 100vw;
         height: 100%;
+        margin: 0 auto;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
         box-sizing: border-box;


### PR DESCRIPTION
Use 9:19.5 aspect ratio (iPhone-like) instead of just max-width.