### PR TITLE
Add 10 language localizations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Habit tracker powered by [Memos](https://github.com/usememos/memos). Kotlin Mult
 
 **Platforms:** Android · iOS · Desktop · [Web](https://be1ski.github.io/vibits/)<br>
 **Modes:** Online ([Memos](https://github.com/usememos/memos) sync) · Offline · Demo<br>
-**Localization:** 🇬🇧 🇷🇺
+**Localization:** 🇬🇧 🇪🇸 🇨🇳 🇮🇳 🇸🇦 🇧🇷 🇷🇺 🇯🇵 🇩🇪 🇫🇷
 
 ## Run
 

--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
@@ -12,22 +12,13 @@ actual class LocaleProvider {
   actual fun getSystemLocale(): String = Locale.getDefault().language
 
   actual fun configureLocale(language: AppLanguage): Boolean {
-    val locale =
-      when (language) {
-        AppLanguage.SYSTEM -> Locale.getDefault()
-        AppLanguage.ENGLISH -> Locale.forLanguageTag("en")
-        AppLanguage.RUSSIAN -> Locale.forLanguageTag("ru")
-      }
-    // Set default locale for Compose Resources
+    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: Locale.getDefault()
     Locale.setDefault(locale)
 
-    // Also use AppCompatDelegate for Android per-app language
     val localeList =
-      when (language) {
-        AppLanguage.SYSTEM -> LocaleListCompat.getEmptyLocaleList()
-        AppLanguage.ENGLISH -> LocaleListCompat.forLanguageTags("en")
-        AppLanguage.RUSSIAN -> LocaleListCompat.forLanguageTags("ru")
-      }
+      language.localeCode
+        ?.let { LocaleListCompat.forLanguageTags(it) }
+        ?: LocaleListCompat.getEmptyLocaleList()
     AppCompatDelegate.setApplicationLocales(localeList)
     return false
   }

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">إلغاء</string>
+    <string name="action_clear">مسح</string>
+    <string name="action_close">إغلاق</string>
+    <string name="action_copied">تم النسخ</string>
+    <string name="action_configure_habits">تكوين العادات</string>
+    <string name="action_create">إنشاء</string>
+    <string name="action_create_memo">إنشاء مذكرة</string>
+    <string name="action_delete">حذف</string>
+    <string name="action_hide_details">إخفاء التفاصيل</string>
+    <string name="action_next">التالي</string>
+    <string name="action_previous">السابق</string>
+    <string name="action_refresh">تحديث</string>
+    <string name="action_reset">إعادة تعيين</string>
+    <string name="action_reset_app">إعادة تعيين التطبيق</string>
+    <string name="action_save">حفظ</string>
+    <string name="action_show_details">عرض التفاصيل</string>
+    <string name="action_track">تتبع</string>
+    <string name="action_track_today">تتبع اليوم</string>
+    <string name="action_update">تحديث</string>
+    <string name="action_view_logs">عرض السجلات</string>
+    <string name="action_export">تصدير</string>
+    <string name="action_export_logs">تصدير السجلات</string>
+    <string name="action_export_memos">تصدير المذكرات</string>
+    <string name="msg_export_success">تم التصدير إلى %1$s</string>
+    <string name="msg_export_failed">فشل التصدير</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">إث</string>
+    <string name="day_tue">ثل</string>
+    <string name="day_wed">أر</string>
+    <string name="day_thu">خم</string>
+    <string name="day_fri">جم</string>
+    <string name="day_sat">سب</string>
+    <string name="day_sun">أح</string>
+
+    <!-- Months short -->
+    <string name="month_jan">يناير</string>
+    <string name="month_feb">فبراير</string>
+    <string name="month_mar">مارس</string>
+    <string name="month_apr">أبريل</string>
+    <string name="month_may">مايو</string>
+    <string name="month_jun">يونيو</string>
+    <string name="month_jul">يوليو</string>
+    <string name="month_aug">أغسطس</string>
+    <string name="month_sep">سبتمبر</string>
+    <string name="month_oct">أكتوبر</string>
+    <string name="month_nov">نوفمبر</string>
+    <string name="month_dec">ديسمبر</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">الإصدار: %1$s</string>
+    <string name="format_credentials">بيانات الاعتماد: %1$s</string>
+    <string name="format_environment">البيئة: %1$s</string>
+    <string name="format_habits_progress">%1$d من %2$d عادات مكتملة</string>
+    <string name="format_memos_db">قاعدة بيانات المذكرات: %1$s</string>
+    <string name="format_offline_storage">غير متصل: %1$s</string>
+    <string name="format_memos_count">%1$d مذكرة</string>
+    <string name="format_memos_today">%1$d مذكرة اليوم</string>
+    <string name="format_memos_this_week">%1$d مذكرة هذا الأسبوع</string>
+    <string name="format_memos_in_month">%1$d مذكرة في %2$s</string>
+    <string name="format_memos_in_quarter">%1$d مذكرة في %2$s</string>
+    <string name="format_memos_in_year">%1$d مذكرة في %2$d</string>
+    <string name="action_show_memos">عرض المذكرات</string>
+    <string name="action_hide_memos">إخفاء المذكرات</string>
+    <string name="action_write">كتابة</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d عادات</string>
+    <string name="format_tooltip_memos">%1$s: %2$d مذكرة</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">أضف مذكرة تكوين العادات للبدء في التتبع.</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">اسم العادة</string>
+    <string name="hint_habits_config">رياضة | #habits/gym\nقراءة | #habits/reading</string>
+    <string name="hint_write_memo">اكتب مذكرة...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">رمز الوصول</string>
+    <string name="label_language">اللغة</string>
+    <string name="label_time_night">ليل</string>
+    <string name="label_time_morning">صباح</string>
+    <string name="label_time_day">نهار</string>
+    <string name="label_time_evening">مساء</string>
+    <string name="label_activity">النشاط</string>
+    <string name="label_app_mode">وضع التطبيق</string>
+    <string name="label_base_url">عنوان URL الأساسي</string>
+    <string name="label_credentials">بيانات الاعتماد</string>
+    <string name="label_demo_mode">الوضع التجريبي</string>
+    <string name="label_environment">البيئة</string>
+    <string name="label_habits_config">تكوين العادات</string>
+    <string name="label_memos_db">قاعدة بيانات المذكرات</string>
+    <string name="label_storage">التخزين</string>
+    <string name="label_version">الإصدار</string>
+    <string name="label_success_rate">معدل النجاح</string>
+    <string name="label_today">اليوم</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">فشل الاتصال</string>
+    <string name="msg_delete_day_confirm">لم يتم اختيار عادات. سيتم حذف إدخال اليوم.</string>
+    <string name="msg_fill_all_fields">يرجى ملء جميع الحقول</string>
+    <string name="msg_no_habits_yet">لم يتم تكوين عادات بعد.</string>
+    <string name="msg_no_logs">لا توجد سجلات بعد</string>
+    <string name="msg_no_memos_yet">لا توجد مذكرات في هذه الفترة.</string>
+    <string name="msg_reset_confirm">هل أنت متأكد من إعادة تعيين التطبيق؟ سيتم مسح جميع البيانات.</string>
+    <string name="msg_select_habit">اختر عادة واحدة على الأقل.</string>
+    <string name="msg_mark_done_confirm">وضع علامة "%1$s" كمكتمل لـ %2$s؟</string>
+    <string name="msg_mark_not_done_confirm">إزالة إكمال "%1$s" في %2$s؟</string>
+    <string name="msg_restart_required">يلزم إعادة التشغيل لتطبيق تغيير اللغة</string>
+
+    <!-- Language selection -->
+    <string name="language_system">النظام</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">السمة</string>
+    <string name="theme_system">النظام</string>
+    <string name="theme_light">فاتح</string>
+    <string name="theme_dark">داكن</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">اختر الوضع</string>
+    <string name="mode_select_subtitle">اختر كيف تريد استخدام التطبيق</string>
+    <string name="mode_online_title">متصل</string>
+    <string name="mode_online_desc">اتصل بخادم Memos للمزامنة الكاملة</string>
+    <string name="mode_offline_title">غير متصل</string>
+    <string name="mode_offline_desc">تخزين البيانات محليًا بدون اتصال بالخادم</string>
+    <string name="mode_demo_title">تجريبي</string>
+    <string name="mode_demo_desc">جرب التطبيق مع بيانات نموذجية</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">الرئيسية</string>
+    <string name="nav_habits">العادات</string>
+    <string name="nav_memos">المذكرات</string>
+    <string name="nav_settings">الإعدادات</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">محتوى مخفي</string>
+    <string name="privacy_hidden_habit">عادة مخفية</string>
+
+    <!-- Time periods -->
+    <string name="time_month">شهر</string>
+    <string name="time_months">أشهر</string>
+    <string name="time_quarter">ربع</string>
+    <string name="time_quarters">أرباع</string>
+    <string name="time_week">أسبوع</string>
+    <string name="time_weeks">أسابيع</string>
+    <string name="time_year">سنة</string>
+    <string name="time_years">سنوات</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">إنشاء يوم</string>
+    <string name="title_delete_day">حذف اليوم؟</string>
+    <string name="title_delete_memo">حذف المذكرة؟</string>
+    <string name="title_edit_day">تعديل اليوم</string>
+    <string name="title_edit_memo">تعديل المذكرة</string>
+    <string name="title_logs">السجلات (%1$d)</string>
+    <string name="title_new_memo">مذكرة جديدة</string>
+    <string name="title_mark_done">وضع علامة مكتمل؟</string>
+    <string name="title_mark_not_done">وضع علامة غير مكتمل؟</string>
+    <string name="title_update_day">تحديث اليوم</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">تمرين</string>
+    <string name="demo_habit_reading">قراءة</string>
+    <string name="demo_habit_meditation">تأمل</string>
+    <string name="demo_habit_water">شرب الماء</string>
+    <string name="demo_habit_learning">تعلم</string>
+    <string name="demo_habit_walking">10K خطوة</string>
+    <string name="demo_habit_no_sugar">بدون سكر</string>
+    <string name="demo_habit_early_sleep">النوم قبل 11 مساءً</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">Abbrechen</string>
+    <string name="action_clear">Löschen</string>
+    <string name="action_close">Schließen</string>
+    <string name="action_copied">Kopiert</string>
+    <string name="action_configure_habits">Gewohnheiten konfigurieren</string>
+    <string name="action_create">Erstellen</string>
+    <string name="action_create_memo">Notiz erstellen</string>
+    <string name="action_delete">Löschen</string>
+    <string name="action_hide_details">Details ausblenden</string>
+    <string name="action_next">Weiter</string>
+    <string name="action_previous">Zurück</string>
+    <string name="action_refresh">Aktualisieren</string>
+    <string name="action_reset">Zurücksetzen</string>
+    <string name="action_reset_app">App zurücksetzen</string>
+    <string name="action_save">Speichern</string>
+    <string name="action_show_details">Details anzeigen</string>
+    <string name="action_track">Erfassen</string>
+    <string name="action_track_today">Heute erfassen</string>
+    <string name="action_update">Aktualisieren</string>
+    <string name="action_view_logs">Logs</string>
+    <string name="action_export">Export</string>
+    <string name="action_export_logs">Protokolle exportieren</string>
+    <string name="action_export_memos">Notizen exportieren</string>
+    <string name="msg_export_success">Exportiert nach %1$s</string>
+    <string name="msg_export_failed">Export fehlgeschlagen</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">Mo</string>
+    <string name="day_tue">Di</string>
+    <string name="day_wed">Mi</string>
+    <string name="day_thu">Do</string>
+    <string name="day_fri">Fr</string>
+    <string name="day_sat">Sa</string>
+    <string name="day_sun">So</string>
+
+    <!-- Months short -->
+    <string name="month_jan">Jan</string>
+    <string name="month_feb">Feb</string>
+    <string name="month_mar">Mär</string>
+    <string name="month_apr">Apr</string>
+    <string name="month_may">Mai</string>
+    <string name="month_jun">Jun</string>
+    <string name="month_jul">Jul</string>
+    <string name="month_aug">Aug</string>
+    <string name="month_sep">Sep</string>
+    <string name="month_oct">Okt</string>
+    <string name="month_nov">Nov</string>
+    <string name="month_dec">Dez</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">Version: %1$s</string>
+    <string name="format_credentials">Anmeldedaten: %1$s</string>
+    <string name="format_environment">Umgebung: %1$s</string>
+    <string name="format_habits_progress">%1$d von %2$d Gewohnheiten erledigt</string>
+    <string name="format_memos_db">Notizen-DB: %1$s</string>
+    <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_memos_count">%1$d Notizen</string>
+    <string name="format_memos_today">%1$d Notizen heute</string>
+    <string name="format_memos_this_week">%1$d Notizen diese Woche</string>
+    <string name="format_memos_in_month">%1$d Notizen im %2$s</string>
+    <string name="format_memos_in_quarter">%1$d Notizen im %2$s</string>
+    <string name="format_memos_in_year">%1$d Notizen in %2$d</string>
+    <string name="action_show_memos">Notizen anzeigen</string>
+    <string name="action_hide_memos">Notizen ausblenden</string>
+    <string name="action_write">Schreiben</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d Gewohnheiten</string>
+    <string name="format_tooltip_memos">%1$s: %2$d Notizen</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">Fügen Sie eine Gewohnheits-Konfigurationsnotiz hinzu, um mit dem Tracking zu beginnen.</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">Gewohnheitsname</string>
+    <string name="hint_habits_config">Sport | #habits/gym\nLesen | #habits/reading</string>
+    <string name="hint_write_memo">Notiz schreiben...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">Zugriffstoken</string>
+    <string name="label_language">Sprache</string>
+    <string name="label_time_night">Nacht</string>
+    <string name="label_time_morning">Morgen</string>
+    <string name="label_time_day">Tag</string>
+    <string name="label_time_evening">Abend</string>
+    <string name="label_activity">Aktivität</string>
+    <string name="label_app_mode">App-Modus</string>
+    <string name="label_base_url">Basis-URL</string>
+    <string name="label_credentials">Anmeldedaten</string>
+    <string name="label_demo_mode">Demo-Modus</string>
+    <string name="label_environment">Umgebung</string>
+    <string name="label_habits_config">Gewohnheits-Konfiguration</string>
+    <string name="label_memos_db">Notizen-DB</string>
+    <string name="label_storage">Speicher</string>
+    <string name="label_version">Version</string>
+    <string name="label_success_rate">Erfolgsrate</string>
+    <string name="label_today">Heute</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">Verbindung fehlgeschlagen</string>
+    <string name="msg_delete_day_confirm">Keine Gewohnheiten ausgewählt. Der Tageseintrag wird gelöscht.</string>
+    <string name="msg_fill_all_fields">Bitte füllen Sie alle Felder aus</string>
+    <string name="msg_no_habits_yet">Noch keine Gewohnheiten konfiguriert.</string>
+    <string name="msg_no_logs">Noch keine Protokolle</string>
+    <string name="msg_no_memos_yet">Keine Notizen in diesem Zeitraum.</string>
+    <string name="msg_reset_confirm">Sind Sie sicher, dass Sie die App zurücksetzen möchten? Alle Daten werden gelöscht.</string>
+    <string name="msg_select_habit">Wählen Sie mindestens eine Gewohnheit aus.</string>
+    <string name="msg_mark_done_confirm">"%1$s" als erledigt für %2$s markieren?</string>
+    <string name="msg_mark_not_done_confirm">Erledigung von "%1$s" am %2$s entfernen?</string>
+    <string name="msg_restart_required">Neustart erforderlich, um die Sprachänderung anzuwenden</string>
+
+    <!-- Language selection -->
+    <string name="language_system">System</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">Design</string>
+    <string name="theme_system">System</string>
+    <string name="theme_light">Hell</string>
+    <string name="theme_dark">Dunkel</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">Modus wählen</string>
+    <string name="mode_select_subtitle">Wählen Sie, wie Sie die App nutzen möchten</string>
+    <string name="mode_online_title">Online</string>
+    <string name="mode_online_desc">Mit Ihrem Memos-Server für vollständige Synchronisierung verbinden</string>
+    <string name="mode_offline_title">Offline</string>
+    <string name="mode_offline_desc">Daten lokal ohne Serververbindung speichern</string>
+    <string name="mode_demo_title">Demo</string>
+    <string name="mode_demo_desc">App mit Beispieldaten testen</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">Feed</string>
+    <string name="nav_habits">Gewohnheiten</string>
+    <string name="nav_memos">Notizen</string>
+    <string name="nav_settings">Einstellungen</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">Versteckter Inhalt</string>
+    <string name="privacy_hidden_habit">Versteckte Gewohnheit</string>
+
+    <!-- Time periods -->
+    <string name="time_month">Monat</string>
+    <string name="time_months">Monate</string>
+    <string name="time_quarter">Quartal</string>
+    <string name="time_quarters">Quartale</string>
+    <string name="time_week">Woche</string>
+    <string name="time_weeks">Wochen</string>
+    <string name="time_year">Jahr</string>
+    <string name="time_years">Jahre</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">Tag erstellen</string>
+    <string name="title_delete_day">Tag löschen?</string>
+    <string name="title_delete_memo">Notiz löschen?</string>
+    <string name="title_edit_day">Tag bearbeiten</string>
+    <string name="title_edit_memo">Notiz bearbeiten</string>
+    <string name="title_logs">Protokolle (%1$d)</string>
+    <string name="title_new_memo">Neue Notiz</string>
+    <string name="title_mark_done">Als erledigt markieren?</string>
+    <string name="title_mark_not_done">Als nicht erledigt markieren?</string>
+    <string name="title_update_day">Tag aktualisieren</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">Sport</string>
+    <string name="demo_habit_reading">Lesen</string>
+    <string name="demo_habit_meditation">Meditation</string>
+    <string name="demo_habit_water">Wasser trinken</string>
+    <string name="demo_habit_learning">Lernen</string>
+    <string name="demo_habit_walking">10K Schritte</string>
+    <string name="demo_habit_no_sugar">Kein Zucker</string>
+    <string name="demo_habit_early_sleep">Vor 23 Uhr schlafen</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Borrar</string>
+    <string name="action_close">Cerrar</string>
+    <string name="action_copied">Copiado</string>
+    <string name="action_configure_habits">Configurar hábitos</string>
+    <string name="action_create">Crear</string>
+    <string name="action_create_memo">Crear nota</string>
+    <string name="action_delete">Eliminar</string>
+    <string name="action_hide_details">Ocultar detalles</string>
+    <string name="action_next">Siguiente</string>
+    <string name="action_previous">Anterior</string>
+    <string name="action_refresh">Actualizar</string>
+    <string name="action_reset">Restablecer</string>
+    <string name="action_reset_app">Restablecer app</string>
+    <string name="action_save">Guardar</string>
+    <string name="action_show_details">Mostrar detalles</string>
+    <string name="action_track">Registrar</string>
+    <string name="action_track_today">Registrar hoy</string>
+    <string name="action_update">Actualizar</string>
+    <string name="action_view_logs">Logs</string>
+    <string name="action_export">Exportar</string>
+    <string name="action_export_logs">Exportar registros</string>
+    <string name="action_export_memos">Exportar notas</string>
+    <string name="msg_export_success">Exportado a %1$s</string>
+    <string name="msg_export_failed">Error al exportar</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">Lu</string>
+    <string name="day_tue">Ma</string>
+    <string name="day_wed">Mi</string>
+    <string name="day_thu">Ju</string>
+    <string name="day_fri">Vi</string>
+    <string name="day_sat">Sá</string>
+    <string name="day_sun">Do</string>
+
+    <!-- Months short -->
+    <string name="month_jan">Ene</string>
+    <string name="month_feb">Feb</string>
+    <string name="month_mar">Mar</string>
+    <string name="month_apr">Abr</string>
+    <string name="month_may">May</string>
+    <string name="month_jun">Jun</string>
+    <string name="month_jul">Jul</string>
+    <string name="month_aug">Ago</string>
+    <string name="month_sep">Sep</string>
+    <string name="month_oct">Oct</string>
+    <string name="month_nov">Nov</string>
+    <string name="month_dec">Dic</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">Versión: %1$s</string>
+    <string name="format_credentials">Credenciales: %1$s</string>
+    <string name="format_environment">Entorno: %1$s</string>
+    <string name="format_habits_progress">%1$d de %2$d hábitos completados</string>
+    <string name="format_memos_db">Base de datos: %1$s</string>
+    <string name="format_offline_storage">Sin conexión: %1$s</string>
+    <string name="format_memos_count">%1$d notas</string>
+    <string name="format_memos_today">%1$d notas hoy</string>
+    <string name="format_memos_this_week">%1$d notas esta semana</string>
+    <string name="format_memos_in_month">%1$d notas en %2$s</string>
+    <string name="format_memos_in_quarter">%1$d notas en %2$s</string>
+    <string name="format_memos_in_year">%1$d notas en %2$d</string>
+    <string name="action_show_memos">Mostrar notas</string>
+    <string name="action_hide_memos">Ocultar notas</string>
+    <string name="action_write">Escribir</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
+    <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">Añade una nota de configuración para empezar a registrar.</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">Nombre del hábito</string>
+    <string name="hint_habits_config">Gimnasia | #habits/gym\nLectura | #habits/reading</string>
+    <string name="hint_write_memo">Escribe una nota...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">Token de acceso</string>
+    <string name="label_language">Idioma</string>
+    <string name="label_time_night">Noche</string>
+    <string name="label_time_morning">Mañana</string>
+    <string name="label_time_day">Día</string>
+    <string name="label_time_evening">Tarde</string>
+    <string name="label_activity">Actividad</string>
+    <string name="label_app_mode">Modo de app</string>
+    <string name="label_base_url">URL base</string>
+    <string name="label_credentials">Credenciales</string>
+    <string name="label_demo_mode">Modo demo</string>
+    <string name="label_environment">Entorno</string>
+    <string name="label_habits_config">Configuración de hábitos</string>
+    <string name="label_memos_db">Base de notas</string>
+    <string name="label_storage">Almacenamiento</string>
+    <string name="label_version">Versión</string>
+    <string name="label_success_rate">Tasa de éxito</string>
+    <string name="label_today">Hoy</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">Error de conexión</string>
+    <string name="msg_delete_day_confirm">No hay hábitos seleccionados. Se eliminará la entrada del día.</string>
+    <string name="msg_fill_all_fields">Por favor, complete todos los campos</string>
+    <string name="msg_no_habits_yet">Aún no hay hábitos configurados.</string>
+    <string name="msg_no_logs">Aún no hay registros</string>
+    <string name="msg_no_memos_yet">No hay notas en este período.</string>
+    <string name="msg_reset_confirm">¿Está seguro de que desea restablecer la app? Se eliminarán todos los datos.</string>
+    <string name="msg_select_habit">Seleccione al menos un hábito.</string>
+    <string name="msg_mark_done_confirm">¿Marcar "%1$s" como completado para %2$s?</string>
+    <string name="msg_mark_not_done_confirm">¿Quitar la marca de "%1$s" para %2$s?</string>
+    <string name="msg_restart_required">Se requiere reiniciar para aplicar el cambio de idioma</string>
+
+    <!-- Language selection -->
+    <string name="language_system">Sistema</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">Tema</string>
+    <string name="theme_system">Sistema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Oscuro</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">Seleccionar modo</string>
+    <string name="mode_select_subtitle">Elija cómo quiere usar la app</string>
+    <string name="mode_online_title">En línea</string>
+    <string name="mode_online_desc">Conectar a su servidor Memos para sincronización completa</string>
+    <string name="mode_offline_title">Sin conexión</string>
+    <string name="mode_offline_desc">Almacenar datos localmente sin conexión al servidor</string>
+    <string name="mode_demo_title">Demo</string>
+    <string name="mode_demo_desc">Probar la app con datos de ejemplo</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">Inicio</string>
+    <string name="nav_habits">Hábitos</string>
+    <string name="nav_memos">Notas</string>
+    <string name="nav_settings">Ajustes</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">Contenido oculto</string>
+    <string name="privacy_hidden_habit">Hábito oculto</string>
+
+    <!-- Time periods -->
+    <string name="time_month">Mes</string>
+    <string name="time_months">Meses</string>
+    <string name="time_quarter">Trimestre</string>
+    <string name="time_quarters">Trimestres</string>
+    <string name="time_week">Semana</string>
+    <string name="time_weeks">Semanas</string>
+    <string name="time_year">Año</string>
+    <string name="time_years">Años</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">Crear día</string>
+    <string name="title_delete_day">¿Eliminar día?</string>
+    <string name="title_delete_memo">¿Eliminar nota?</string>
+    <string name="title_edit_day">Editar día</string>
+    <string name="title_edit_memo">Editar nota</string>
+    <string name="title_logs">Registros (%1$d)</string>
+    <string name="title_new_memo">Nueva nota</string>
+    <string name="title_mark_done">¿Marcar como hecho?</string>
+    <string name="title_mark_not_done">¿Marcar como no hecho?</string>
+    <string name="title_update_day">Actualizar día</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">Ejercicio</string>
+    <string name="demo_habit_reading">Lectura</string>
+    <string name="demo_habit_meditation">Meditación</string>
+    <string name="demo_habit_water">Beber agua</string>
+    <string name="demo_habit_learning">Aprendizaje</string>
+    <string name="demo_habit_walking">10K pasos</string>
+    <string name="demo_habit_no_sugar">Sin azúcar</string>
+    <string name="demo_habit_early_sleep">Dormir antes de las 23h</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">Annuler</string>
+    <string name="action_clear">Effacer</string>
+    <string name="action_close">Fermer</string>
+    <string name="action_copied">Copié</string>
+    <string name="action_configure_habits">Configurer les habitudes</string>
+    <string name="action_create">Créer</string>
+    <string name="action_create_memo">Créer une note</string>
+    <string name="action_delete">Supprimer</string>
+    <string name="action_hide_details">Masquer les détails</string>
+    <string name="action_next">Suivant</string>
+    <string name="action_previous">Précédent</string>
+    <string name="action_refresh">Actualiser</string>
+    <string name="action_reset">Réinitialiser</string>
+    <string name="action_reset_app">Réinitialiser l\'app</string>
+    <string name="action_save">Enregistrer</string>
+    <string name="action_show_details">Afficher les détails</string>
+    <string name="action_track">Enregistrer</string>
+    <string name="action_track_today">Enregistrer aujourd\'hui</string>
+    <string name="action_update">Mettre à jour</string>
+    <string name="action_view_logs">Logs</string>
+    <string name="action_export">Exporter</string>
+    <string name="action_export_logs">Exporter les journaux</string>
+    <string name="action_export_memos">Exporter les notes</string>
+    <string name="msg_export_success">Exporté vers %1$s</string>
+    <string name="msg_export_failed">Échec de l\'exportation</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">Lu</string>
+    <string name="day_tue">Ma</string>
+    <string name="day_wed">Me</string>
+    <string name="day_thu">Je</string>
+    <string name="day_fri">Ve</string>
+    <string name="day_sat">Sa</string>
+    <string name="day_sun">Di</string>
+
+    <!-- Months short -->
+    <string name="month_jan">Jan</string>
+    <string name="month_feb">Fév</string>
+    <string name="month_mar">Mar</string>
+    <string name="month_apr">Avr</string>
+    <string name="month_may">Mai</string>
+    <string name="month_jun">Juin</string>
+    <string name="month_jul">Juil</string>
+    <string name="month_aug">Août</string>
+    <string name="month_sep">Sep</string>
+    <string name="month_oct">Oct</string>
+    <string name="month_nov">Nov</string>
+    <string name="month_dec">Déc</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">Version : %1$s</string>
+    <string name="format_credentials">Identifiants : %1$s</string>
+    <string name="format_environment">Environnement : %1$s</string>
+    <string name="format_habits_progress">%1$d sur %2$d habitudes accomplies</string>
+    <string name="format_memos_db">Base de données : %1$s</string>
+    <string name="format_offline_storage">Hors ligne : %1$s</string>
+    <string name="format_memos_count">%1$d notes</string>
+    <string name="format_memos_today">%1$d notes aujourd\'hui</string>
+    <string name="format_memos_this_week">%1$d notes cette semaine</string>
+    <string name="format_memos_in_month">%1$d notes en %2$s</string>
+    <string name="format_memos_in_quarter">%1$d notes en %2$s</string>
+    <string name="format_memos_in_year">%1$d notes en %2$d</string>
+    <string name="action_show_memos">Afficher les notes</string>
+    <string name="action_hide_memos">Masquer les notes</string>
+    <string name="action_write">Écrire</string>
+    <string name="format_tooltip_habits">%1$s : %2$d/%3$d habitudes</string>
+    <string name="format_tooltip_memos">%1$s : %2$d notes</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">Ajoutez une note de configuration d\'habitudes pour commencer le suivi.</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">Nom de l\'habitude</string>
+    <string name="hint_habits_config">Sport | #habits/gym\nLecture | #habits/reading</string>
+    <string name="hint_write_memo">Écrire une note...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">Jeton d\'accès</string>
+    <string name="label_language">Langue</string>
+    <string name="label_time_night">Nuit</string>
+    <string name="label_time_morning">Matin</string>
+    <string name="label_time_day">Jour</string>
+    <string name="label_time_evening">Soir</string>
+    <string name="label_activity">Activité</string>
+    <string name="label_app_mode">Mode de l\'app</string>
+    <string name="label_base_url">URL de base</string>
+    <string name="label_credentials">Identifiants</string>
+    <string name="label_demo_mode">Mode démo</string>
+    <string name="label_environment">Environnement</string>
+    <string name="label_habits_config">Configuration des habitudes</string>
+    <string name="label_memos_db">Base de notes</string>
+    <string name="label_storage">Stockage</string>
+    <string name="label_version">Version</string>
+    <string name="label_success_rate">Taux de réussite</string>
+    <string name="label_today">Aujourd\'hui</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">Échec de la connexion</string>
+    <string name="msg_delete_day_confirm">Aucune habitude sélectionnée. L\'entrée du jour sera supprimée.</string>
+    <string name="msg_fill_all_fields">Veuillez remplir tous les champs</string>
+    <string name="msg_no_habits_yet">Aucune habitude configurée pour l\'instant.</string>
+    <string name="msg_no_logs">Aucun journal pour l\'instant</string>
+    <string name="msg_no_memos_yet">Aucune note pour cette période.</string>
+    <string name="msg_reset_confirm">Êtes-vous sûr de vouloir réinitialiser l\'app ? Toutes les données seront supprimées.</string>
+    <string name="msg_select_habit">Sélectionnez au moins une habitude.</string>
+    <string name="msg_mark_done_confirm">Marquer « %1$s » comme accompli pour %2$s ?</string>
+    <string name="msg_mark_not_done_confirm">Retirer l\'accomplissement de « %1$s » le %2$s ?</string>
+    <string name="msg_restart_required">Redémarrage nécessaire pour appliquer le changement de langue</string>
+
+    <!-- Language selection -->
+    <string name="language_system">Système</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">Thème</string>
+    <string name="theme_system">Système</string>
+    <string name="theme_light">Clair</string>
+    <string name="theme_dark">Sombre</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">Sélectionner le mode</string>
+    <string name="mode_select_subtitle">Choisissez comment vous souhaitez utiliser l\'app</string>
+    <string name="mode_online_title">En ligne</string>
+    <string name="mode_online_desc">Connectez-vous à votre serveur Memos pour une synchronisation complète</string>
+    <string name="mode_offline_title">Hors ligne</string>
+    <string name="mode_offline_desc">Stockez les données localement sans connexion au serveur</string>
+    <string name="mode_demo_title">Démo</string>
+    <string name="mode_demo_desc">Essayez l\'app avec des données d\'exemple</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">Fil</string>
+    <string name="nav_habits">Habitudes</string>
+    <string name="nav_memos">Notes</string>
+    <string name="nav_settings">Paramètres</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">Contenu masqué</string>
+    <string name="privacy_hidden_habit">Habitude masquée</string>
+
+    <!-- Time periods -->
+    <string name="time_month">Mois</string>
+    <string name="time_months">Mois</string>
+    <string name="time_quarter">Trimestre</string>
+    <string name="time_quarters">Trimestres</string>
+    <string name="time_week">Semaine</string>
+    <string name="time_weeks">Semaines</string>
+    <string name="time_year">Année</string>
+    <string name="time_years">Années</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">Créer un jour</string>
+    <string name="title_delete_day">Supprimer le jour ?</string>
+    <string name="title_delete_memo">Supprimer la note ?</string>
+    <string name="title_edit_day">Modifier le jour</string>
+    <string name="title_edit_memo">Modifier la note</string>
+    <string name="title_logs">Journaux (%1$d)</string>
+    <string name="title_new_memo">Nouvelle note</string>
+    <string name="title_mark_done">Marquer comme fait ?</string>
+    <string name="title_mark_not_done">Marquer comme non fait ?</string>
+    <string name="title_update_day">Mettre à jour le jour</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">Exercice</string>
+    <string name="demo_habit_reading">Lecture</string>
+    <string name="demo_habit_meditation">Méditation</string>
+    <string name="demo_habit_water">Boire de l\'eau</string>
+    <string name="demo_habit_learning">Apprentissage</string>
+    <string name="demo_habit_walking">10K pas</string>
+    <string name="demo_habit_no_sugar">Sans sucre</string>
+    <string name="demo_habit_early_sleep">Dormir avant 23h</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">रद्द करें</string>
+    <string name="action_clear">साफ़ करें</string>
+    <string name="action_close">बंद करें</string>
+    <string name="action_copied">कॉपी हुआ</string>
+    <string name="action_configure_habits">आदतें कॉन्फ़िगर करें</string>
+    <string name="action_create">बनाएं</string>
+    <string name="action_create_memo">मेमो बनाएं</string>
+    <string name="action_delete">हटाएं</string>
+    <string name="action_hide_details">विवरण छुपाएं</string>
+    <string name="action_next">अगला</string>
+    <string name="action_previous">पिछला</string>
+    <string name="action_refresh">रिफ्रेश</string>
+    <string name="action_reset">रीसेट</string>
+    <string name="action_reset_app">ऐप रीसेट करें</string>
+    <string name="action_save">सेव करें</string>
+    <string name="action_show_details">विवरण दिखाएं</string>
+    <string name="action_track">ट्रैक करें</string>
+    <string name="action_track_today">आज ट्रैक करें</string>
+    <string name="action_update">अपडेट</string>
+    <string name="action_view_logs">लॉग देखें</string>
+    <string name="action_export">निर्यात</string>
+    <string name="action_export_logs">लॉग निर्यात करें</string>
+    <string name="action_export_memos">मेमो निर्यात करें</string>
+    <string name="msg_export_success">%1$s पर निर्यात हुआ</string>
+    <string name="msg_export_failed">निर्यात विफल</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">सो</string>
+    <string name="day_tue">मं</string>
+    <string name="day_wed">बु</string>
+    <string name="day_thu">गु</string>
+    <string name="day_fri">शु</string>
+    <string name="day_sat">श</string>
+    <string name="day_sun">र</string>
+
+    <!-- Months short -->
+    <string name="month_jan">जन</string>
+    <string name="month_feb">फर</string>
+    <string name="month_mar">मार्च</string>
+    <string name="month_apr">अप्रैल</string>
+    <string name="month_may">मई</string>
+    <string name="month_jun">जून</string>
+    <string name="month_jul">जुला</string>
+    <string name="month_aug">अग</string>
+    <string name="month_sep">सित</string>
+    <string name="month_oct">अक्टू</string>
+    <string name="month_nov">नव</string>
+    <string name="month_dec">दिस</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">संस्करण: %1$s</string>
+    <string name="format_credentials">क्रेडेंशियल: %1$s</string>
+    <string name="format_environment">वातावरण: %1$s</string>
+    <string name="format_habits_progress">%2$d में से %1$d आदतें पूरी</string>
+    <string name="format_memos_db">मेमो DB: %1$s</string>
+    <string name="format_offline_storage">ऑफ़लाइन: %1$s</string>
+    <string name="format_memos_count">%1$d मेमो</string>
+    <string name="format_memos_today">आज %1$d मेमो</string>
+    <string name="format_memos_this_week">इस सप्ताह %1$d मेमो</string>
+    <string name="format_memos_in_month">%2$s में %1$d मेमो</string>
+    <string name="format_memos_in_quarter">%2$s में %1$d मेमो</string>
+    <string name="format_memos_in_year">%2$d में %1$d मेमो</string>
+    <string name="action_show_memos">मेमो दिखाएं</string>
+    <string name="action_hide_memos">मेमो छुपाएं</string>
+    <string name="action_write">लिखें</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d आदतें</string>
+    <string name="format_tooltip_memos">%1$s: %2$d मेमो</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">ट्रैकिंग शुरू करने के लिए आदत कॉन्फ़िगरेशन मेमो जोड़ें।</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">आदत का नाम</string>
+    <string name="hint_habits_config">व्यायाम | #habits/gym\nपढ़ना | #habits/reading</string>
+    <string name="hint_write_memo">एक मेमो लिखें...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">एक्सेस टोकन</string>
+    <string name="label_language">भाषा</string>
+    <string name="label_time_night">रात</string>
+    <string name="label_time_morning">सुबह</string>
+    <string name="label_time_day">दिन</string>
+    <string name="label_time_evening">शाम</string>
+    <string name="label_activity">गतिविधि</string>
+    <string name="label_app_mode">ऐप मोड</string>
+    <string name="label_base_url">बेस URL</string>
+    <string name="label_credentials">क्रेडेंशियल</string>
+    <string name="label_demo_mode">डेमो मोड</string>
+    <string name="label_environment">वातावरण</string>
+    <string name="label_habits_config">आदत कॉन्फ़िगरेशन</string>
+    <string name="label_memos_db">मेमो DB</string>
+    <string name="label_storage">स्टोरेज</string>
+    <string name="label_version">संस्करण</string>
+    <string name="label_success_rate">सफलता दर</string>
+    <string name="label_today">आज</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">कनेक्शन विफल</string>
+    <string name="msg_delete_day_confirm">कोई आदत चयनित नहीं। दैनिक प्रविष्टि हटा दी जाएगी।</string>
+    <string name="msg_fill_all_fields">कृपया सभी फ़ील्ड भरें</string>
+    <string name="msg_no_habits_yet">अभी तक कोई आदत कॉन्फ़िगर नहीं।</string>
+    <string name="msg_no_logs">अभी कोई लॉग नहीं</string>
+    <string name="msg_no_memos_yet">इस अवधि में कोई मेमो नहीं।</string>
+    <string name="msg_reset_confirm">क्या आप वाकई ऐप रीसेट करना चाहते हैं? सभी डेटा हटा दिया जाएगा।</string>
+    <string name="msg_select_habit">कम से कम एक आदत चुनें।</string>
+    <string name="msg_mark_done_confirm">"%1$s" को %2$s के लिए पूर्ण के रूप में चिह्नित करें?</string>
+    <string name="msg_mark_not_done_confirm">%2$s पर "%1$s" की पूर्णता हटाएं?</string>
+    <string name="msg_restart_required">भाषा परिवर्तन लागू करने के लिए पुनः आरंभ आवश्यक</string>
+
+    <!-- Language selection -->
+    <string name="language_system">सिस्टम</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">थीम</string>
+    <string name="theme_system">सिस्टम</string>
+    <string name="theme_light">लाइट</string>
+    <string name="theme_dark">डार्क</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">मोड चुनें</string>
+    <string name="mode_select_subtitle">ऐप का उपयोग कैसे करना चाहते हैं चुनें</string>
+    <string name="mode_online_title">ऑनलाइन</string>
+    <string name="mode_online_desc">पूर्ण सिंक के लिए अपने Memos सर्वर से कनेक्ट करें</string>
+    <string name="mode_offline_title">ऑफ़लाइन</string>
+    <string name="mode_offline_desc">सर्वर कनेक्शन के बिना स्थानीय रूप से डेटा स्टोर करें</string>
+    <string name="mode_demo_title">डेमो</string>
+    <string name="mode_demo_desc">नमूना डेटा के साथ ऐप आज़माएं</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">फ़ीड</string>
+    <string name="nav_habits">आदतें</string>
+    <string name="nav_memos">मेमो</string>
+    <string name="nav_settings">सेटिंग्स</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">छुपी सामग्री</string>
+    <string name="privacy_hidden_habit">छुपी आदत</string>
+
+    <!-- Time periods -->
+    <string name="time_month">महीना</string>
+    <string name="time_months">महीने</string>
+    <string name="time_quarter">तिमाही</string>
+    <string name="time_quarters">तिमाहियां</string>
+    <string name="time_week">सप्ताह</string>
+    <string name="time_weeks">सप्ताह</string>
+    <string name="time_year">वर्ष</string>
+    <string name="time_years">वर्ष</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">दिन बनाएं</string>
+    <string name="title_delete_day">दिन हटाएं?</string>
+    <string name="title_delete_memo">मेमो हटाएं?</string>
+    <string name="title_edit_day">दिन संपादित करें</string>
+    <string name="title_edit_memo">मेमो संपादित करें</string>
+    <string name="title_logs">लॉग (%1$d)</string>
+    <string name="title_new_memo">नया मेमो</string>
+    <string name="title_mark_done">पूर्ण चिह्नित करें?</string>
+    <string name="title_mark_not_done">अपूर्ण चिह्नित करें?</string>
+    <string name="title_update_day">दिन अपडेट करें</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">व्यायाम</string>
+    <string name="demo_habit_reading">पढ़ना</string>
+    <string name="demo_habit_meditation">ध्यान</string>
+    <string name="demo_habit_water">पानी पीना</string>
+    <string name="demo_habit_learning">सीखना</string>
+    <string name="demo_habit_walking">10K कदम</string>
+    <string name="demo_habit_no_sugar">बिना चीनी</string>
+    <string name="demo_habit_early_sleep">रात 11 बजे तक सोना</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">キャンセル</string>
+    <string name="action_clear">クリア</string>
+    <string name="action_close">閉じる</string>
+    <string name="action_copied">コピー済み</string>
+    <string name="action_configure_habits">習慣を設定</string>
+    <string name="action_create">作成</string>
+    <string name="action_create_memo">メモを作成</string>
+    <string name="action_delete">削除</string>
+    <string name="action_hide_details">詳細を隠す</string>
+    <string name="action_next">次へ</string>
+    <string name="action_previous">前へ</string>
+    <string name="action_refresh">更新</string>
+    <string name="action_reset">リセット</string>
+    <string name="action_reset_app">アプリをリセット</string>
+    <string name="action_save">保存</string>
+    <string name="action_show_details">詳細を表示</string>
+    <string name="action_track">記録</string>
+    <string name="action_track_today">今日を記録</string>
+    <string name="action_update">更新</string>
+    <string name="action_view_logs">ログを表示</string>
+    <string name="action_export">エクスポート</string>
+    <string name="action_export_logs">ログをエクスポート</string>
+    <string name="action_export_memos">メモをエクスポート</string>
+    <string name="msg_export_success">%1$s にエクスポートしました</string>
+    <string name="msg_export_failed">エクスポートに失敗しました</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">月</string>
+    <string name="day_tue">火</string>
+    <string name="day_wed">水</string>
+    <string name="day_thu">木</string>
+    <string name="day_fri">金</string>
+    <string name="day_sat">土</string>
+    <string name="day_sun">日</string>
+
+    <!-- Months short -->
+    <string name="month_jan">1月</string>
+    <string name="month_feb">2月</string>
+    <string name="month_mar">3月</string>
+    <string name="month_apr">4月</string>
+    <string name="month_may">5月</string>
+    <string name="month_jun">6月</string>
+    <string name="month_jul">7月</string>
+    <string name="month_aug">8月</string>
+    <string name="month_sep">9月</string>
+    <string name="month_oct">10月</string>
+    <string name="month_nov">11月</string>
+    <string name="month_dec">12月</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">バージョン: %1$s</string>
+    <string name="format_credentials">認証情報: %1$s</string>
+    <string name="format_environment">環境: %1$s</string>
+    <string name="format_habits_progress">%2$d個中%1$d個の習慣完了</string>
+    <string name="format_memos_db">メモDB: %1$s</string>
+    <string name="format_offline_storage">オフライン: %1$s</string>
+    <string name="format_memos_count">%1$d件のメモ</string>
+    <string name="format_memos_today">今日%1$d件のメモ</string>
+    <string name="format_memos_this_week">今週%1$d件のメモ</string>
+    <string name="format_memos_in_month">%2$sに%1$d件のメモ</string>
+    <string name="format_memos_in_quarter">%2$sに%1$d件のメモ</string>
+    <string name="format_memos_in_year">%2$d年に%1$d件のメモ</string>
+    <string name="action_show_memos">メモを表示</string>
+    <string name="action_hide_memos">メモを隠す</string>
+    <string name="action_write">書く</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d習慣</string>
+    <string name="format_tooltip_memos">%1$s: %2$d件のメモ</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">トラッキングを開始するには習慣設定メモを追加してください。</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">習慣名</string>
+    <string name="hint_habits_config">運動 | #habits/gym\n読書 | #habits/reading</string>
+    <string name="hint_write_memo">メモを書く...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">アクセストークン</string>
+    <string name="label_language">言語</string>
+    <string name="label_time_night">夜</string>
+    <string name="label_time_morning">朝</string>
+    <string name="label_time_day">昼</string>
+    <string name="label_time_evening">夕方</string>
+    <string name="label_activity">アクティビティ</string>
+    <string name="label_app_mode">アプリモード</string>
+    <string name="label_base_url">ベースURL</string>
+    <string name="label_credentials">認証情報</string>
+    <string name="label_demo_mode">デモモード</string>
+    <string name="label_environment">環境</string>
+    <string name="label_habits_config">習慣設定</string>
+    <string name="label_memos_db">メモDB</string>
+    <string name="label_storage">ストレージ</string>
+    <string name="label_version">バージョン</string>
+    <string name="label_success_rate">成功率</string>
+    <string name="label_today">今日</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">接続に失敗しました</string>
+    <string name="msg_delete_day_confirm">習慣が選択されていません。この日のエントリは削除されます。</string>
+    <string name="msg_fill_all_fields">すべての項目を入力してください</string>
+    <string name="msg_no_habits_yet">まだ習慣が設定されていません。</string>
+    <string name="msg_no_logs">ログがありません</string>
+    <string name="msg_no_memos_yet">この期間にメモがありません。</string>
+    <string name="msg_reset_confirm">アプリをリセットしますか？すべてのデータが削除されます。</string>
+    <string name="msg_select_habit">少なくとも1つの習慣を選択してください。</string>
+    <string name="msg_mark_done_confirm">「%1$s」を%2$sに完了としてマークしますか？</string>
+    <string name="msg_mark_not_done_confirm">%2$sの「%1$s」の完了を取り消しますか？</string>
+    <string name="msg_restart_required">言語変更を適用するには再起動が必要です</string>
+
+    <!-- Language selection -->
+    <string name="language_system">システム</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">テーマ</string>
+    <string name="theme_system">システム</string>
+    <string name="theme_light">ライト</string>
+    <string name="theme_dark">ダーク</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">モードを選択</string>
+    <string name="mode_select_subtitle">アプリの使用方法を選択</string>
+    <string name="mode_online_title">オンライン</string>
+    <string name="mode_online_desc">Memosサーバーに接続して完全同期</string>
+    <string name="mode_offline_title">オフライン</string>
+    <string name="mode_offline_desc">サーバー接続なしでローカルにデータを保存</string>
+    <string name="mode_demo_title">デモ</string>
+    <string name="mode_demo_desc">サンプルデータでアプリを試す</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">フィード</string>
+    <string name="nav_habits">習慣</string>
+    <string name="nav_memos">メモ</string>
+    <string name="nav_settings">設定</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">非表示コンテンツ</string>
+    <string name="privacy_hidden_habit">非表示の習慣</string>
+
+    <!-- Time periods -->
+    <string name="time_month">月</string>
+    <string name="time_months">月</string>
+    <string name="time_quarter">四半期</string>
+    <string name="time_quarters">四半期</string>
+    <string name="time_week">週</string>
+    <string name="time_weeks">週</string>
+    <string name="time_year">年</string>
+    <string name="time_years">年</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">日を作成</string>
+    <string name="title_delete_day">日を削除しますか？</string>
+    <string name="title_delete_memo">メモを削除しますか？</string>
+    <string name="title_edit_day">日を編集</string>
+    <string name="title_edit_memo">メモを編集</string>
+    <string name="title_logs">ログ (%1$d)</string>
+    <string name="title_new_memo">新規メモ</string>
+    <string name="title_mark_done">完了としてマーク？</string>
+    <string name="title_mark_not_done">未完了としてマーク？</string>
+    <string name="title_update_day">日を更新</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">運動</string>
+    <string name="demo_habit_reading">読書</string>
+    <string name="demo_habit_meditation">瞑想</string>
+    <string name="demo_habit_water">水を飲む</string>
+    <string name="demo_habit_learning">学習</string>
+    <string name="demo_habit_walking">1万歩</string>
+    <string name="demo_habit_no_sugar">砂糖なし</string>
+    <string name="demo_habit_early_sleep">23時までに就寝</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">Cancelar</string>
+    <string name="action_clear">Limpar</string>
+    <string name="action_close">Fechar</string>
+    <string name="action_copied">Copiado</string>
+    <string name="action_configure_habits">Configurar hábitos</string>
+    <string name="action_create">Criar</string>
+    <string name="action_create_memo">Criar nota</string>
+    <string name="action_delete">Excluir</string>
+    <string name="action_hide_details">Ocultar detalhes</string>
+    <string name="action_next">Próximo</string>
+    <string name="action_previous">Anterior</string>
+    <string name="action_refresh">Atualizar</string>
+    <string name="action_reset">Redefinir</string>
+    <string name="action_reset_app">Redefinir app</string>
+    <string name="action_save">Salvar</string>
+    <string name="action_show_details">Mostrar detalhes</string>
+    <string name="action_track">Registrar</string>
+    <string name="action_track_today">Registrar hoje</string>
+    <string name="action_update">Atualizar</string>
+    <string name="action_view_logs">Ver logs</string>
+    <string name="action_export">Exportar</string>
+    <string name="action_export_logs">Exportar logs</string>
+    <string name="action_export_memos">Exportar notas</string>
+    <string name="msg_export_success">Exportado para %1$s</string>
+    <string name="msg_export_failed">Falha ao exportar</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">Seg</string>
+    <string name="day_tue">Ter</string>
+    <string name="day_wed">Qua</string>
+    <string name="day_thu">Qui</string>
+    <string name="day_fri">Sex</string>
+    <string name="day_sat">Sáb</string>
+    <string name="day_sun">Dom</string>
+
+    <!-- Months short -->
+    <string name="month_jan">Jan</string>
+    <string name="month_feb">Fev</string>
+    <string name="month_mar">Mar</string>
+    <string name="month_apr">Abr</string>
+    <string name="month_may">Mai</string>
+    <string name="month_jun">Jun</string>
+    <string name="month_jul">Jul</string>
+    <string name="month_aug">Ago</string>
+    <string name="month_sep">Set</string>
+    <string name="month_oct">Out</string>
+    <string name="month_nov">Nov</string>
+    <string name="month_dec">Dez</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">Versão: %1$s</string>
+    <string name="format_credentials">Credenciais: %1$s</string>
+    <string name="format_environment">Ambiente: %1$s</string>
+    <string name="format_habits_progress">%1$d de %2$d hábitos concluídos</string>
+    <string name="format_memos_db">Banco de dados: %1$s</string>
+    <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_memos_count">%1$d notas</string>
+    <string name="format_memos_today">%1$d notas hoje</string>
+    <string name="format_memos_this_week">%1$d notas esta semana</string>
+    <string name="format_memos_in_month">%1$d notas em %2$s</string>
+    <string name="format_memos_in_quarter">%1$d notas em %2$s</string>
+    <string name="format_memos_in_year">%1$d notas em %2$d</string>
+    <string name="action_show_memos">Mostrar notas</string>
+    <string name="action_hide_memos">Ocultar notas</string>
+    <string name="action_write">Escrever</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
+    <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">Adicione uma nota de configuração de hábitos para começar a rastrear.</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">Nome do hábito</string>
+    <string name="hint_habits_config">Ginástica | #habits/gym\nLeitura | #habits/reading</string>
+    <string name="hint_write_memo">Escreva uma nota...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">Token de acesso</string>
+    <string name="label_language">Idioma</string>
+    <string name="label_time_night">Noite</string>
+    <string name="label_time_morning">Manhã</string>
+    <string name="label_time_day">Dia</string>
+    <string name="label_time_evening">Tarde</string>
+    <string name="label_activity">Atividade</string>
+    <string name="label_app_mode">Modo do app</string>
+    <string name="label_base_url">URL base</string>
+    <string name="label_credentials">Credenciais</string>
+    <string name="label_demo_mode">Modo demo</string>
+    <string name="label_environment">Ambiente</string>
+    <string name="label_habits_config">Configuração de hábitos</string>
+    <string name="label_memos_db">Banco de notas</string>
+    <string name="label_storage">Armazenamento</string>
+    <string name="label_version">Versão</string>
+    <string name="label_success_rate">Taxa de sucesso</string>
+    <string name="label_today">Hoje</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">Falha na conexão</string>
+    <string name="msg_delete_day_confirm">Nenhum hábito selecionado. A entrada diária será excluída.</string>
+    <string name="msg_fill_all_fields">Por favor, preencha todos os campos</string>
+    <string name="msg_no_habits_yet">Nenhum hábito configurado ainda.</string>
+    <string name="msg_no_logs">Sem logs ainda</string>
+    <string name="msg_no_memos_yet">Sem notas neste período.</string>
+    <string name="msg_reset_confirm">Tem certeza de que deseja redefinir o app? Todos os dados serão apagados.</string>
+    <string name="msg_select_habit">Selecione pelo menos um hábito.</string>
+    <string name="msg_mark_done_confirm">Marcar "%1$s" como concluído para %2$s?</string>
+    <string name="msg_mark_not_done_confirm">Remover conclusão de "%1$s" em %2$s?</string>
+    <string name="msg_restart_required">Reinício necessário para aplicar a mudança de idioma</string>
+
+    <!-- Language selection -->
+    <string name="language_system">Sistema</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">Tema</string>
+    <string name="theme_system">Sistema</string>
+    <string name="theme_light">Claro</string>
+    <string name="theme_dark">Escuro</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">Selecionar modo</string>
+    <string name="mode_select_subtitle">Escolha como deseja usar o app</string>
+    <string name="mode_online_title">Online</string>
+    <string name="mode_online_desc">Conecte ao seu servidor Memos para sincronização completa</string>
+    <string name="mode_offline_title">Offline</string>
+    <string name="mode_offline_desc">Armazene dados localmente sem conexão com servidor</string>
+    <string name="mode_demo_title">Demo</string>
+    <string name="mode_demo_desc">Experimente o app com dados de exemplo</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">Feed</string>
+    <string name="nav_habits">Hábitos</string>
+    <string name="nav_memos">Notas</string>
+    <string name="nav_settings">Configurações</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">Conteúdo oculto</string>
+    <string name="privacy_hidden_habit">Hábito oculto</string>
+
+    <!-- Time periods -->
+    <string name="time_month">Mês</string>
+    <string name="time_months">Meses</string>
+    <string name="time_quarter">Trimestre</string>
+    <string name="time_quarters">Trimestres</string>
+    <string name="time_week">Semana</string>
+    <string name="time_weeks">Semanas</string>
+    <string name="time_year">Ano</string>
+    <string name="time_years">Anos</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">Criar dia</string>
+    <string name="title_delete_day">Excluir dia?</string>
+    <string name="title_delete_memo">Excluir nota?</string>
+    <string name="title_edit_day">Editar dia</string>
+    <string name="title_edit_memo">Editar nota</string>
+    <string name="title_logs">Logs (%1$d)</string>
+    <string name="title_new_memo">Nova nota</string>
+    <string name="title_mark_done">Marcar como feito?</string>
+    <string name="title_mark_not_done">Marcar como não feito?</string>
+    <string name="title_update_day">Atualizar dia</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">Exercício</string>
+    <string name="demo_habit_reading">Leitura</string>
+    <string name="demo_habit_meditation">Meditação</string>
+    <string name="demo_habit_water">Beber água</string>
+    <string name="demo_habit_learning">Aprendizado</string>
+    <string name="demo_habit_walking">10K passos</string>
+    <string name="demo_habit_no_sugar">Sem açúcar</string>
+    <string name="demo_habit_early_sleep">Dormir até 23h</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -109,7 +109,15 @@
     <!-- Language selection -->
     <string name="language_system">Системный</string>
     <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
     <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
 
     <!-- Theme selection -->
     <string name="label_theme">Тема</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,0 +1,184 @@
+<resources>
+    <!-- Actions -->
+    <string name="action_cancel">取消</string>
+    <string name="action_clear">清除</string>
+    <string name="action_close">关闭</string>
+    <string name="action_copied">已复制</string>
+    <string name="action_configure_habits">配置习惯</string>
+    <string name="action_create">创建</string>
+    <string name="action_create_memo">创建备忘</string>
+    <string name="action_delete">删除</string>
+    <string name="action_hide_details">隐藏详情</string>
+    <string name="action_next">下一个</string>
+    <string name="action_previous">上一个</string>
+    <string name="action_refresh">刷新</string>
+    <string name="action_reset">重置</string>
+    <string name="action_reset_app">重置应用</string>
+    <string name="action_save">保存</string>
+    <string name="action_show_details">显示详情</string>
+    <string name="action_track">记录</string>
+    <string name="action_track_today">今日记录</string>
+    <string name="action_update">更新</string>
+    <string name="action_view_logs">查看日志</string>
+    <string name="action_export">导出</string>
+    <string name="action_export_logs">导出日志</string>
+    <string name="action_export_memos">导出备忘</string>
+    <string name="msg_export_success">已导出至 %1$s</string>
+    <string name="msg_export_failed">导出失败</string>
+
+    <!-- App -->
+    <string name="app_name">Vibits</string>
+
+    <!-- Days of week -->
+    <string name="day_mon">一</string>
+    <string name="day_tue">二</string>
+    <string name="day_wed">三</string>
+    <string name="day_thu">四</string>
+    <string name="day_fri">五</string>
+    <string name="day_sat">六</string>
+    <string name="day_sun">日</string>
+
+    <!-- Months short -->
+    <string name="month_jan">1月</string>
+    <string name="month_feb">2月</string>
+    <string name="month_mar">3月</string>
+    <string name="month_apr">4月</string>
+    <string name="month_may">5月</string>
+    <string name="month_jun">6月</string>
+    <string name="month_jul">7月</string>
+    <string name="month_aug">8月</string>
+    <string name="month_sep">9月</string>
+    <string name="month_oct">10月</string>
+    <string name="month_nov">11月</string>
+    <string name="month_dec">12月</string>
+
+    <!-- Format strings -->
+    <string name="format_app_version">版本: %1$s</string>
+    <string name="format_credentials">凭证: %1$s</string>
+    <string name="format_environment">环境: %1$s</string>
+    <string name="format_habits_progress">已完成 %1$d / %2$d 个习惯</string>
+    <string name="format_memos_db">备忘数据库: %1$s</string>
+    <string name="format_offline_storage">离线: %1$s</string>
+    <string name="format_memos_count">%1$d 条备忘</string>
+    <string name="format_memos_today">今天 %1$d 条备忘</string>
+    <string name="format_memos_this_week">本周 %1$d 条备忘</string>
+    <string name="format_memos_in_month">%2$s %1$d 条备忘</string>
+    <string name="format_memos_in_quarter">%2$s %1$d 条备忘</string>
+    <string name="format_memos_in_year">%2$d年 %1$d 条备忘</string>
+    <string name="action_show_memos">显示备忘</string>
+    <string name="action_hide_memos">隐藏备忘</string>
+    <string name="action_write">写</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d 习惯</string>
+    <string name="format_tooltip_memos">%1$s: %2$d 条备忘</string>
+
+    <!-- Hints -->
+    <string name="hint_add_habits_config">添加习惯配置备忘以开始跟踪。</string>
+    <string name="hint_base_url">https://memos.example.com</string>
+    <string name="hint_habit_name">习惯名称</string>
+    <string name="hint_habits_config">健身 | #habits/gym\n阅读 | #habits/reading</string>
+    <string name="hint_write_memo">写一条备忘...</string>
+
+    <!-- Labels -->
+    <string name="label_access_token">访问令牌</string>
+    <string name="label_language">语言</string>
+    <string name="label_time_night">夜晚</string>
+    <string name="label_time_morning">早晨</string>
+    <string name="label_time_day">白天</string>
+    <string name="label_time_evening">傍晚</string>
+    <string name="label_activity">活动</string>
+    <string name="label_app_mode">应用模式</string>
+    <string name="label_base_url">服务器地址</string>
+    <string name="label_credentials">凭证</string>
+    <string name="label_demo_mode">演示模式</string>
+    <string name="label_environment">环境</string>
+    <string name="label_habits_config">习惯配置</string>
+    <string name="label_memos_db">备忘数据库</string>
+    <string name="label_storage">存储</string>
+    <string name="label_version">版本</string>
+    <string name="label_success_rate">成功率</string>
+    <string name="label_today">今天</string>
+
+    <!-- Messages -->
+    <string name="msg_connection_failed">连接失败</string>
+    <string name="msg_delete_day_confirm">未选择任何习惯。该日记录将被删除。</string>
+    <string name="msg_fill_all_fields">请填写所有字段</string>
+    <string name="msg_no_habits_yet">尚未配置任何习惯。</string>
+    <string name="msg_no_logs">暂无日志</string>
+    <string name="msg_no_memos_yet">该时期暂无备忘。</string>
+    <string name="msg_reset_confirm">确定要重置应用吗？所有数据将被清除。</string>
+    <string name="msg_select_habit">请至少选择一个习惯。</string>
+    <string name="msg_mark_done_confirm">将"%1$s"标记为 %2$s 完成？</string>
+    <string name="msg_mark_not_done_confirm">取消"%1$s"在 %2$s 的完成标记？</string>
+    <string name="msg_restart_required">需要重启应用以应用语言更改</string>
+
+    <!-- Language selection -->
+    <string name="language_system">系统</string>
+    <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
+    <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
+
+    <!-- Theme selection -->
+    <string name="label_theme">主题</string>
+    <string name="theme_system">系统</string>
+    <string name="theme_light">浅色</string>
+    <string name="theme_dark">深色</string>
+
+    <!-- Mode selection -->
+    <string name="mode_select_title">选择模式</string>
+    <string name="mode_select_subtitle">选择您想使用应用的方式</string>
+    <string name="mode_online_title">在线</string>
+    <string name="mode_online_desc">连接到您的 Memos 服务器进行完全同步</string>
+    <string name="mode_offline_title">离线</string>
+    <string name="mode_offline_desc">本地存储数据，无需服务器连接</string>
+    <string name="mode_demo_title">演示</string>
+    <string name="mode_demo_desc">使用示例数据体验应用</string>
+
+    <!-- Navigation -->
+    <string name="nav_feed">动态</string>
+    <string name="nav_habits">习惯</string>
+    <string name="nav_memos">备忘</string>
+    <string name="nav_settings">设置</string>
+
+    <!-- Privacy -->
+    <string name="privacy_hidden_content">隐藏内容</string>
+    <string name="privacy_hidden_habit">隐藏的习惯</string>
+
+    <!-- Time periods -->
+    <string name="time_month">月</string>
+    <string name="time_months">月份</string>
+    <string name="time_quarter">季度</string>
+    <string name="time_quarters">季度</string>
+    <string name="time_week">周</string>
+    <string name="time_weeks">周</string>
+    <string name="time_year">年</string>
+    <string name="time_years">年</string>
+
+    <!-- Titles -->
+    <string name="title_create_day">创建日记录</string>
+    <string name="title_delete_day">删除日记录？</string>
+    <string name="title_delete_memo">删除备忘？</string>
+    <string name="title_edit_day">编辑日记录</string>
+    <string name="title_edit_memo">编辑备忘</string>
+    <string name="title_logs">日志 (%1$d)</string>
+    <string name="title_new_memo">新建备忘</string>
+    <string name="title_mark_done">标记完成？</string>
+    <string name="title_mark_not_done">取消标记？</string>
+    <string name="title_update_day">更新日记录</string>
+
+    <!-- Demo habits -->
+    <string name="demo_habit_exercise">锻炼</string>
+    <string name="demo_habit_reading">阅读</string>
+    <string name="demo_habit_meditation">冥想</string>
+    <string name="demo_habit_water">喝水</string>
+    <string name="demo_habit_learning">学习</string>
+    <string name="demo_habit_walking">一万步</string>
+    <string name="demo_habit_no_sugar">无糖</string>
+    <string name="demo_habit_early_sleep">23点前睡觉</string>
+</resources>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -114,7 +114,15 @@
     <!-- Language selection -->
     <string name="language_system">System</string>
     <string name="language_english">English</string>
+    <string name="language_spanish">Español</string>
+    <string name="language_chinese">中文</string>
+    <string name="language_hindi">हिन्दी</string>
+    <string name="language_arabic">العربية</string>
+    <string name="language_portuguese">Português</string>
     <string name="language_russian">Русский</string>
+    <string name="language_japanese">日本語</string>
+    <string name="language_german">Deutsch</string>
+    <string name="language_french">Français</string>
 
     <!-- Theme selection -->
     <string name="label_theme">Theme</string>

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/model/AppLanguage.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/model/AppLanguage.kt
@@ -8,5 +8,13 @@ enum class AppLanguage(
 ) {
   SYSTEM(null),
   ENGLISH("en"),
+  SPANISH("es"),
+  CHINESE("zh"),
+  HINDI("hi"),
+  ARABIC("ar"),
+  PORTUGUESE("pt"),
   RUSSIAN("ru"),
+  JAPANESE("ja"),
+  GERMAN("de"),
+  FRENCH("fr"),
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/components/SettingsDialogContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/components/SettingsDialogContent.kt
@@ -84,8 +84,16 @@ import space.be1ski.vibits.shared.label_memos_db
 import space.be1ski.vibits.shared.label_storage
 import space.be1ski.vibits.shared.label_theme
 import space.be1ski.vibits.shared.label_version
+import space.be1ski.vibits.shared.language_arabic
+import space.be1ski.vibits.shared.language_chinese
 import space.be1ski.vibits.shared.language_english
+import space.be1ski.vibits.shared.language_french
+import space.be1ski.vibits.shared.language_german
+import space.be1ski.vibits.shared.language_hindi
+import space.be1ski.vibits.shared.language_japanese
+import space.be1ski.vibits.shared.language_portuguese
 import space.be1ski.vibits.shared.language_russian
+import space.be1ski.vibits.shared.language_spanish
 import space.be1ski.vibits.shared.language_system
 import space.be1ski.vibits.shared.mode_demo_title
 import space.be1ski.vibits.shared.mode_offline_title
@@ -158,26 +166,6 @@ private fun SettingsDialogBody(
       Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
     }
     SegmentedSelector(
-      label = stringResource(Res.string.label_language),
-      options = AppLanguage.entries,
-      selected = state.selectedLanguage,
-      onSelect = { language -> dispatch(SettingsAction.SelectLanguage(language)) },
-      optionLabel = { language ->
-        when (language) {
-          AppLanguage.SYSTEM -> stringResource(Res.string.language_system)
-          AppLanguage.ENGLISH -> stringResource(Res.string.language_english)
-          AppLanguage.RUSSIAN -> stringResource(Res.string.language_russian)
-        }
-      },
-    )
-    if (state.languageChanged) {
-      Text(
-        text = stringResource(Res.string.msg_restart_required),
-        color = MaterialTheme.colorScheme.tertiary,
-        style = MaterialTheme.typography.bodySmall,
-      )
-    }
-    SegmentedSelector(
       label = stringResource(Res.string.label_theme),
       options = AppTheme.entries,
       selected = state.selectedTheme,
@@ -190,6 +178,17 @@ private fun SettingsDialogBody(
         }
       },
     )
+    LanguageDropdown(
+      selectedLanguage = state.selectedLanguage,
+      onSelect = { language -> dispatch(SettingsAction.SelectLanguage(language)) },
+    )
+    if (state.languageChanged) {
+      Text(
+        text = stringResource(Res.string.msg_restart_required),
+        color = MaterialTheme.colorScheme.tertiary,
+        style = MaterialTheme.typography.bodySmall,
+      )
+    }
     if (state.appMode == AppMode.ONLINE) {
       TextField(
         value = state.editBaseUrl,
@@ -373,6 +372,65 @@ private fun shortenPath(path: String): String =
     "..." + path.takeLast(PATH_MAX_LENGTH - ELLIPSIS_LENGTH)
   } else {
     path
+  }
+
+@Composable
+private fun LanguageDropdown(
+  selectedLanguage: AppLanguage,
+  onSelect: (AppLanguage) -> Unit,
+) {
+  var expanded by remember { mutableStateOf(false) }
+
+  Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+    Text(stringResource(Res.string.label_language))
+    Column {
+      SingleChoiceSegmentedButtonRow(modifier = Modifier.fillMaxWidth()) {
+        SegmentedButton(
+          selected = false,
+          onClick = { expanded = true },
+          shape = SegmentedButtonDefaults.itemShape(index = 0, count = 1),
+          icon = {},
+        ) {
+          Text(getLanguageLabel(selectedLanguage))
+          Icon(
+            Icons.Default.KeyboardArrowDown,
+            contentDescription = null,
+            modifier = Modifier.size(18.dp),
+          )
+        }
+      }
+      DropdownMenu(
+        expanded = expanded,
+        onDismissRequest = { expanded = false },
+      ) {
+        AppLanguage.entries.forEach { language ->
+          DropdownMenuItem(
+            text = { Text(getLanguageLabel(language)) },
+            onClick = {
+              onSelect(language)
+              expanded = false
+            },
+          )
+        }
+      }
+    }
+  }
+}
+
+@Composable
+private fun getLanguageLabel(language: AppLanguage): String =
+  when (language) {
+    AppLanguage.SYSTEM -> stringResource(Res.string.language_system)
+    AppLanguage.ENGLISH -> stringResource(Res.string.language_english)
+    AppLanguage.SPANISH -> stringResource(Res.string.language_spanish)
+    AppLanguage.CHINESE -> stringResource(Res.string.language_chinese)
+    AppLanguage.HINDI -> stringResource(Res.string.language_hindi)
+    AppLanguage.ARABIC -> stringResource(Res.string.language_arabic)
+    AppLanguage.PORTUGUESE -> stringResource(Res.string.language_portuguese)
+    AppLanguage.RUSSIAN -> stringResource(Res.string.language_russian)
+    AppLanguage.JAPANESE -> stringResource(Res.string.language_japanese)
+    AppLanguage.GERMAN -> stringResource(Res.string.language_german)
+    AppLanguage.FRENCH -> stringResource(Res.string.language_french)
   }
 
 @Composable

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
@@ -11,12 +11,7 @@ actual class LocaleProvider {
   actual fun getSystemLocale(): String = Locale.getDefault().language
 
   actual fun configureLocale(language: AppLanguage): Boolean {
-    val locale =
-      when (language) {
-        AppLanguage.SYSTEM -> Locale.getDefault()
-        AppLanguage.ENGLISH -> Locale.forLanguageTag("en")
-        AppLanguage.RUSSIAN -> Locale.forLanguageTag("ru")
-      }
+    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: Locale.getDefault()
     Locale.setDefault(locale)
     return true
   }


### PR DESCRIPTION
## Summary
- Add Spanish, Chinese, Hindi, Arabic, Portuguese, Japanese, German, French translations
- Replace SegmentedSelector with dropdown menu for language selection (supports 11 options)
- Update LocaleProvider implementations to use localeCode property
- Update README with new localization flags

## Test plan
- [ ] Verify dropdown shows all 11 language options
- [ ] Test language switching on desktop
- [ ] Test language switching on Android
- [ ] Verify strings load correctly in each language