### PR TITLE
Fix misleading log message for memo loading

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandler.kt
@@ -30,7 +30,7 @@ class MemosEffectHandler(
         }
 
         is MemosEffect.LoadRemoteMemos -> {
-          Log.d(TAG, "Loading remote memos")
+          Log.d(TAG, "Loading memos")
           runCatching { useCases.loadMemos() }
             .onSuccess { memos -> emit(MemosAction.MemosLoaded(memos)) }
             .onFailure { error ->


### PR DESCRIPTION
## Summary
- Change "Loading remote memos" to "Loading memos" in MemosEffectHandler
- The actual loading delegates to ModeAwareMemosRepository which uses different sources based on mode

## Test plan
- [ ] Check logs in offline mode show "Loading memos" not "Loading remote memos"