### PR TITLE
Fix web app fullwidth on mobile devices

### DIFF
--- a/webApp/src/wasmJsMain/resources/index.html
+++ b/webApp/src/wasmJsMain/resources/index.html
@@ -14,14 +14,20 @@
       html, body { margin: 0; padding: 0; width: 100%; height: 100%; }
       body { overflow: hidden; background-color: #1C1B1F; }
       #root {
-        aspect-ratio: 9 / 19.5;
-        max-height: 100vh;
-        max-width: 100vw;
+        width: 100%;
         height: 100%;
-        margin: 0 auto;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
         box-sizing: border-box;
+      }
+      @media (min-width: 600px) {
+        #root {
+          aspect-ratio: 9 / 19.5;
+          max-height: 100vh;
+          max-width: 100vw;
+          width: auto;
+          margin: 0 auto;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary
- Apply aspect-ratio constraint only on desktop (min-width: 600px)
- On mobile devices, use full width without aspect ratio restriction

## Test plan
- [ ] Check on iPhone - should fill full width
- [ ] Check on desktop - should maintain phone-like aspect ratio