### PR TITLE
Fix habit cells clickable before configuration date

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreen.kt
@@ -128,6 +128,7 @@ private fun rememberStatsScreenDerived(
     timeZone = timeZone,
     successRateData = successRateData,
     periodPosts = periodPosts,
+    configStartDate = configStartDate,
   )
 }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenContent.kt
@@ -605,6 +605,7 @@ internal fun StatsMainChart(
       compactHeight = derived.useCompactHeight,
       demoMode = state.demoMode,
       today = derived.today,
+      configStartDate = derived.configStartDate,
       onHabitClick = onSingleHabitToggle,
     )
   } else {
@@ -776,6 +777,7 @@ private fun LastSevenDaysMatrix(
   compactHeight: Boolean,
   demoMode: Boolean,
   today: kotlinx.datetime.LocalDate,
+  configStartDate: kotlinx.datetime.LocalDate?,
   onHabitClick: (day: ContributionDay, habitTag: String, habitLabel: String) -> Unit = { _, _, _ -> },
 ) {
   if (days.isEmpty() || habits.isEmpty()) {
@@ -820,6 +822,8 @@ private fun LastSevenDaysMatrix(
           days.forEach { day ->
             val done = day.habitStatuses.firstOrNull { status -> status.tag == habit.tag }?.done == true
             val isFuture = day.date > today
+            val isBeforeConfig = configStartDate != null && day.date < configStartDate
+            val isClickable = !isFuture && !isBeforeConfig
             val baseColor =
               if (done) {
                 androidx.compose.ui.graphics
@@ -827,14 +831,14 @@ private fun LastSevenDaysMatrix(
               } else {
                 pendingColor
               }
-            val cellColor = if (isFuture) baseColor.copy(alpha = 0.3f) else baseColor
+            val cellColor = if (!isClickable) baseColor.copy(alpha = 0.3f) else baseColor
             Box(
               modifier =
                 Modifier
                   .size(cellSize)
                   .background(cellColor, shape = MaterialTheme.shapes.extraSmall)
                   .then(
-                    if (!isFuture) {
+                    if (isClickable) {
                       Modifier.clickable { onHabitClick(day, habit.tag, habit.label) }
                     } else {
                       Modifier

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenModels.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenModels.kt
@@ -57,4 +57,6 @@ internal data class StatsScreenDerivedState(
   val timeZone: TimeZone,
   val successRateData: SuccessRateData?,
   val periodPosts: List<Memo>,
+  /** Date when habits were first configured (null if no config). */
+  val configStartDate: LocalDate? = null,
 )


### PR DESCRIPTION
## Summary
- Block habit grid cells from being clicked for dates before the habit configuration was created
- Show pre-config date cells with reduced opacity (same as future dates)
- Prevents the toggle dialog from appearing for dates when habits didn't exist

## Test plan
- [ ] Reset app, select offline mode
- [ ] Add new habits
- [ ] Verify cells for days before today are grayed out and not clickable
- [ ] Verify today's cell is still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)