### PR TITLE
Fix ExperimentalWasmJsInterop warnings

### DIFF
--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/export/FileExporter.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
 package space.be1ski.vibits.shared.core.export
 
 import kotlinx.browser.document

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
@@ -1,3 +1,5 @@
+@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)
+
 package space.be1ski.vibits.shared.core.platform
 
 import kotlinx.browser.window


### PR DESCRIPTION
## Summary
- Add `@file:OptIn(kotlin.js.ExperimentalWasmJsInterop::class)` to FileExporter.kt and LocaleProvider.kt
- Silences compiler warnings for `js()` function and WASM JS interop types

## Test plan
- [x] `./gradlew checkAll` passes
- [x] No warnings during compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)