### PR TITLE
Fix AppRoot import in desktopApp and webApp, add to CI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -85,6 +85,8 @@ tasks.register("checkAll") {
     ":shared:compileKotlinDesktop",
     ":shared:desktopTest",
     ":androidApp:compileDebugKotlin",
+    ":desktopApp:compileKotlinDesktop",
+    ":webApp:compileKotlinWasmJs",
   )
 }
 

--- a/desktopApp/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
+++ b/desktopApp/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
@@ -4,8 +4,8 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
-import space.be1ski.vibits.shared.app.AppRoot
 import space.be1ski.vibits.shared.app.di.AppGraph
+import space.be1ski.vibits.shared.app.view.AppRoot
 
 fun main() =
   application {

--- a/webApp/src/wasmJsMain/kotlin/space/be1ski/vibits/web/Main.kt
+++ b/webApp/src/wasmJsMain/kotlin/space/be1ski/vibits/web/Main.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.web
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document
-import space.be1ski.vibits.shared.app.AppRoot
 import space.be1ski.vibits.shared.app.di.AppGraph
+import space.be1ski.vibits.shared.app.view.AppRoot
 
 @OptIn(ExperimentalComposeUiApi::class)
 fun main() {


### PR DESCRIPTION
## Summary
- Fix import path: `app.AppRoot` -> `app.view.AppRoot` in desktopApp and webApp
- Add `:desktopApp:compileKotlinDesktop` to checkAll
- Add `:webApp:compileKotlinWasmJs` to checkAll

This ensures release builds (dmg, msi, web) don't fail due to import issues that CI didn't catch.

## Test plan
- [x] `./gradlew checkAll` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)