### PR TITLE
Fix System language not restoring

### DIFF
--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
@@ -9,10 +9,12 @@ import java.util.Locale
  * Android implementation using AppCompatDelegate for per-app language settings.
  */
 actual class LocaleProvider {
-  actual fun getSystemLocale(): String = Locale.getDefault().language
+  private val originalSystemLocale: Locale = Locale.getDefault()
+
+  actual fun getSystemLocale(): String = originalSystemLocale.language
 
   actual fun configureLocale(language: AppLanguage): Boolean {
-    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: Locale.getDefault()
+    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: originalSystemLocale
     Locale.setDefault(locale)
 
     val localeList =

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/LocaleProvider.kt
@@ -8,10 +8,12 @@ import java.util.Locale
  * Requires restart for changes to take effect.
  */
 actual class LocaleProvider {
-  actual fun getSystemLocale(): String = Locale.getDefault().language
+  private val originalSystemLocale: Locale = Locale.getDefault()
+
+  actual fun getSystemLocale(): String = originalSystemLocale.language
 
   actual fun configureLocale(language: AppLanguage): Boolean {
-    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: Locale.getDefault()
+    val locale = language.localeCode?.let { Locale.forLanguageTag(it) } ?: originalSystemLocale
     Locale.setDefault(locale)
     return true
   }


### PR DESCRIPTION
## Summary
- Store original system locale at LocaleProvider initialization
- Use stored locale when switching back to "System" language instead of modified `Locale.getDefault()`
- Fixes Android and Desktop platforms

## Test plan
- [x] `./gradlew checkAll` passes
- [ ] Select a language other than System
- [ ] Switch back to System - should restore actual system language

🤖 Generated with [Claude Code](https://claude.com/claude-code)