### PR TITLE
Add file export feature

### DIFF
--- a/androidApp/src/main/AndroidManifest.xml
+++ b/androidApp/src/main/AndroidManifest.xml
@@ -16,5 +16,14 @@
         <category android:name="android.intent.category.LAUNCHER"/>
       </intent-filter>
     </activity>
+    <provider
+      android:name="androidx.core.content.FileProvider"
+      android:authorities="${applicationId}.fileprovider"
+      android:exported="false"
+      android:grantUriPermissions="true">
+      <meta-data
+        android:name="android.support.FILE_PROVIDER_PATHS"
+        android:resource="@xml/file_paths" />
+    </provider>
   </application>
 </manifest>

--- a/androidApp/src/main/res/xml/file_paths.xml
+++ b/androidApp/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <cache-path
+    name="exports"
+    path="exports/" />
+</paths>

--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,11 +1,12 @@
 package space.be1ski.vibits.shared.core.export
 
-import android.os.Environment
+import android.content.Intent
+import androidx.core.content.FileProvider
 import space.be1ski.vibits.shared.data.local.AndroidContextHolder
 import java.io.File
 
 /**
- * Android implementation that saves files to Documents folder.
+ * Android implementation that shares files via system share sheet.
  */
 actual class FileExporter {
   actual fun export(
@@ -14,15 +15,41 @@ actual class FileExporter {
   ): String? =
     runCatching {
       if (!AndroidContextHolder.isReady()) return@runCatching null
-      val file = getExportFile(fileName) ?: return@runCatching null
-      file.parentFile?.mkdirs()
-      file.writeText(content)
-      file.absolutePath
-    }.getOrNull()
+      val context = AndroidContextHolder.context
 
-  private fun getExportFile(fileName: String): File? {
-    val documentsDir =
-      AndroidContextHolder.context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
-    return documentsDir?.let { File(it, fileName) }
-  }
+      val exportsDir = File(context.cacheDir, "exports")
+      exportsDir.mkdirs()
+      val file = File(exportsDir, fileName)
+      file.writeText(content)
+
+      val uri =
+        FileProvider.getUriForFile(
+          context,
+          "${context.packageName}.fileprovider",
+          file,
+        )
+
+      val mimeType =
+        when {
+          fileName.endsWith(".json") -> "application/json"
+          fileName.endsWith(".txt") -> "text/plain"
+          else -> "*/*"
+        }
+
+      val shareIntent =
+        Intent(Intent.ACTION_SEND).apply {
+          type = mimeType
+          putExtra(Intent.EXTRA_STREAM, uri)
+          addFlags(Intent.FLAG_GRANT_READ_URI_PERMISSION)
+          addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+
+      val chooser =
+        Intent.createChooser(shareIntent, null).apply {
+          addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+      context.startActivity(chooser)
+
+      fileName
+    }.getOrNull()
 }

--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,0 +1,28 @@
+package space.be1ski.vibits.shared.core.export
+
+import android.os.Environment
+import space.be1ski.vibits.shared.data.local.AndroidContextHolder
+import java.io.File
+
+/**
+ * Android implementation that saves files to Documents folder.
+ */
+actual class FileExporter {
+  actual fun export(
+    fileName: String,
+    content: String,
+  ): String? =
+    runCatching {
+      if (!AndroidContextHolder.isReady()) return@runCatching null
+      val file = getExportFile(fileName) ?: return@runCatching null
+      file.parentFile?.mkdirs()
+      file.writeText(content)
+      file.absolutePath
+    }.getOrNull()
+
+  private fun getExportFile(fileName: String): File? {
+    val documentsDir =
+      AndroidContextHolder.context.getExternalFilesDir(Environment.DIRECTORY_DOCUMENTS)
+    return documentsDir?.let { File(it, fileName) }
+  }
+}

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -20,6 +20,11 @@
     <string name="action_track_today">Отметить сегодня</string>
     <string name="action_update">Обновить</string>
     <string name="action_view_logs">Логи</string>
+    <string name="action_export">Экспорт</string>
+    <string name="action_export_logs">Экспорт логов</string>
+    <string name="action_export_memos">Экспорт воспоминаний</string>
+    <string name="msg_export_success">Экспортировано в %1$s</string>
+    <string name="msg_export_failed">Ошибка экспорта</string>
 
     <!-- App -->
     <string name="app_name">Vibits</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -20,6 +20,11 @@
     <string name="action_track_today">Track today</string>
     <string name="action_update">Update</string>
     <string name="action_view_logs">View Logs</string>
+    <string name="action_export">Export</string>
+    <string name="action_export_logs">Export Logs</string>
+    <string name="action_export_memos">Export Memos</string>
+    <string name="msg_export_success">Exported to %1$s</string>
+    <string name="msg_export_failed">Export failed</string>
 
     <!-- App -->
     <string name="app_name">Vibits</string>

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,0 +1,18 @@
+package space.be1ski.vibits.shared.core.export
+
+/**
+ * Platform-specific file exporter that saves content to Downloads/Documents folder.
+ * Returns the file path on success or null on failure.
+ */
+expect class FileExporter() {
+  /**
+   * Export text content to a file.
+   * @param fileName The name of the file (e.g., "logs.txt", "memos.json")
+   * @param content The content to write
+   * @return The file path on success, null on failure
+   */
+  fun export(
+    fileName: String,
+    content: String,
+  ): String?
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/data/export/Exporter.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/data/export/Exporter.kt
@@ -1,0 +1,81 @@
+package space.be1ski.vibits.shared.data.export
+
+import dev.zacsweers.metro.Inject
+import kotlinx.serialization.json.Json
+import space.be1ski.vibits.shared.core.export.FileExporter
+import space.be1ski.vibits.shared.core.logging.Log
+import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemoStorage
+import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemosFileDto
+import kotlin.time.Clock
+
+/**
+ * Handles exporting app data to files.
+ */
+@Inject
+class Exporter(
+  private val fileExporter: FileExporter = FileExporter(),
+  private val offlineMemoStorage: OfflineMemoStorage = OfflineMemoStorage(),
+) {
+  private val json =
+    Json {
+      ignoreUnknownKeys = true
+      prettyPrint = true
+    }
+
+  /**
+   * Export logs to a text file.
+   * @return ExportResult with file name on success or error message on failure
+   */
+  fun exportLogs(): ExportResult {
+    val fileName = generateFileName("logs", "txt")
+    val content = Log.export()
+    val path = fileExporter.export(fileName, content)
+    return if (path != null) {
+      ExportResult.Success(fileName)
+    } else {
+      ExportResult.Failure
+    }
+  }
+
+  /**
+   * Export offline memos to a JSON file.
+   * @return ExportResult with file name on success or error message on failure
+   */
+  fun exportMemos(): ExportResult {
+    val fileName = generateFileName("memos", "json")
+    val data = offlineMemoStorage.load()
+    val content = json.encodeToString(OfflineMemosFileDto.serializer(), data)
+    val path = fileExporter.export(fileName, content)
+    return if (path != null) {
+      ExportResult.Success(fileName)
+    } else {
+      ExportResult.Failure
+    }
+  }
+
+  private fun generateFileName(
+    prefix: String,
+    extension: String,
+  ): String {
+    val timestamp =
+      Clock.System
+        .now()
+        .toString()
+        .replace(":", "-")
+        .replace(".", "-")
+        .take(TIMESTAMP_LENGTH)
+    return "${prefix}_$timestamp.$extension"
+  }
+
+  private companion object {
+    const val TIMESTAMP_LENGTH = 19
+  }
+}
+
+sealed interface ExportResult {
+  data class Success(
+    val fileName: String,
+  ) : ExportResult
+
+  data object Failure : ExportResult
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/data/export/Exporter.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/data/export/Exporter.kt
@@ -29,9 +29,9 @@ class Exporter(
   fun exportLogs(): ExportResult {
     val fileName = generateFileName("logs", "txt")
     val content = Log.export()
-    val path = fileExporter.export(fileName, content)
-    return if (path != null) {
-      ExportResult.Success(fileName)
+    val filePath = fileExporter.export(fileName, content)
+    return if (filePath != null) {
+      ExportResult.Success(filePath)
     } else {
       ExportResult.Failure
     }
@@ -45,9 +45,9 @@ class Exporter(
     val fileName = generateFileName("memos", "json")
     val data = offlineMemoStorage.load()
     val content = json.encodeToString(OfflineMemosFileDto.serializer(), data)
-    val path = fileExporter.export(fileName, content)
-    return if (path != null) {
-      ExportResult.Success(fileName)
+    val filePath = fileExporter.export(fileName, content)
+    return if (filePath != null) {
+      ExportResult.Success(filePath)
     } else {
       ExportResult.Failure
     }
@@ -74,7 +74,7 @@ class Exporter(
 
 sealed interface ExportResult {
   data class Success(
-    val fileName: String,
+    val filePath: String,
   ) : ExportResult
 
   data object Failure : ExportResult

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,0 +1,26 @@
+package space.be1ski.vibits.shared.core.export
+
+import java.io.File
+import java.nio.file.Paths
+
+/**
+ * Desktop implementation that saves files to ~/Documents/Vibits folder.
+ */
+actual class FileExporter {
+  actual fun export(
+    fileName: String,
+    content: String,
+  ): String? =
+    runCatching {
+      val file = getExportFile(fileName)
+      file.parentFile?.mkdirs()
+      file.writeText(content)
+      file.absolutePath
+    }.getOrNull()
+
+  private fun getExportFile(fileName: String): File {
+    val home = System.getProperty("user.home")
+    val exportDir = Paths.get(home, "Documents", "Vibits").toFile()
+    return File(exportDir, fileName)
+  }
+}

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/data/local/AppDetailsProvider.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/data/local/AppDetailsProvider.kt
@@ -9,7 +9,7 @@ import java.nio.file.Paths
 actual class AppDetailsProvider {
   actual fun load(): AppDetails {
     val home = System.getProperty("user.home")
-    val offlinePath = Paths.get(home, "Documents", "Memos", "memos.json").toString()
+    val offlinePath = Paths.get(home, "Documents", "Vibits", "memos.json").toString()
     return AppDetails(
       version = DesktopStoragePaths.appVersion(),
       environment = DesktopStoragePaths.environmentLabel(),

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/offline/OfflineMemoStorage.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/offline/OfflineMemoStorage.kt
@@ -5,7 +5,7 @@ import java.io.File
 import java.nio.file.Paths
 
 /**
- * Desktop implementation storing memos in Documents/Memos folder.
+ * Desktop implementation storing memos in Documents/Vibits folder.
  */
 actual class OfflineMemoStorage {
   private val fileName = "memos.json"
@@ -36,7 +36,7 @@ actual class OfflineMemoStorage {
 
   private fun getFile(): File {
     val home = System.getProperty("user.home")
-    val documentsDir = Paths.get(home, "Documents", "Memos").toFile()
+    val documentsDir = Paths.get(home, "Documents", "Vibits").toFile()
     return File(documentsDir, fileName)
   }
 }

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,0 +1,40 @@
+package space.be1ski.vibits.shared.core.export
+
+import kotlinx.cinterop.BetaInteropApi
+import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.usePinned
+import platform.Foundation.NSData
+import platform.Foundation.NSDocumentDirectory
+import platform.Foundation.NSFileManager
+import platform.Foundation.NSSearchPathForDirectoriesInDomains
+import platform.Foundation.NSUserDomainMask
+import platform.Foundation.create
+
+/**
+ * iOS implementation that saves files to Documents directory.
+ */
+actual class FileExporter {
+  @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
+  actual fun export(
+    fileName: String,
+    content: String,
+  ): String? =
+    runCatching {
+      val path = getFilePath(fileName) ?: return null
+      val bytes = content.encodeToByteArray()
+      val nsData =
+        bytes.usePinned { pinned ->
+          NSData.create(bytes = pinned.addressOf(0), length = bytes.size.toULong())
+        }
+      NSFileManager.defaultManager.createFileAtPath(path, nsData, null)
+      path
+    }.getOrNull()
+
+  @OptIn(ExperimentalForeignApi::class)
+  private fun getFilePath(fileName: String): String? {
+    val paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, true)
+    val documentsDir = paths.firstOrNull() as? String ?: return null
+    return "$documentsDir/$fileName"
+  }
+}

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,0 +1,33 @@
+package space.be1ski.vibits.shared.core.export
+
+import kotlinx.browser.document
+import org.w3c.dom.HTMLAnchorElement
+import org.w3c.dom.url.URL
+import org.w3c.files.Blob
+import org.w3c.files.BlobPropertyBag
+
+@Suppress("UNUSED_PARAMETER")
+private fun createBlobParts(content: String): JsArray<JsAny?> = js("([content])")
+
+/**
+ * Web implementation that triggers a browser download.
+ */
+actual class FileExporter {
+  actual fun export(
+    fileName: String,
+    content: String,
+  ): String? =
+    runCatching {
+      val parts = createBlobParts(content)
+      val blob = Blob(parts, BlobPropertyBag(type = "text/plain"))
+      val url = URL.createObjectURL(blob)
+
+      val anchor = document.createElement("a") as HTMLAnchorElement
+      anchor.href = url
+      anchor.download = fileName
+      anchor.click()
+
+      URL.revokeObjectURL(url)
+      fileName
+    }.getOrNull()
+}


### PR DESCRIPTION
## Summary
- Add cross-platform file export for logs (all modes) and memos (offline mode)
- Platform implementations:
  - **Desktop**: Saves to ~/Documents/Vibits
  - **Android**: Opens system share sheet via FileProvider
  - **iOS**: Saves to app's Documents directory
  - **Web**: Triggers browser download
- Clean UI with compact action buttons (Logs, Reset, Export dropdown)
- Show full file path in export success message

## Test plan
- [ ] Desktop: Export logs, verify file in ~/Documents/Vibits
- [ ] Android: Export logs, verify share sheet opens
- [ ] iOS: Export logs, verify file saved
- [ ] Web: Export logs, verify browser download
- [ ] Offline mode: Export memos option available

🤖 Generated with [Claude Code](https://claude.com/claude-code)