### PR TITLE
Migrate Metro DI to class-level annotations

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.shared.app.di
 
-import dev.zacsweers.metro.Binds
 import dev.zacsweers.metro.DependencyGraph
 import dev.zacsweers.metro.Provides
 import dev.zacsweers.metro.SingleIn
@@ -9,27 +8,16 @@ import io.ktor.client.HttpClient
 import space.be1ski.vibits.shared.core.network.createHttpClient
 import space.be1ski.vibits.shared.core.platform.LocaleProvider
 import space.be1ski.vibits.shared.data.local.AppDetailsProvider
-import space.be1ski.vibits.shared.feature.auth.data.CredentialsRepositoryImpl
 import space.be1ski.vibits.shared.feature.auth.data.CredentialsStore
-import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
-import space.be1ski.vibits.shared.feature.memos.data.ModeAwareMemosRepository
-import space.be1ski.vibits.shared.feature.memos.data.demo.DemoMemosRepository
 import space.be1ski.vibits.shared.feature.memos.data.local.MemoCache
-import space.be1ski.vibits.shared.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemoStorage
-import space.be1ski.vibits.shared.feature.memos.data.remote.MemosApi
-import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
-import space.be1ski.vibits.shared.feature.mode.data.AppModeRepositoryImpl
 import space.be1ski.vibits.shared.feature.mode.data.AppModeStore
-import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
-import space.be1ski.vibits.shared.feature.settings.data.PreferencesRepositoryImpl
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStore
-import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
 /**
  * Metro dependency graph for the application.
+ * Only expect/actual classes need @Provides here - all other bindings use @ContributesBinding.
  */
-@Suppress("TooManyFunctions", "LongParameterList")
 @SingleIn(AppScope::class)
 @DependencyGraph(AppScope::class)
 abstract class AppGraph {
@@ -76,29 +64,4 @@ abstract class AppGraph {
   @Provides
   @SingleIn(AppScope::class)
   fun offlineMemoStorage(): OfflineMemoStorage = OfflineMemoStorage()
-
-  @Provides
-  @SingleIn(AppScope::class)
-  fun memoMapper(): MemoMapper = MemoMapper()
-
-  @Provides
-  @SingleIn(AppScope::class)
-  fun memosApi(httpClient: HttpClient): MemosApi = MemosApi(httpClient)
-
-  @Provides
-  @SingleIn(AppScope::class)
-  fun demoMemosRepository(): DemoMemosRepository = DemoMemosRepository()
-
-  // Repository bindings (interface -> implementation)
-  @Binds
-  abstract val CredentialsRepositoryImpl.bindCredentialsRepository: CredentialsRepository
-
-  @Binds
-  abstract val PreferencesRepositoryImpl.bindPreferencesRepository: PreferencesRepository
-
-  @Binds
-  abstract val AppModeRepositoryImpl.bindAppModeRepository: AppModeRepository
-
-  @Binds
-  abstract val ModeAwareMemosRepository.bindMemosRepository: MemosRepository
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/data/CredentialsRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/data/CredentialsRepositoryImpl.kt
@@ -1,6 +1,9 @@
 package space.be1ski.vibits.shared.feature.auth.data
 
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
@@ -12,6 +15,8 @@ private const val URL_LOG_MAX_LENGTH = 50
  * Repository implementation backed by platform credential storage.
  */
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class CredentialsRepositoryImpl(
   private val credentialsStore: CredentialsStore,
 ) : CredentialsRepository {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/MemosRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/MemosRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package space.be1ski.vibits.shared.feature.memos.data
 
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.shared.feature.memos.data.local.MemoCache
@@ -17,6 +19,7 @@ private const val TAG = "MemosRepository"
  * Repository implementation that loads memos from the network and caches them locally.
  */
 @Inject
+@SingleIn(AppScope::class)
 class MemosRepositoryImpl(
   private val memosApi: MemosApi,
   private val memoMapper: MemoMapper,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepository.kt
@@ -1,6 +1,9 @@
 package space.be1ski.vibits.shared.feature.memos.data
 
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.memos.data.demo.DemoMemosRepository
 import space.be1ski.vibits.shared.feature.memos.data.local.MemoCache
@@ -17,6 +20,8 @@ private const val TAG = "ModeAwareRepo"
  * Clears cache when switching modes to ensure data isolation.
  */
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class ModeAwareMemosRepository(
   private val appModeRepository: AppModeRepository,
   private val onlineRepository: MemosRepositoryImpl,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoMemosRepository.kt
@@ -1,5 +1,8 @@
 package space.be1ski.vibits.shared.feature.memos.data.demo
 
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
 import kotlin.time.Clock
@@ -10,6 +13,8 @@ import kotlin.uuid.Uuid
  * In-memory repository for demo mode.
  * All changes are stored in memory and reset when demo mode is toggled.
  */
+@Inject
+@SingleIn(AppScope::class)
 class DemoMemosRepository : MemosRepository {
   private val memos = mutableListOf<Memo>()
   private var initialized = false

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/mapper/MemoMapper.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/mapper/MemoMapper.kt
@@ -1,5 +1,8 @@
 package space.be1ski.vibits.shared.feature.memos.data.mapper
 
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import kotlin.time.Instant
@@ -7,6 +10,8 @@ import kotlin.time.Instant
 /**
  * Maps network memo DTOs into domain models.
  */
+@Inject
+@SingleIn(AppScope::class)
 class MemoMapper {
   private companion object {
     const val EPOCH_SECONDS_LENGTH = 10

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/offline/OfflineMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/offline/OfflineMemosRepository.kt
@@ -1,6 +1,8 @@
 package space.be1ski.vibits.shared.feature.memos.data.offline
 
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
 import kotlin.time.Clock
@@ -13,6 +15,7 @@ import kotlin.uuid.Uuid
  * Stores memos in local JSON file.
  */
 @Inject
+@SingleIn(AppScope::class)
 class OfflineMemosRepository(
   private val storage: OfflineMemoStorage,
 ) : MemosRepository {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
@@ -1,5 +1,7 @@
 package space.be1ski.vibits.shared.feature.memos.data.remote
 
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.delete
@@ -12,6 +14,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.memos.data.remote.dto.CreateMemoRequestDto
 import space.be1ski.vibits.shared.feature.memos.data.remote.dto.ListMemosResponseDto
@@ -20,6 +23,8 @@ import space.be1ski.vibits.shared.feature.memos.data.remote.dto.UpdateMemoReques
 
 private const val TAG = "MemosApi"
 
+@Inject
+@SingleIn(AppScope::class)
 @Suppress("TooGenericExceptionCaught")
 class MemosApi(
   private val httpClient: HttpClient,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/data/AppModeRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/data/AppModeRepositoryImpl.kt
@@ -1,10 +1,15 @@
 package space.be1ski.vibits.shared.feature.mode.data
 
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
 
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class AppModeRepositoryImpl(
   private val store: AppModeStore,
 ) : AppModeRepository {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/data/PreferencesRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/data/PreferencesRepositoryImpl.kt
@@ -1,6 +1,9 @@
 package space.be1ski.vibits.shared.feature.settings.data
 
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
@@ -14,6 +17,8 @@ private const val TAG = "Preferences"
  * Repository implementation backed by platform preferences storage.
  */
 @Inject
+@SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 class PreferencesRepositoryImpl(
   private val preferencesStore: PreferencesStore,
 ) : PreferencesRepository {


### PR DESCRIPTION
## Summary
- Move `@Inject @SingleIn @ContributesBinding` annotations directly onto implementation classes
- Remove manual `@Provides` and `@Binds` from `AppGraph` for classes with constructor injection
- `AppGraph` now only contains `@Provides` for expect/actual platform classes

## Changes
- **Repositories**: Added `@ContributesBinding(AppScope::class)` to bind interface → impl
  - `CredentialsRepositoryImpl`, `PreferencesRepositoryImpl`, `AppModeRepositoryImpl`, `ModeAwareMemosRepository`
- **Data classes**: Added `@Inject @SingleIn(AppScope::class)`
  - `MemoMapper`, `MemosApi`, `DemoMemosRepository`, `MemosRepositoryImpl`, `OfflineMemosRepository`
- **AppGraph**: Removed ~30 lines of manual bindings, kept only platform-specific `@Provides`

## Test plan
- [x] `./gradlew :shared:compileKotlinDesktop` passes
- [x] `./gradlew :shared:desktopTest` passes
- [x] `./gradlew :shared:ktlintCheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)