### PR TITLE
Remove duplicate links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 
 Habit tracker powered by [Memos](https://github.com/usememos/memos). Kotlin Multiplatform + Compose Multiplatform.
 
-**Platforms:** Android · iOS · Desktop · [Web](https://be1ski.github.io/vibits/)<br>
-**Modes:** Online ([Memos](https://github.com/usememos/memos) sync) · Offline · Demo<br>
+**Platforms:** Android · iOS · Desktop · Web<br>
+**Modes:** Online (Memos sync) · Offline · Demo<br>
 **Localization:** 🇬🇧 🇷🇺
 
 ## Run


### PR DESCRIPTION
Remove duplicate Memos link and Web link (Live Demo badge already exists).