### PR TITLE
Add Exporter tests with Clock injection

### DIFF
--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -5,11 +5,13 @@ import androidx.core.content.FileProvider
 import space.be1ski.vibits.shared.app.data.AndroidContextHolder
 import java.io.File
 
+actual fun createFileExporter(): FileExporter = AndroidFileExporter()
+
 /**
  * Android implementation that shares files via system share sheet.
  */
-actual class FileExporter {
-  actual fun export(
+private class AndroidFileExporter : FileExporter {
+  override fun export(
     fileName: String,
     content: String,
   ): String? =

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/data/Exporter.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/data/Exporter.kt
@@ -15,6 +15,7 @@ import kotlin.time.Clock
 class Exporter(
   private val fileExporter: FileExporter,
   private val offlineMemoStorage: OfflineMemoStorage,
+  private val clock: Clock = Clock.System,
 ) {
   private val json =
     Json {
@@ -58,7 +59,7 @@ class Exporter(
     extension: String,
   ): String {
     val timestamp =
-      Clock.System
+      clock
         .now()
         .toString()
         .replace(":", "-")

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
@@ -7,6 +7,7 @@ import dev.zacsweers.metro.createGraph
 import io.ktor.client.HttpClient
 import space.be1ski.vibits.shared.core.platform.app.AppDetailsProvider
 import space.be1ski.vibits.shared.core.platform.export.FileExporter
+import space.be1ski.vibits.shared.core.platform.export.createFileExporter
 import space.be1ski.vibits.shared.core.platform.locale.LocaleProvider
 import space.be1ski.vibits.shared.core.platform.network.createHttpClient
 import space.be1ski.vibits.shared.feature.auth.data.platform.CredentialsStore
@@ -71,5 +72,5 @@ abstract class AppGraph {
 
   @Provides
   @SingleIn(AppScope::class)
-  fun fileExporter(): FileExporter = FileExporter()
+  fun fileExporter(): FileExporter = createFileExporter()
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -4,7 +4,7 @@ package space.be1ski.vibits.shared.core.platform.export
  * Platform-specific file exporter that saves content to Downloads/Documents folder.
  * Returns the file path on success or null on failure.
  */
-expect class FileExporter() {
+interface FileExporter {
   /**
    * Export text content to a file.
    * @param fileName The name of the file (e.g., "logs.txt", "memos.json")
@@ -16,3 +16,5 @@ expect class FileExporter() {
     content: String,
   ): String?
 }
+
+expect fun createFileExporter(): FileExporter

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
@@ -67,7 +67,7 @@ import space.be1ski.vibits.shared.app.data.Exporter
 import space.be1ski.vibits.shared.app.domain.model.AppDetails
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.core.logging.LogLevel
-import space.be1ski.vibits.shared.core.platform.export.FileExporter
+import space.be1ski.vibits.shared.core.platform.export.createFileExporter
 import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.SegmentedSelector
 import space.be1ski.vibits.shared.feature.memos.data.platform.createOfflineMemoStorage
@@ -506,7 +506,7 @@ private fun ActionsRow(
   var exportStatus by remember { mutableStateOf<String?>(null) }
   val exportFailedMsg = stringResource(Res.string.msg_export_failed)
   val exportSuccessTemplate = stringResource(Res.string.msg_export_success, "%s")
-  val exporter = remember { Exporter(FileExporter(), createOfflineMemoStorage()) }
+  val exporter = remember { Exporter(createFileExporter(), createOfflineMemoStorage()) }
 
   val onExport: (ExportResult) -> Unit = { result ->
     exportExpanded = false

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/data/ExporterTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/data/ExporterTest.kt
@@ -1,0 +1,109 @@
+package space.be1ski.vibits.shared.app.data
+
+import space.be1ski.vibits.shared.core.platform.export.FileExporter
+import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemosFileDto
+import space.be1ski.vibits.shared.feature.memos.data.platform.OfflineMemoStorage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import kotlin.time.Clock
+import kotlin.time.Instant
+
+class ExporterTest {
+  @Test
+  fun `when exportLogs succeeds then returns Success with file path`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = "/path/to/logs.txt")
+    val fakeStorage = FakeOfflineMemoStorage()
+    val exporter = Exporter(fakeFileExporter, fakeStorage)
+
+    val result = exporter.exportLogs()
+
+    assertTrue(result is ExportResult.Success)
+    assertEquals("/path/to/logs.txt", result.filePath)
+  }
+
+  @Test
+  fun `when exportLogs fails then returns Failure`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = null)
+    val fakeStorage = FakeOfflineMemoStorage()
+    val exporter = Exporter(fakeFileExporter, fakeStorage)
+
+    val result = exporter.exportLogs()
+
+    assertTrue(result is ExportResult.Failure)
+  }
+
+  @Test
+  fun `when exportMemos succeeds then returns Success with file path`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = "/path/to/memos.json")
+    val fakeStorage = FakeOfflineMemoStorage()
+    val exporter = Exporter(fakeFileExporter, fakeStorage)
+
+    val result = exporter.exportMemos()
+
+    assertTrue(result is ExportResult.Success)
+    assertEquals("/path/to/memos.json", result.filePath)
+  }
+
+  @Test
+  fun `when exportMemos fails then returns Failure`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = null)
+    val fakeStorage = FakeOfflineMemoStorage()
+    val exporter = Exporter(fakeFileExporter, fakeStorage)
+
+    val result = exporter.exportMemos()
+
+    assertTrue(result is ExportResult.Failure)
+  }
+
+  @Test
+  fun `when exportLogs then generates file name with logs prefix and txt extension`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = "/path/to/file")
+    val fakeStorage = FakeOfflineMemoStorage()
+    val fakeClock = FakeClock(Instant.parse("2024-01-15T10:30:45.123Z"))
+    val exporter = Exporter(fakeFileExporter, fakeStorage, fakeClock)
+
+    exporter.exportLogs()
+
+    assertEquals("logs_2024-01-15T10-30-45.txt", fakeFileExporter.lastFileName)
+  }
+
+  @Test
+  fun `when exportMemos then generates file name with memos prefix and json extension`() {
+    val fakeFileExporter = FakeFileExporter(exportResult = "/path/to/file")
+    val fakeStorage = FakeOfflineMemoStorage()
+    val fakeClock = FakeClock(Instant.parse("2024-01-15T10:30:45.123Z"))
+    val exporter = Exporter(fakeFileExporter, fakeStorage, fakeClock)
+
+    exporter.exportMemos()
+
+    assertEquals("memos_2024-01-15T10-30-45.json", fakeFileExporter.lastFileName)
+  }
+}
+
+private class FakeFileExporter(
+  private val exportResult: String?,
+) : FileExporter {
+  var lastFileName: String? = null
+    private set
+
+  override fun export(
+    fileName: String,
+    content: String,
+  ): String? {
+    lastFileName = fileName
+    return exportResult
+  }
+}
+
+private class FakeOfflineMemoStorage : OfflineMemoStorage {
+  override fun load(): OfflineMemosFileDto = OfflineMemosFileDto()
+
+  override fun save(data: OfflineMemosFileDto) = Unit
+}
+
+private class FakeClock(
+  private val fixedInstant: Instant,
+) : Clock {
+  override fun now(): Instant = fixedInstant
+}

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -3,11 +3,13 @@ package space.be1ski.vibits.shared.core.platform.export
 import java.io.File
 import java.nio.file.Paths
 
+actual fun createFileExporter(): FileExporter = DesktopFileExporter()
+
 /**
  * Desktop implementation that saves files to ~/Documents/Vibits folder.
  */
-actual class FileExporter {
-  actual fun export(
+private class DesktopFileExporter : FileExporter {
+  override fun export(
     fileName: String,
     content: String,
   ): String? =

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -11,12 +11,14 @@ import platform.Foundation.NSSearchPathForDirectoriesInDomains
 import platform.Foundation.NSUserDomainMask
 import platform.Foundation.create
 
+actual fun createFileExporter(): FileExporter = IosFileExporter()
+
 /**
  * iOS implementation that saves files to Documents directory.
  */
-actual class FileExporter {
+private class IosFileExporter : FileExporter {
   @OptIn(ExperimentalForeignApi::class, BetaInteropApi::class)
-  actual fun export(
+  override fun export(
     fileName: String,
     content: String,
   ): String? =

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -11,11 +11,13 @@ import org.w3c.files.BlobPropertyBag
 @Suppress("UNUSED_PARAMETER")
 private fun createBlobParts(content: String): JsArray<JsAny?> = js("([content])")
 
+actual fun createFileExporter(): FileExporter = WasmFileExporter()
+
 /**
  * Web implementation that triggers a browser download.
  */
-actual class FileExporter {
-  actual fun export(
+private class WasmFileExporter : FileExporter {
+  override fun export(
     fileName: String,
     content: String,
   ): String? =


### PR DESCRIPTION
## Summary

Refactors `FileExporter` from an `expect class` to an `interface` with platform-specific factory function `createFileExporter()`. This enables dependency injection and testability without mocking frameworks.

Adds `Clock` constructor parameter to `Exporter` class (defaulting to `Clock.System`) to allow deterministic testing of timestamp-based file name generation.

### Changes
- `FileExporter.kt` (commonMain): Convert from `expect class` to `interface`, add `expect fun createFileExporter()`
- Platform implementations (android/desktop/ios/wasmJs): Implement `actual fun createFileExporter()` returning private platform-specific class
- `Exporter.kt`: Add `Clock` parameter with default value, use injected clock in `generateFileName()`
- `AppGraph.kt`: Update DI to use `createFileExporter()`
- `SettingsDialogContent.kt`: Update to use `createFileExporter()`

### Tests
6 tests covering `Exporter` behavior:
- `exportLogs`/`exportMemos` success returns `ExportResult.Success` with file path
- `exportLogs`/`exportMemos` failure returns `ExportResult.Failure`
- File name format: `{prefix}_{timestamp}.{extension}` where timestamp is ISO-8601 with colons/dots replaced by hyphens, truncated to 19 chars