### PR TITLE
Add tests for all EffectHandlers

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -11,7 +11,7 @@ coverage:
 ignore:
   - "**/di/**"
   - "**/view/**"
-  - "**/*EffectHandler.kt"
+  - "**/commonTest/**"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
@@ -17,8 +17,8 @@ fun createModeSelectionFeature(
     reducer = modeSelectionReducer,
     effectHandler =
       ModeSelectionEffectHandler(
-        validateCredentials = dependencies.validateCredentials,
-        saveCredentials = dependencies.saveCredentials,
-        saveAppMode = dependencies.saveAppMode,
+        validateCredentials = { baseUrl, token -> dependencies.validateCredentials(baseUrl, token) },
+        saveCredentials = { credentials -> dependencies.saveCredentials(credentials) },
+        saveAppMode = { mode -> dependencies.saveAppMode(mode) },
       ),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -6,16 +6,14 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
 private const val TAG = "ModeEffect"
 
 class ModeSelectionEffectHandler(
-  private val validateCredentials: ValidateCredentialsUseCase,
-  private val saveCredentials: SaveCredentialsUseCase,
-  private val saveAppMode: SaveAppModeUseCase,
+  private val validateCredentials: suspend (String, String) -> Result<Unit>,
+  private val saveCredentials: (Credentials) -> Unit,
+  private val saveAppMode: (AppMode) -> Unit,
 ) : EffectHandler<ModeSelectionEffect, ModeSelectionAction> {
   override fun invoke(effect: ModeSelectionEffect): Flow<ModeSelectionAction> =
     when (effect) {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
@@ -25,11 +25,11 @@ fun createSettingsFeature(
     reducer = settingsReducer,
     effectHandler =
       SettingsEffectHandler(
-        validateCredentials = dependencies.validateCredentials,
-        switchAppMode = dependencies.switchAppMode,
-        saveCredentials = dependencies.saveCredentials,
-        resetApp = dependencies.resetApp,
-        saveLanguage = dependencies.saveLanguage,
-        saveTheme = dependencies.saveTheme,
+        validateCredentials = { baseUrl, token -> dependencies.validateCredentials(baseUrl, token) },
+        switchAppMode = { mode -> dependencies.switchAppMode(mode) },
+        saveCredentials = { credentials -> dependencies.saveCredentials(credentials) },
+        resetApp = { dependencies.resetApp() },
+        saveLanguage = { language -> dependencies.saveLanguage(language) },
+        saveTheme = { theme -> dependencies.saveTheme(theme) },
       ),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
@@ -6,22 +6,19 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUseCase
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
 
 private const val TAG = "SettingsEffect"
 
 class SettingsEffectHandler(
-  private val validateCredentials: ValidateCredentialsUseCase,
-  private val switchAppMode: SwitchAppModeUseCase,
-  private val saveCredentials: SaveCredentialsUseCase,
-  private val resetApp: ResetAppUseCase,
-  private val saveLanguage: SaveLanguageUseCase,
-  private val saveTheme: SaveThemeUseCase,
+  private val validateCredentials: suspend (String, String) -> Result<Unit>,
+  private val switchAppMode: suspend (AppMode) -> Unit,
+  private val saveCredentials: (Credentials) -> Unit,
+  private val resetApp: suspend () -> Unit,
+  private val saveLanguage: (AppLanguage) -> Boolean,
+  private val saveTheme: (AppTheme) -> Unit,
 ) : EffectHandler<SettingsEffect, SettingsAction> {
   override fun invoke(effect: SettingsEffect): Flow<SettingsAction> =
     when (effect) {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsEffectHandlerTest.kt
@@ -1,0 +1,131 @@
+package space.be1ski.vibits.shared.feature.habits.presentation
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
+import space.be1ski.vibits.shared.test.FakeMemosRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class HabitsEffectHandlerTest {
+  @Test
+  fun `CreateMemo emits MemoCreated on success`() =
+    runTest {
+      val expectedMemo = Memo(name = "memos/1", content = "test")
+      val repository =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.success(expectedMemo)
+        }
+      val handler = createHandler(repository)
+
+      val actions = handler(HabitsEffect.CreateMemo(content = "test")).toList()
+
+      assertEquals(listOf(HabitsAction.MemoCreated(expectedMemo)), actions)
+      assertEquals(1, repository.createMemoCalls)
+    }
+
+  @Test
+  fun `CreateMemo emits MemoOperationFailed on failure`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.failure(Exception("Network error"))
+        }
+      val handler = createHandler(repository)
+
+      val actions = handler(HabitsEffect.CreateMemo(content = "test")).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is HabitsAction.MemoOperationFailed)
+      assertEquals("Network error", (actions[0] as HabitsAction.MemoOperationFailed).error)
+    }
+
+  @Test
+  fun `UpdateMemo emits MemoUpdated on success`() =
+    runTest {
+      val expectedMemo = Memo(name = "memos/1", content = "updated")
+      val repository =
+        FakeMemosRepository().apply {
+          updateMemoResult = Result.success(expectedMemo)
+        }
+      val handler = createHandler(repository)
+
+      val actions =
+        handler(
+          HabitsEffect.UpdateMemo(name = "memos/1", content = "updated"),
+        ).toList()
+
+      assertEquals(listOf(HabitsAction.MemoUpdated(expectedMemo)), actions)
+      assertEquals(1, repository.updateMemoCalls)
+    }
+
+  @Test
+  fun `UpdateMemo emits MemoOperationFailed on failure`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          updateMemoResult = Result.failure(Exception("Update failed"))
+        }
+      val handler = createHandler(repository)
+
+      val actions =
+        handler(
+          HabitsEffect.UpdateMemo(name = "memos/1", content = "updated"),
+        ).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is HabitsAction.MemoOperationFailed)
+    }
+
+  @Test
+  fun `DeleteMemo emits MemoDeleted on success`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          deleteMemoResult = Result.success(Unit)
+        }
+      val handler = createHandler(repository)
+
+      val actions = handler(HabitsEffect.DeleteMemo(name = "memos/1")).toList()
+
+      assertEquals(listOf(HabitsAction.MemoDeleted("memos/1")), actions)
+      assertEquals(1, repository.deleteMemoCalls)
+    }
+
+  @Test
+  fun `DeleteMemo emits MemoOperationFailed on failure`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          deleteMemoResult = Result.failure(Exception("Delete failed"))
+        }
+      val handler = createHandler(repository)
+
+      val actions = handler(HabitsEffect.DeleteMemo(name = "memos/1")).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is HabitsAction.MemoOperationFailed)
+    }
+
+  @Test
+  fun `RefreshMemos calls onRefresh callback`() =
+    runTest {
+      var refreshCalled = false
+      val handler = createHandler(onRefresh = { refreshCalled = true })
+
+      handler(HabitsEffect.RefreshMemos).toList()
+
+      assertTrue(refreshCalled)
+    }
+
+  private fun createHandler(
+    repository: FakeMemosRepository = FakeMemosRepository(),
+    onRefresh: () -> Unit = {},
+  ): HabitsEffectHandler {
+    return HabitsEffectHandler(
+      memosRepository = repository,
+      onRefresh = onRefresh,
+    )
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandlerTest.kt
@@ -1,0 +1,205 @@
+package space.be1ski.vibits.shared.feature.memos.presentation
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.LoadCredentialsUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
+import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
+import space.be1ski.vibits.shared.feature.memos.domain.usecase.CreateMemoUseCase
+import space.be1ski.vibits.shared.feature.memos.domain.usecase.DeleteMemoUseCase
+import space.be1ski.vibits.shared.feature.memos.domain.usecase.LoadCachedMemosUseCase
+import space.be1ski.vibits.shared.feature.memos.domain.usecase.LoadMemosUseCase
+import space.be1ski.vibits.shared.feature.memos.domain.usecase.UpdateMemoUseCase
+import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import space.be1ski.vibits.shared.test.FakeMemosRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MemosEffectHandlerTest {
+  @Test
+  fun `LoadCredentials emits CredentialsLoaded`() =
+    runTest {
+      val credentialsRepo =
+        FakeCredentialsRepository(
+          initial = Credentials(baseUrl = "https://test.com", token = "test-token"),
+        )
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(MemosEffect.LoadCredentials).toList()
+
+      assertEquals(
+        listOf(MemosAction.CredentialsLoaded(baseUrl = "https://test.com", token = "test-token")),
+        actions,
+      )
+    }
+
+  @Test
+  fun `SaveCredentials saves to repository`() =
+    runTest {
+      val credentialsRepo = FakeCredentialsRepository()
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      handler(
+        MemosEffect.SaveCredentials(baseUrl = "https://new.com", token = "new-token"),
+      ).toList()
+
+      assertEquals("https://new.com", credentialsRepo.stored.baseUrl)
+      assertEquals("new-token", credentialsRepo.stored.token)
+    }
+
+  @Test
+  fun `LoadCachedMemos emits CachedMemosLoaded on success`() =
+    runTest {
+      val expectedMemos = listOf(Memo(name = "memos/1", content = "cached"))
+      val memosRepo =
+        FakeMemosRepository().apply {
+          cachedMemosResult = expectedMemos
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.LoadCachedMemos).toList()
+
+      assertEquals(listOf(MemosAction.CachedMemosLoaded(expectedMemos)), actions)
+    }
+
+  @Test
+  fun `LoadRemoteMemos emits MemosLoaded on success`() =
+    runTest {
+      val expectedMemos = listOf(Memo(name = "memos/1", content = "remote"))
+      val memosRepo =
+        FakeMemosRepository().apply {
+          listMemosResult = Result.success(expectedMemos)
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.LoadRemoteMemos).toList()
+
+      assertEquals(listOf(MemosAction.MemosLoaded(expectedMemos)), actions)
+    }
+
+  @Test
+  fun `LoadRemoteMemos emits OperationFailed on failure`() =
+    runTest {
+      val memosRepo =
+        FakeMemosRepository().apply {
+          listMemosResult = Result.failure(Exception("Network error"))
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.LoadRemoteMemos).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is MemosAction.OperationFailed)
+      assertEquals("Network error", (actions[0] as MemosAction.OperationFailed).error)
+    }
+
+  @Test
+  fun `CreateMemo emits MemoCreated on success`() =
+    runTest {
+      val expectedMemo = Memo(name = "memos/new", content = "new content")
+      val memosRepo =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.success(expectedMemo)
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.CreateMemo(content = "new content")).toList()
+
+      assertEquals(listOf(MemosAction.MemoCreated(expectedMemo)), actions)
+    }
+
+  @Test
+  fun `CreateMemo emits OperationFailed on failure`() =
+    runTest {
+      val memosRepo =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.failure(Exception("Create failed"))
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.CreateMemo(content = "test")).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is MemosAction.OperationFailed)
+    }
+
+  @Test
+  fun `UpdateMemo emits MemoUpdated on success`() =
+    runTest {
+      val expectedMemo = Memo(name = "memos/1", content = "updated")
+      val memosRepo =
+        FakeMemosRepository().apply {
+          updateMemoResult = Result.success(expectedMemo)
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions =
+        handler(
+          MemosEffect.UpdateMemo(name = "memos/1", content = "updated"),
+        ).toList()
+
+      assertEquals(listOf(MemosAction.MemoUpdated(expectedMemo)), actions)
+    }
+
+  @Test
+  fun `UpdateMemo emits OperationFailed on failure`() =
+    runTest {
+      val memosRepo =
+        FakeMemosRepository().apply {
+          updateMemoResult = Result.failure(Exception("Update failed"))
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions =
+        handler(
+          MemosEffect.UpdateMemo(name = "memos/1", content = "updated"),
+        ).toList()
+
+      assertTrue(actions[0] is MemosAction.OperationFailed)
+    }
+
+  @Test
+  fun `DeleteMemo emits MemoDeleted on success`() =
+    runTest {
+      val memosRepo =
+        FakeMemosRepository().apply {
+          deleteMemoResult = Result.success(Unit)
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.DeleteMemo(name = "memos/1")).toList()
+
+      assertEquals(listOf(MemosAction.MemoDeleted("memos/1")), actions)
+    }
+
+  @Test
+  fun `DeleteMemo emits OperationFailed on failure`() =
+    runTest {
+      val memosRepo =
+        FakeMemosRepository().apply {
+          deleteMemoResult = Result.failure(Exception("Delete failed"))
+        }
+      val handler = createHandler(memosRepository = memosRepo)
+
+      val actions = handler(MemosEffect.DeleteMemo(name = "memos/1")).toList()
+
+      assertTrue(actions[0] is MemosAction.OperationFailed)
+    }
+
+  private fun createHandler(
+    credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
+    memosRepository: FakeMemosRepository = FakeMemosRepository(),
+  ): MemosEffectHandler {
+    return MemosEffectHandler(
+      loadCredentials = LoadCredentialsUseCase(credentialsRepository),
+      saveCredentials = SaveCredentialsUseCase(credentialsRepository),
+      loadMemos = LoadMemosUseCase(memosRepository),
+      loadCachedMemos = LoadCachedMemosUseCase(memosRepository),
+      createMemo = CreateMemoUseCase(memosRepository),
+      updateMemo = UpdateMemoUseCase(memosRepository),
+      deleteMemo = DeleteMemoUseCase(memosRepository),
+    )
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -1,0 +1,93 @@
+package space.be1ski.vibits.shared.feature.mode.presentation
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class ModeSelectionEffectHandlerTest {
+  @Test
+  fun `ValidateCredentials emits ValidationSucceeded on success`() =
+    runTest {
+      val handler = createHandler(validateResult = Result.success(Unit))
+
+      val actions =
+        handler(
+          ModeSelectionEffect.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
+        ).toList()
+
+      assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
+    }
+
+  @Test
+  fun `ValidateCredentials emits ValidationFailed on failure`() =
+    runTest {
+      val handler = createHandler(validateResult = Result.failure(Exception("Connection failed")))
+
+      val actions =
+        handler(
+          ModeSelectionEffect.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
+        ).toList()
+
+      assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
+    }
+
+  @Test
+  fun `SaveCredentials calls saveCredentials function`() =
+    runTest {
+      var savedCredentials: Credentials? = null
+      val handler =
+        createHandler(
+          saveCredentials = { savedCredentials = it },
+        )
+
+      handler(
+        ModeSelectionEffect.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
+      ).toList()
+
+      assertEquals("https://saved.com", savedCredentials?.baseUrl)
+      assertEquals("saved-token", savedCredentials?.token)
+    }
+
+  @Test
+  fun `SaveMode calls saveAppMode function`() =
+    runTest {
+      var savedMode: AppMode? = null
+      val handler =
+        createHandler(
+          saveAppMode = { savedMode = it },
+        )
+
+      handler(ModeSelectionEffect.SaveMode(mode = AppMode.OFFLINE)).toList()
+
+      assertEquals(AppMode.OFFLINE, savedMode)
+    }
+
+  @Test
+  fun `NotifyModeSelected returns empty flow`() =
+    runTest {
+      val handler = createHandler()
+
+      val actions =
+        handler(
+          ModeSelectionEffect.NotifyModeSelected(mode = AppMode.ONLINE),
+        ).toList()
+
+      assertTrue(actions.isEmpty())
+    }
+
+  private fun createHandler(
+    validateResult: Result<Unit> = Result.success(Unit),
+    saveCredentials: (Credentials) -> Unit = {},
+    saveAppMode: (AppMode) -> Unit = {},
+  ): ModeSelectionEffectHandler {
+    return ModeSelectionEffectHandler(
+      validateCredentials = { _, _ -> validateResult },
+      saveCredentials = saveCredentials,
+      saveAppMode = saveAppMode,
+    )
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -1,0 +1,176 @@
+package space.be1ski.vibits.shared.feature.settings.presentation
+
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class SettingsEffectHandlerTest {
+  @Test
+  fun `ValidateCredentials emits ValidationSucceeded on success`() =
+    runTest {
+      val handler = createHandler(validateResult = Result.success(Unit))
+
+      val actions =
+        handler(
+          SettingsEffect.ValidateCredentials(
+            baseUrl = "https://test.com",
+            token = "token",
+            targetMode = AppMode.ONLINE,
+          ),
+        ).toList()
+
+      assertEquals(listOf(SettingsAction.ValidationSucceeded), actions)
+    }
+
+  @Test
+  fun `ValidateCredentials emits ValidationFailed on failure`() =
+    runTest {
+      val handler = createHandler(validateResult = Result.failure(Exception("Connection failed")))
+
+      val actions =
+        handler(
+          SettingsEffect.ValidateCredentials(
+            baseUrl = "https://test.com",
+            token = "token",
+            targetMode = AppMode.ONLINE,
+          ),
+        ).toList()
+
+      assertEquals(1, actions.size)
+      assertTrue(actions[0] is SettingsAction.ValidationFailed)
+    }
+
+  @Test
+  fun `SwitchMode saves mode and emits ModeSwitched`() =
+    runTest {
+      var switchedMode: AppMode? = null
+      val handler =
+        createHandler(
+          switchAppMode = { switchedMode = it },
+        )
+
+      val actions = handler(SettingsEffect.SwitchMode(mode = AppMode.OFFLINE)).toList()
+
+      assertEquals(listOf(SettingsAction.ModeSwitched), actions)
+      assertEquals(AppMode.OFFLINE, switchedMode)
+    }
+
+  @Test
+  fun `SaveCredentials saves to repository`() =
+    runTest {
+      var savedCredentials: Credentials? = null
+      val handler =
+        createHandler(
+          saveCredentials = { savedCredentials = it },
+        )
+
+      handler(
+        SettingsEffect.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
+      ).toList()
+
+      assertEquals("https://saved.com", savedCredentials?.baseUrl)
+      assertEquals("saved-token", savedCredentials?.token)
+    }
+
+  @Test
+  fun `ResetApp resets and emits ResetCompleted`() =
+    runTest {
+      var resetCalled = false
+      val handler =
+        createHandler(
+          resetApp = { resetCalled = true },
+        )
+
+      val actions = handler(SettingsEffect.ResetApp).toList()
+
+      assertEquals(listOf(SettingsAction.ResetCompleted), actions)
+      assertTrue(resetCalled)
+    }
+
+  @Test
+  fun `SaveLanguage calls saveLanguage function`() =
+    runTest {
+      var savedLanguage: AppLanguage? = null
+      val handler =
+        createHandler(
+          saveLanguage = {
+            savedLanguage = it
+            false
+          },
+        )
+
+      handler(SettingsEffect.SaveLanguage(language = AppLanguage.ENGLISH)).toList()
+
+      assertEquals(AppLanguage.ENGLISH, savedLanguage)
+    }
+
+  @Test
+  fun `SaveTheme calls saveTheme function`() =
+    runTest {
+      var savedTheme: AppTheme? = null
+      val handler =
+        createHandler(
+          saveTheme = { savedTheme = it },
+        )
+
+      handler(SettingsEffect.SaveTheme(theme = AppTheme.DARK)).toList()
+
+      assertEquals(AppTheme.DARK, savedTheme)
+    }
+
+  @Test
+  fun `Notification effects return empty flow`() =
+    runTest {
+      val handler = createHandler()
+
+      val notifyModeActions =
+        handler(
+          SettingsEffect.NotifyModeChanged(newMode = AppMode.OFFLINE),
+        ).toList()
+      val notifyResetActions = handler(SettingsEffect.NotifyResetCompleted).toList()
+      val notifyCredentialsActions =
+        handler(
+          SettingsEffect.NotifyCredentialsSaved(baseUrl = "url", token = "token"),
+        ).toList()
+      val notifyLanguageActions =
+        handler(
+          SettingsEffect.NotifyLanguageChanged(language = AppLanguage.ENGLISH),
+        ).toList()
+      val notifyThemeActions =
+        handler(
+          SettingsEffect.NotifyThemeChanged(theme = AppTheme.DARK),
+        ).toList()
+      val notifyDialogActions = handler(SettingsEffect.NotifyDialogClosed).toList()
+
+      assertTrue(notifyModeActions.isEmpty())
+      assertTrue(notifyResetActions.isEmpty())
+      assertTrue(notifyCredentialsActions.isEmpty())
+      assertTrue(notifyLanguageActions.isEmpty())
+      assertTrue(notifyThemeActions.isEmpty())
+      assertTrue(notifyDialogActions.isEmpty())
+    }
+
+  private fun createHandler(
+    validateResult: Result<Unit> = Result.success(Unit),
+    switchAppMode: suspend (AppMode) -> Unit = {},
+    saveCredentials: (Credentials) -> Unit = {},
+    resetApp: suspend () -> Unit = {},
+    saveLanguage: (AppLanguage) -> Boolean = { false },
+    saveTheme: (AppTheme) -> Unit = {},
+  ): SettingsEffectHandler {
+    return SettingsEffectHandler(
+      validateCredentials = { _, _ -> validateResult },
+      switchAppMode = switchAppMode,
+      saveCredentials = saveCredentials,
+      resetApp = resetApp,
+      saveLanguage = saveLanguage,
+      saveTheme = saveTheme,
+    )
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
@@ -3,10 +3,13 @@ package space.be1ski.vibits.shared.test
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.shared.feature.memos.data.local.MemoCache
+import space.be1ski.vibits.shared.feature.memos.data.remote.dto.ListMemosResponseDto
+import space.be1ski.vibits.shared.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.shared.feature.settings.domain.model.UserPreferences
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
@@ -137,5 +140,110 @@ class FakePreferencesRepository(
   override fun save(preferences: UserPreferences) {
     stored = preferences
     saveCalls += 1
+  }
+}
+
+// Fake Use Cases for EffectHandler tests
+
+class FakeValidateCredentialsUseCase(
+  private val result: Result<Unit> = Result.success(Unit),
+) {
+  var invokedWith: Pair<String, String>? = null
+    private set
+
+  suspend operator fun invoke(
+    baseUrl: String,
+    token: String,
+  ): Result<Unit> {
+    invokedWith = baseUrl to token
+    return result
+  }
+}
+
+class FakeModeAwareMemosRepository : MemosRepository {
+  var clearCacheOnModeChangeCalls: Int = 0
+    private set
+
+  override suspend fun listMemos(): List<Memo> = emptyList()
+
+  override suspend fun cachedMemos(): List<Memo> = emptyList()
+
+  override suspend fun updateMemo(
+    name: String,
+    content: String,
+  ): Memo = Memo()
+
+  override suspend fun createMemo(content: String): Memo = Memo()
+
+  override suspend fun deleteMemo(name: String) {}
+
+  suspend fun clearCacheOnModeChange() {
+    clearCacheOnModeChangeCalls++
+  }
+}
+
+/**
+ * Fake MemosApi for testing ValidateCredentialsUseCase.
+ */
+class FakeMemosApi(
+  var listMemosResult: Result<ListMemosResponseDto> = Result.success(ListMemosResponseDto()),
+) {
+  var listMemosCalls: Int = 0
+    private set
+
+  suspend fun listMemos(
+    baseUrl: String,
+    token: String,
+    pageSize: Int,
+    pageToken: String?,
+  ): ListMemosResponseDto {
+    listMemosCalls++
+    return listMemosResult.getOrThrow()
+  }
+}
+
+/**
+ * Fake DemoMemosRepository for testing ResetAppUseCase.
+ */
+class FakeDemoMemosRepository : MemosRepository {
+  var resetCalls: Int = 0
+    private set
+
+  fun reset() {
+    resetCalls++
+  }
+
+  override suspend fun listMemos(): List<Memo> = emptyList()
+
+  override suspend fun cachedMemos(): List<Memo> = emptyList()
+
+  override suspend fun updateMemo(
+    name: String,
+    content: String,
+  ): Memo = Memo()
+
+  override suspend fun createMemo(content: String): Memo = Memo()
+
+  override suspend fun deleteMemo(name: String) {}
+}
+
+/**
+ * Fake LocaleProvider for testing SaveLanguageUseCase.
+ */
+class FakeLocaleProvider(
+  private val systemLocale: String = "en",
+  private val requiresRestart: Boolean = false,
+) {
+  var configureLocaleCalls: Int = 0
+    private set
+  var lastConfiguredLanguage: AppLanguage? = null
+    private set
+
+  fun getSystemLocale(): String = systemLocale
+
+  fun configureLocale(language: AppLanguage): Boolean {
+    configureLocaleCalls++
+    lastConfiguredLanguage = language
+    return requiresRestart
   }
 }


### PR DESCRIPTION
## Summary
- Refactored EffectHandlers to use functional types instead of concrete use case classes for better testability
- Added comprehensive tests for all 4 EffectHandlers:
  - `ModeSelectionEffectHandler` - validation, save credentials, save mode
  - `SettingsEffectHandler` - validation, switch mode, credentials, reset, language, theme
  - `HabitsEffectHandler` - memo CRUD operations, refresh callback
  - `MemosEffectHandler` - credentials loading/saving, memo CRUD operations

## Test plan
- [x] All EffectHandler tests pass
- [x] ktlint check passes
- [x] Full desktop test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)