### PR TITLE
Move isClickable logic from view to domain layer

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/VibitsAppComponents.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/VibitsAppComponents.kt
@@ -153,10 +153,10 @@ internal fun rememberSuccessRate(
   activityRange: ActivityRange,
   calculateSuccessRate: CalculateSuccessRateUseCase,
 ): Float? {
-  val weekDataState = rememberActivityWeekData(memos, activityRange, ActivityMode.HABITS)
+  val today = remember { currentLocalDate() }
+  val weekDataState = rememberActivityWeekData(memos, activityRange, ActivityMode.HABITS, today)
   val weekData = weekDataState.data
   val habitsTimeline = rememberHabitsConfigTimeline(memos)
-  val today = remember { currentLocalDate() }
   val configStartDate = remember(habitsTimeline) { habitsTimeline.firstOrNull()?.date }
   val data =
     remember(weekData, activityRange, today, configStartDate) {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/model/ContributionDay.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/model/ContributionDay.kt
@@ -20,4 +20,6 @@ data class ContributionDay(
   val dailyMemo: DailyMemoInfo?,
   /** True if the day is within the requested range. */
   val inRange: Boolean,
+  /** True if the day can be clicked to toggle habits (not future, not before config). */
+  val isClickable: Boolean = true,
 )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreen.kt
@@ -71,7 +71,7 @@ private fun rememberStatsScreenDerived(
         dailyMemo = todayMemo,
       )
     }
-  val weekDataState = rememberActivityWeekData(memos, range, activityMode)
+  val weekDataState = rememberActivityWeekData(memos, range, activityMode, today)
   val weekData = weekDataState.data
   val isLoadingWeekData = weekDataState.isLoading
   val showWeekdayLegend =

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/StatsScreenContent.kt
@@ -604,8 +604,6 @@ internal fun StatsMainChart(
       habits = derived.currentHabitsConfig,
       compactHeight = derived.useCompactHeight,
       demoMode = state.demoMode,
-      today = derived.today,
-      configStartDate = derived.configStartDate,
       onHabitClick = onSingleHabitToggle,
     )
   } else {
@@ -776,8 +774,6 @@ private fun LastSevenDaysMatrix(
   habits: List<HabitConfig>,
   compactHeight: Boolean,
   demoMode: Boolean,
-  today: kotlinx.datetime.LocalDate,
-  configStartDate: kotlinx.datetime.LocalDate?,
   onHabitClick: (day: ContributionDay, habitTag: String, habitLabel: String) -> Unit = { _, _, _ -> },
 ) {
   if (days.isEmpty() || habits.isEmpty()) {
@@ -821,9 +817,6 @@ private fun LastSevenDaysMatrix(
           )
           days.forEach { day ->
             val done = day.habitStatuses.firstOrNull { status -> status.tag == habit.tag }?.done == true
-            val isFuture = day.date > today
-            val isBeforeConfig = configStartDate != null && day.date < configStartDate
-            val isClickable = !isFuture && !isBeforeConfig
             val baseColor =
               if (done) {
                 androidx.compose.ui.graphics
@@ -831,14 +824,14 @@ private fun LastSevenDaysMatrix(
               } else {
                 pendingColor
               }
-            val cellColor = if (!isClickable) baseColor.copy(alpha = 0.3f) else baseColor
+            val cellColor = if (!day.isClickable) baseColor.copy(alpha = 0.3f) else baseColor
             Box(
               modifier =
                 Modifier
                   .size(cellSize)
                   .background(cellColor, shape = MaterialTheme.shapes.extraSmall)
                   .then(
-                    if (isClickable) {
+                    if (day.isClickable) {
                       Modifier.clickable { onHabitClick(day, habit.tag, habit.label) }
                     } else {
                       Modifier

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/components/ContributionGridState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/components/ContributionGridState.kt
@@ -34,6 +34,7 @@ internal data class DayDataContext(
   val configTimeline: List<HabitsConfigEntry>,
   val dailyMemos: Map<LocalDate, DailyMemoInfo>,
   val counts: Map<LocalDate, Int>,
+  val today: LocalDate,
 )
 
 internal data class HabitSelectionState(
@@ -122,6 +123,7 @@ fun rememberActivityWeekData(
   memos: List<Memo>,
   range: ActivityRange,
   mode: ActivityMode,
+  today: LocalDate,
 ): ActivityWeekDataState {
   val cache = LocalActivityWeekDataCache.current
   val timeZone = remember { TimeZone.currentSystemDefault() }
@@ -146,7 +148,7 @@ fun rememberActivityWeekData(
   LaunchedEffect(cacheVersion, range, mode) {
     val result =
       withContext(Dispatchers.Default) {
-        buildActivityWeekData(configTimeline, dailyMemos, timeZone, memos, range, mode)
+        buildActivityWeekData(configTimeline, dailyMemos, timeZone, memos, range, mode, today)
       }
     cache.put(memos, range, mode, result)
     currentData = result
@@ -210,6 +212,7 @@ private fun buildActivityWeekData(
   memos: List<Memo>,
   range: ActivityRange,
   mode: ActivityMode,
+  today: LocalDate,
 ): ActivityWeekData {
   val bounds = rangeBounds(range)
   val effectiveConfigTimeline = if (mode == ActivityMode.HABITS) configTimeline else emptyList()
@@ -229,6 +232,7 @@ private fun buildActivityWeekData(
             configTimeline = effectiveConfigTimeline,
             dailyMemos = dailyMemos,
             counts = counts,
+            today = today,
           ),
         )
       }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/components/ContributionGridStateHelpers.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/components/ContributionGridStateHelpers.kt
@@ -21,6 +21,10 @@ internal fun buildDayData(context: DayDataContext): ContributionDay {
   val totalHabits = if (habitState.useHabits) habitsForDay.size else 0
   val ratio = completionRatio(totalHabits, completed)
   val inRange = context.date >= context.bounds.start && context.date <= context.bounds.end
+  val configStartDate = context.configTimeline.firstOrNull()?.date
+  val isFuture = context.date > context.today
+  val isBeforeConfig = configStartDate != null && context.date < configStartDate
+  val isClickable = !isFuture && !isBeforeConfig
   return ContributionDay(
     date = context.date,
     count = completed,
@@ -29,6 +33,7 @@ internal fun buildDayData(context: DayDataContext): ContributionDay {
     habitStatuses = habitState.habitStatuses,
     dailyMemo = dailyMemo,
     inRange = inRange,
+    isClickable = isClickable,
   )
 }
 


### PR DESCRIPTION
## Summary
- Add `isClickable` field to `ContributionDay` domain model
- Calculate `isClickable` in `buildDayData` based on `today` and `configStartDate`  
- Simplify `LastSevenDaysMatrix` view to just use `day.isClickable`
- Pass `today` through `DayDataContext` for proper calculation

This follows the principle that view should be "dumb" and domain should contain business logic.

## Test plan
- [ ] Reset app, select offline mode
- [ ] Add new habits
- [ ] Verify cells for days before today are grayed out and not clickable
- [ ] Verify today's cell is still clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)