### PR TITLE
Use fun interface for use cases instead of raw lambdas

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCase.kt
@@ -4,11 +4,15 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 
+fun interface SaveCredentials {
+  operator fun invoke(credentials: Credentials)
+}
+
 @Inject
 class SaveCredentialsUseCase(
   private val credentialsRepository: CredentialsRepository,
-) {
-  operator fun invoke(credentials: Credentials) {
+) : SaveCredentials {
+  override operator fun invoke(credentials: Credentials) {
     credentialsRepository.save(credentials)
   }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/ValidateCredentialsUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/ValidateCredentialsUseCase.kt
@@ -6,6 +6,13 @@ import space.be1ski.vibits.shared.feature.memos.data.remote.MemosApi
 
 private const val TAG = "ValidateCreds"
 
+fun interface ValidateCredentials {
+  suspend operator fun invoke(
+    baseUrl: String,
+    token: String,
+  ): Result<Unit>
+}
+
 /**
  * Use case that validates credentials by making a test API request.
  * Returns true if credentials are valid, false otherwise.
@@ -13,8 +20,8 @@ private const val TAG = "ValidateCreds"
 @Inject
 class ValidateCredentialsUseCase(
   private val memosApi: MemosApi,
-) {
-  suspend operator fun invoke(
+) : ValidateCredentials {
+  override suspend operator fun invoke(
     baseUrl: String,
     token: String,
   ): Result<Unit> {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
@@ -17,8 +17,8 @@ fun createModeSelectionFeature(
     reducer = modeSelectionReducer,
     effectHandler =
       ModeSelectionEffectHandler(
-        validateCredentials = { baseUrl, token -> dependencies.validateCredentials(baseUrl, token) },
-        saveCredentials = { credentials -> dependencies.saveCredentials(credentials) },
-        saveAppMode = { mode -> dependencies.saveAppMode(mode) },
+        validateCredentials = dependencies.validateCredentials,
+        saveCredentials = dependencies.saveCredentials,
+        saveAppMode = dependencies.saveAppMode,
       ),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppUseCase.kt
@@ -14,6 +14,10 @@ import space.be1ski.vibits.shared.feature.settings.domain.repository.Preferences
 
 private const val TAG = "ResetApp"
 
+fun interface ResetApp {
+  suspend operator fun invoke()
+}
+
 /**
  * Use case for resetting app to initial state.
  * Clears mode selection, cache, credentials, preferences, and demo data,
@@ -26,8 +30,8 @@ class ResetAppUseCase(
   private val credentialsRepository: CredentialsRepository,
   private val preferencesRepository: PreferencesRepository,
   private val demoMemosRepository: DemoMemosRepository,
-) {
-  suspend operator fun invoke() {
+) : ResetApp {
+  override suspend operator fun invoke() {
     Log.i(TAG, "Resetting app to initial state...")
     memoCache.clear()
     credentialsRepository.save(Credentials(baseUrl = "", token = ""))

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SaveAppModeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SaveAppModeUseCase.kt
@@ -4,9 +4,13 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
 
+fun interface SaveAppMode {
+  operator fun invoke(mode: AppMode)
+}
+
 @Inject
 class SaveAppModeUseCase(
   private val appModeRepository: AppModeRepository,
-) {
-  operator fun invoke(mode: AppMode) = appModeRepository.saveMode(mode)
+) : SaveAppMode {
+  override operator fun invoke(mode: AppMode) = appModeRepository.saveMode(mode)
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
@@ -8,6 +8,10 @@ import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeReposito
 
 private const val TAG = "SwitchMode"
 
+fun interface SwitchAppMode {
+  suspend operator fun invoke(mode: AppMode)
+}
+
 /**
  * Use case for switching app mode with cache invalidation.
  */
@@ -15,8 +19,8 @@ private const val TAG = "SwitchMode"
 class SwitchAppModeUseCase(
   private val appModeRepository: AppModeRepository,
   private val modeAwareMemosRepository: ModeAwareMemosRepository,
-) {
-  suspend operator fun invoke(mode: AppMode) {
+) : SwitchAppMode {
+  override suspend operator fun invoke(mode: AppMode) {
     val currentMode = appModeRepository.loadMode()
     if (currentMode != mode) {
       Log.i(TAG, "Switching mode: $currentMode -> $mode")

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -6,14 +6,16 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentials
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentials
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppMode
 
 private const val TAG = "ModeEffect"
 
 class ModeSelectionEffectHandler(
-  private val validateCredentials: suspend (String, String) -> Result<Unit>,
-  private val saveCredentials: (Credentials) -> Unit,
-  private val saveAppMode: (AppMode) -> Unit,
+  private val validateCredentials: ValidateCredentials,
+  private val saveCredentials: SaveCredentials,
+  private val saveAppMode: SaveAppMode,
 ) : EffectHandler<ModeSelectionEffect, ModeSelectionAction> {
   override fun invoke(effect: ModeSelectionEffect): Flow<ModeSelectionAction> =
     when (effect) {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
@@ -25,11 +25,11 @@ fun createSettingsFeature(
     reducer = settingsReducer,
     effectHandler =
       SettingsEffectHandler(
-        validateCredentials = { baseUrl, token -> dependencies.validateCredentials(baseUrl, token) },
-        switchAppMode = { mode -> dependencies.switchAppMode(mode) },
-        saveCredentials = { credentials -> dependencies.saveCredentials(credentials) },
-        resetApp = { dependencies.resetApp() },
-        saveLanguage = { language -> dependencies.saveLanguage(language) },
-        saveTheme = { theme -> dependencies.saveTheme(theme) },
+        validateCredentials = dependencies.validateCredentials,
+        switchAppMode = dependencies.switchAppMode,
+        saveCredentials = dependencies.saveCredentials,
+        resetApp = dependencies.resetApp,
+        saveLanguage = dependencies.saveLanguage,
+        saveTheme = dependencies.saveTheme,
       ),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveLanguageUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveLanguageUseCase.kt
@@ -5,6 +5,10 @@ import space.be1ski.vibits.shared.core.platform.LocaleProvider
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
+fun interface SaveLanguage {
+  operator fun invoke(language: AppLanguage): Boolean
+}
+
 /**
  * Saves the selected language preference and configures the locale.
  * @return true if a restart is required for the change to take effect
@@ -13,8 +17,8 @@ import space.be1ski.vibits.shared.feature.settings.domain.repository.Preferences
 class SaveLanguageUseCase(
   private val preferencesRepository: PreferencesRepository,
   private val localeProvider: LocaleProvider,
-) {
-  operator fun invoke(language: AppLanguage): Boolean {
+) : SaveLanguage {
+  override operator fun invoke(language: AppLanguage): Boolean {
     val currentPrefs = preferencesRepository.load()
     val updatedPrefs = currentPrefs.copy(language = language)
     preferencesRepository.save(updatedPrefs)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveThemeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveThemeUseCase.kt
@@ -4,11 +4,15 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
+fun interface SaveTheme {
+  operator fun invoke(theme: AppTheme)
+}
+
 @Inject
 class SaveThemeUseCase(
   private val preferencesRepository: PreferencesRepository,
-) {
-  operator fun invoke(theme: AppTheme) {
+) : SaveTheme {
+  override operator fun invoke(theme: AppTheme) {
     val currentPrefs = preferencesRepository.load()
     val updatedPrefs = currentPrefs.copy(theme = theme)
     preferencesRepository.save(updatedPrefs)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
@@ -6,19 +6,22 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
-import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
-import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentials
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentials
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetApp
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppMode
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguage
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveTheme
 
 private const val TAG = "SettingsEffect"
 
 class SettingsEffectHandler(
-  private val validateCredentials: suspend (String, String) -> Result<Unit>,
-  private val switchAppMode: suspend (AppMode) -> Unit,
-  private val saveCredentials: (Credentials) -> Unit,
-  private val resetApp: suspend () -> Unit,
-  private val saveLanguage: (AppLanguage) -> Boolean,
-  private val saveTheme: (AppTheme) -> Unit,
+  private val validateCredentials: ValidateCredentials,
+  private val switchAppMode: SwitchAppMode,
+  private val saveCredentials: SaveCredentials,
+  private val resetApp: ResetApp,
+  private val saveLanguage: SaveLanguage,
+  private val saveTheme: SaveTheme,
 ) : EffectHandler<SettingsEffect, SettingsAction> {
   override fun invoke(effect: SettingsEffect): Flow<SettingsAction> =
     when (effect) {


### PR DESCRIPTION
## Summary
- Replace raw function types in EffectHandlers with proper `fun interface`
- Use cases now implement these interfaces, enabling both DI injection and SAM conversion for testing
- Clean up factory files - no more lambda wrappers needed

**Interfaces added:**
- `ValidateCredentials`, `SaveCredentials` (auth)
- `SaveAppMode`, `SwitchAppMode`, `ResetApp` (mode)
- `SaveLanguage`, `SaveTheme` (settings)

## Test plan
- [x] All tests pass
- [x] ktlint passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)