### PR TITLE
Remove fun interface pattern from use cases

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
@@ -19,10 +19,6 @@ import space.be1ski.vibits.shared.feature.mode.data.platform.AppModeStore
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStore
 import space.be1ski.vibits.shared.feature.settings.data.createPreferencesStore
 
-/**
- * Metro dependency graph for the application.
- * Only expect/actual classes need @Provides here - all other bindings use @ContributesBinding.
- */
 @SingleIn(AppScope::class)
 @DependencyGraph(AppScope::class)
 abstract class AppGraph {
@@ -37,7 +33,6 @@ abstract class AppGraph {
     }
   }
 
-  // Infrastructure - expect/actual classes need @Provides
   @Provides
   @SingleIn(AppScope::class)
   fun httpClient(): HttpClient = createHttpClient()

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCase.kt
@@ -4,15 +4,11 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 
-fun interface SaveCredentials {
-  operator fun invoke(credentials: Credentials)
-}
-
 @Inject
 class SaveCredentialsUseCase(
   private val credentialsRepository: CredentialsRepository,
-) : SaveCredentials {
-  override operator fun invoke(credentials: Credentials) {
+) {
+  operator fun invoke(credentials: Credentials) {
     credentialsRepository.save(credentials)
   }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/ValidateCredentialsUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/ValidateCredentialsUseCase.kt
@@ -2,26 +2,15 @@ package space.be1ski.vibits.shared.feature.auth.domain.usecase
 
 import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.core.logging.Log
-import space.be1ski.vibits.shared.feature.memos.data.remote.MemosApi
+import space.be1ski.vibits.shared.feature.memos.data.remote.MemosApiClient
 
 private const val TAG = "ValidateCreds"
 
-fun interface ValidateCredentials {
-  suspend operator fun invoke(
-    baseUrl: String,
-    token: String,
-  ): Result<Unit>
-}
-
-/**
- * Use case that validates credentials by making a test API request.
- * Returns true if credentials are valid, false otherwise.
- */
 @Inject
 class ValidateCredentialsUseCase(
-  private val memosApi: MemosApi,
-) : ValidateCredentials {
-  override suspend operator fun invoke(
+  private val memosApi: MemosApiClient,
+) {
+  suspend operator fun invoke(
     baseUrl: String,
     token: String,
   ): Result<Unit> {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepository.kt
@@ -15,10 +15,6 @@ import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeReposito
 
 private const val TAG = "ModeAwareRepo"
 
-/**
- * Repository that delegates to online, offline, or demo implementation based on current mode.
- * Clears cache when switching modes to ensure data isolation.
- */
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -59,14 +55,6 @@ class ModeAwareMemosRepository(
 
   override suspend fun deleteMemo(name: String) {
     currentRepository().deleteMemo(name)
-  }
-
-  /**
-   * Clears Room cache when mode changes to ensure data isolation between modes.
-   */
-  suspend fun clearCacheOnModeChange() {
-    Log.i(TAG, "Clearing cache on mode change")
-    memoCache.clear()
   }
 
   private suspend fun checkModeChange() {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoMemosRepository.kt
@@ -9,20 +9,12 @@ import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-/**
- * In-memory repository for demo mode.
- * All changes are stored in memory and reset when demo mode is toggled.
- */
 @Inject
 @SingleIn(AppScope::class)
 class DemoMemosRepository : MemosRepository {
   private val memos = mutableListOf<Memo>()
   private var initialized = false
 
-  /**
-   * Resets the repository to initial demo data.
-   * Called when entering demo mode to ensure fresh data.
-   */
   fun reset() {
     memos.clear()
     memos.addAll(DemoDataGenerator.generateDemoMemos())

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.shared.feature.memos.data.remote
 
+import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import io.ktor.client.HttpClient
@@ -23,13 +24,23 @@ import space.be1ski.vibits.shared.feature.memos.data.remote.dto.UpdateMemoReques
 
 private const val TAG = "MemosApi"
 
+interface MemosApiClient {
+  suspend fun listMemos(
+    baseUrl: String,
+    token: String,
+    pageSize: Int,
+    pageToken: String?,
+  ): ListMemosResponseDto
+}
+
 @Inject
 @SingleIn(AppScope::class)
+@ContributesBinding(AppScope::class)
 @Suppress("TooGenericExceptionCaught")
 class MemosApi(
   private val httpClient: HttpClient,
-) {
-  suspend fun listMemos(
+) : MemosApiClient {
+  override suspend fun listMemos(
     baseUrl: String,
     token: String,
     pageSize: Int,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionDependencies.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionDependencies.kt
@@ -5,9 +5,6 @@ import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUse
 import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
 
-/**
- * Dependencies for ModeSelectionFeature.
- */
 @Inject
 class ModeSelectionDependencies(
   val validateCredentials: ValidateCredentialsUseCase,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppUseCase.kt
@@ -1,43 +1,23 @@
 package space.be1ski.vibits.shared.feature.mode.domain.usecase
 
 import dev.zacsweers.metro.Inject
-import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
-import space.be1ski.vibits.shared.feature.memos.data.demo.DemoMemosRepository
-import space.be1ski.vibits.shared.feature.memos.data.platform.MemoCache
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
 import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.shared.feature.settings.domain.model.UserPreferences
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
-private const val TAG = "ResetApp"
-
-fun interface ResetApp {
-  suspend operator fun invoke()
-}
-
-/**
- * Use case for resetting app to initial state.
- * Clears mode selection, cache, credentials, preferences, and demo data,
- * showing mode selection screen on next launch.
- */
 @Inject
 class ResetAppUseCase(
   private val appModeRepository: AppModeRepository,
-  private val memoCache: MemoCache,
   private val credentialsRepository: CredentialsRepository,
   private val preferencesRepository: PreferencesRepository,
-  private val demoMemosRepository: DemoMemosRepository,
-) : ResetApp {
-  override suspend operator fun invoke() {
-    Log.i(TAG, "Resetting app to initial state...")
-    memoCache.clear()
+) {
+  operator fun invoke() {
     credentialsRepository.save(Credentials(baseUrl = "", token = ""))
     preferencesRepository.save(UserPreferences(TimeRangeTab.WEEKS, TimeRangeTab.WEEKS))
-    demoMemosRepository.reset()
     appModeRepository.saveMode(AppMode.NOT_SELECTED)
-    Log.i(TAG, "App reset completed")
   }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SaveAppModeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SaveAppModeUseCase.kt
@@ -4,13 +4,9 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
 
-fun interface SaveAppMode {
-  operator fun invoke(mode: AppMode)
-}
-
 @Inject
 class SaveAppModeUseCase(
   private val appModeRepository: AppModeRepository,
-) : SaveAppMode {
-  override operator fun invoke(mode: AppMode) = appModeRepository.saveMode(mode)
+) {
+  operator fun invoke(mode: AppMode) = appModeRepository.saveMode(mode)
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
@@ -1,30 +1,16 @@
 package space.be1ski.vibits.shared.feature.mode.domain.usecase
 
 import dev.zacsweers.metro.Inject
-import space.be1ski.vibits.shared.core.logging.Log
-import space.be1ski.vibits.shared.feature.memos.data.ModeAwareMemosRepository
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.repository.AppModeRepository
 
-private const val TAG = "SwitchMode"
-
-fun interface SwitchAppMode {
-  suspend operator fun invoke(mode: AppMode)
-}
-
-/**
- * Use case for switching app mode with cache invalidation.
- */
 @Inject
 class SwitchAppModeUseCase(
   private val appModeRepository: AppModeRepository,
-  private val modeAwareMemosRepository: ModeAwareMemosRepository,
-) : SwitchAppMode {
-  override suspend operator fun invoke(mode: AppMode) {
+) {
+  operator fun invoke(mode: AppMode) {
     val currentMode = appModeRepository.loadMode()
     if (currentMode != mode) {
-      Log.i(TAG, "Switching mode: $currentMode -> $mode")
-      modeAwareMemosRepository.clearCacheOnModeChange()
       appModeRepository.saveMode(mode)
     }
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -6,16 +6,16 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentials
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppMode
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
 
 private const val TAG = "ModeEffect"
 
 class ModeSelectionEffectHandler(
-  private val validateCredentials: ValidateCredentials,
-  private val saveCredentials: SaveCredentials,
-  private val saveAppMode: SaveAppMode,
+  private val validateCredentials: ValidateCredentialsUseCase,
+  private val saveCredentials: SaveCredentialsUseCase,
+  private val saveAppMode: SaveAppModeUseCase,
 ) : EffectHandler<ModeSelectionEffect, ModeSelectionAction> {
   override fun invoke(effect: ModeSelectionEffect): Flow<ModeSelectionAction> =
     when (effect) {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveLanguageUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveLanguageUseCase.kt
@@ -5,20 +5,12 @@ import space.be1ski.vibits.shared.core.platform.locale.LocaleProvider
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
-fun interface SaveLanguage {
-  operator fun invoke(language: AppLanguage): Boolean
-}
-
-/**
- * Saves the selected language preference and configures the locale.
- * @return true if a restart is required for the change to take effect
- */
 @Inject
 class SaveLanguageUseCase(
   private val preferencesRepository: PreferencesRepository,
   private val localeProvider: LocaleProvider,
-) : SaveLanguage {
-  override operator fun invoke(language: AppLanguage): Boolean {
+) {
+  operator fun invoke(language: AppLanguage): Boolean {
     val currentPrefs = preferencesRepository.load()
     val updatedPrefs = currentPrefs.copy(language = language)
     preferencesRepository.save(updatedPrefs)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveThemeUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/domain/usecase/SaveThemeUseCase.kt
@@ -4,15 +4,11 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.shared.feature.settings.domain.repository.PreferencesRepository
 
-fun interface SaveTheme {
-  operator fun invoke(theme: AppTheme)
-}
-
 @Inject
 class SaveThemeUseCase(
   private val preferencesRepository: PreferencesRepository,
-) : SaveTheme {
-  override operator fun invoke(theme: AppTheme) {
+) {
+  operator fun invoke(theme: AppTheme) {
     val currentPrefs = preferencesRepository.load()
     val updatedPrefs = currentPrefs.copy(theme = theme)
     preferencesRepository.save(updatedPrefs)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
@@ -6,22 +6,22 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentials
-import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentials
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetApp
-import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppMode
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguage
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveTheme
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUseCase
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
 
 private const val TAG = "SettingsEffect"
 
 class SettingsEffectHandler(
-  private val validateCredentials: ValidateCredentials,
-  private val switchAppMode: SwitchAppMode,
-  private val saveCredentials: SaveCredentials,
-  private val resetApp: ResetApp,
-  private val saveLanguage: SaveLanguage,
-  private val saveTheme: SaveTheme,
+  private val validateCredentials: ValidateCredentialsUseCase,
+  private val switchAppMode: SwitchAppModeUseCase,
+  private val saveCredentials: SaveCredentialsUseCase,
+  private val resetApp: ResetAppUseCase,
+  private val saveLanguage: SaveLanguageUseCase,
+  private val saveTheme: SaveThemeUseCase,
 ) : EffectHandler<SettingsEffect, SettingsAction> {
   override fun invoke(effect: SettingsEffect): Flow<SettingsAction> =
     when (effect) {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ModeUseCasesTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ModeUseCasesTest.kt
@@ -1,12 +1,9 @@
 package space.be1ski.vibits.shared.feature.mode.domain.usecase
 
-import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
-import space.be1ski.vibits.shared.feature.memos.data.demo.DemoMemosRepository
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.test.FakeAppModeRepository
 import space.be1ski.vibits.shared.test.FakeCredentialsRepository
-import space.be1ski.vibits.shared.test.FakeMemoCache
 import space.be1ski.vibits.shared.test.FakePreferencesRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -48,57 +45,41 @@ class SaveAppModeUseCaseTest {
 
 class ResetAppUseCaseTest {
   private fun createUseCase(
-    memoCache: FakeMemoCache = FakeMemoCache(),
     appModeRepository: FakeAppModeRepository = FakeAppModeRepository(initial = AppMode.ONLINE),
     credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
     preferencesRepository: FakePreferencesRepository = FakePreferencesRepository(),
-    demoMemosRepository: DemoMemosRepository = DemoMemosRepository(),
-  ) = ResetAppUseCase(appModeRepository, memoCache, credentialsRepository, preferencesRepository, demoMemosRepository)
+  ) = ResetAppUseCase(appModeRepository, credentialsRepository, preferencesRepository)
 
   @Test
-  fun `when invoke then clears memo cache`() =
-    runTest {
-      val memoCache = FakeMemoCache()
-      val useCase = createUseCase(memoCache = memoCache)
+  fun `when invoke then clears credentials`() {
+    val credentialsRepository =
+      FakeCredentialsRepository(
+        initial = Credentials(baseUrl = "https://example.com", token = "token"),
+      )
+    val useCase = createUseCase(credentialsRepository = credentialsRepository)
 
-      useCase()
+    useCase()
 
-      assertEquals(1, memoCache.clearCalls)
-    }
-
-  @Test
-  fun `when invoke then clears credentials`() =
-    runTest {
-      val credentialsRepository =
-        FakeCredentialsRepository(
-          initial = Credentials(baseUrl = "https://example.com", token = "token"),
-        )
-      val useCase = createUseCase(credentialsRepository = credentialsRepository)
-
-      useCase()
-
-      assertEquals(Credentials(baseUrl = "", token = ""), credentialsRepository.stored)
-    }
+    assertEquals(Credentials(baseUrl = "", token = ""), credentialsRepository.stored)
+  }
 
   @Test
-  fun `when invoke then sets mode to NotSelected`() =
-    runTest {
-      val appModeRepository = FakeAppModeRepository(initial = AppMode.ONLINE)
-      val useCase = createUseCase(appModeRepository = appModeRepository)
+  fun `when invoke then sets mode to NotSelected`() {
+    val appModeRepository = FakeAppModeRepository(initial = AppMode.ONLINE)
+    val useCase = createUseCase(appModeRepository = appModeRepository)
 
-      useCase()
+    useCase()
 
-      assertEquals(AppMode.NOT_SELECTED, appModeRepository.storedMode)
-    }
+    assertEquals(AppMode.NOT_SELECTED, appModeRepository.storedMode)
+  }
 
   @Test
-  fun `when invoke then resets preferences`() =
-    runTest {
-      val preferencesRepository = FakePreferencesRepository()
-      val useCase = createUseCase(preferencesRepository = preferencesRepository)
+  fun `when invoke then resets preferences`() {
+    val preferencesRepository = FakePreferencesRepository()
+    val useCase = createUseCase(preferencesRepository = preferencesRepository)
 
-      useCase()
+    useCase()
 
-      assertEquals(1, preferencesRepository.saveCalls)
-    }
+    assertEquals(1, preferencesRepository.saveCalls)
+  }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -2,8 +2,13 @@ package space.be1ski.vibits.shared.feature.mode.presentation
 
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
+import space.be1ski.vibits.shared.test.FakeAppModeRepository
+import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import space.be1ski.vibits.shared.test.FakeMemosApiClient
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -12,7 +17,7 @@ class ModeSelectionEffectHandlerTest {
   @Test
   fun `ValidateCredentials emits ValidationSucceeded on success`() =
     runTest {
-      val handler = createHandler(validateResult = Result.success(Unit))
+      val handler = createHandler()
 
       val actions =
         handler(
@@ -25,7 +30,8 @@ class ModeSelectionEffectHandlerTest {
   @Test
   fun `ValidateCredentials emits ValidationFailed on failure`() =
     runTest {
-      val handler = createHandler(validateResult = Result.failure(Exception("Connection failed")))
+      val api = FakeMemosApiClient(listMemosResult = Result.failure(Exception("Connection failed")))
+      val handler = createHandler(memosApi = api)
 
       val actions =
         handler(
@@ -38,32 +44,26 @@ class ModeSelectionEffectHandlerTest {
   @Test
   fun `SaveCredentials calls saveCredentials function`() =
     runTest {
-      var savedCredentials: Credentials? = null
-      val handler =
-        createHandler(
-          saveCredentials = { savedCredentials = it },
-        )
+      val credentialsRepo = FakeCredentialsRepository()
+      val handler = createHandler(credentialsRepository = credentialsRepo)
 
       handler(
         ModeSelectionEffect.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
       ).toList()
 
-      assertEquals("https://saved.com", savedCredentials?.baseUrl)
-      assertEquals("saved-token", savedCredentials?.token)
+      assertEquals("https://saved.com", credentialsRepo.stored.baseUrl)
+      assertEquals("saved-token", credentialsRepo.stored.token)
     }
 
   @Test
   fun `SaveMode calls saveAppMode function`() =
     runTest {
-      var savedMode: AppMode? = null
-      val handler =
-        createHandler(
-          saveAppMode = { savedMode = it },
-        )
+      val appModeRepo = FakeAppModeRepository()
+      val handler = createHandler(appModeRepository = appModeRepo)
 
       handler(ModeSelectionEffect.SaveMode(mode = AppMode.OFFLINE)).toList()
 
-      assertEquals(AppMode.OFFLINE, savedMode)
+      assertEquals(AppMode.OFFLINE, appModeRepo.storedMode)
     }
 
   @Test
@@ -80,14 +80,14 @@ class ModeSelectionEffectHandlerTest {
     }
 
   private fun createHandler(
-    validateResult: Result<Unit> = Result.success(Unit),
-    saveCredentials: (Credentials) -> Unit = {},
-    saveAppMode: (AppMode) -> Unit = {},
+    memosApi: FakeMemosApiClient = FakeMemosApiClient(),
+    credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
+    appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),
   ): ModeSelectionEffectHandler {
     return ModeSelectionEffectHandler(
-      validateCredentials = { _, _ -> validateResult },
-      saveCredentials = saveCredentials,
-      saveAppMode = saveAppMode,
+      validateCredentials = ValidateCredentialsUseCase(memosApi),
+      saveCredentials = SaveCredentialsUseCase(credentialsRepository),
+      saveAppMode = SaveAppModeUseCase(appModeRepository),
     )
   }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -2,10 +2,20 @@ package space.be1ski.vibits.shared.feature.settings.presentation
 
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
-import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.core.platform.locale.LocaleProvider
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.ValidateCredentialsUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUseCase
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
+import space.be1ski.vibits.shared.test.FakeAppModeRepository
+import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import space.be1ski.vibits.shared.test.FakeMemosApiClient
+import space.be1ski.vibits.shared.test.FakePreferencesRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -14,7 +24,7 @@ class SettingsEffectHandlerTest {
   @Test
   fun `ValidateCredentials emits ValidationSucceeded on success`() =
     runTest {
-      val handler = createHandler(validateResult = Result.success(Unit))
+      val handler = createHandler()
 
       val actions =
         handler(
@@ -31,7 +41,8 @@ class SettingsEffectHandlerTest {
   @Test
   fun `ValidateCredentials emits ValidationFailed on failure`() =
     runTest {
-      val handler = createHandler(validateResult = Result.failure(Exception("Connection failed")))
+      val api = FakeMemosApiClient(listMemosResult = Result.failure(Exception("Connection failed")))
+      val handler = createHandler(memosApi = api)
 
       val actions =
         handler(
@@ -49,79 +60,61 @@ class SettingsEffectHandlerTest {
   @Test
   fun `SwitchMode saves mode and emits ModeSwitched`() =
     runTest {
-      var switchedMode: AppMode? = null
-      val handler =
-        createHandler(
-          switchAppMode = { switchedMode = it },
-        )
+      val appModeRepo = FakeAppModeRepository(initial = AppMode.ONLINE)
+      val handler = createHandler(appModeRepository = appModeRepo)
 
       val actions = handler(SettingsEffect.SwitchMode(mode = AppMode.OFFLINE)).toList()
 
       assertEquals(listOf(SettingsAction.ModeSwitched), actions)
-      assertEquals(AppMode.OFFLINE, switchedMode)
+      assertEquals(AppMode.OFFLINE, appModeRepo.storedMode)
     }
 
   @Test
   fun `SaveCredentials saves to repository`() =
     runTest {
-      var savedCredentials: Credentials? = null
-      val handler =
-        createHandler(
-          saveCredentials = { savedCredentials = it },
-        )
+      val credentialsRepo = FakeCredentialsRepository()
+      val handler = createHandler(credentialsRepository = credentialsRepo)
 
       handler(
         SettingsEffect.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
       ).toList()
 
-      assertEquals("https://saved.com", savedCredentials?.baseUrl)
-      assertEquals("saved-token", savedCredentials?.token)
+      assertEquals("https://saved.com", credentialsRepo.stored.baseUrl)
+      assertEquals("saved-token", credentialsRepo.stored.token)
     }
 
   @Test
   fun `ResetApp resets and emits ResetCompleted`() =
     runTest {
-      var resetCalled = false
-      val handler =
-        createHandler(
-          resetApp = { resetCalled = true },
-        )
+      val appModeRepo = FakeAppModeRepository(initial = AppMode.ONLINE)
+      val handler = createHandler(appModeRepository = appModeRepo)
 
       val actions = handler(SettingsEffect.ResetApp).toList()
 
       assertEquals(listOf(SettingsAction.ResetCompleted), actions)
-      assertTrue(resetCalled)
+      assertEquals(AppMode.NOT_SELECTED, appModeRepo.storedMode)
     }
 
   @Test
   fun `SaveLanguage calls saveLanguage function`() =
     runTest {
-      var savedLanguage: AppLanguage? = null
-      val handler =
-        createHandler(
-          saveLanguage = {
-            savedLanguage = it
-            false
-          },
-        )
+      val prefsRepo = FakePreferencesRepository()
+      val handler = createHandler(preferencesRepository = prefsRepo)
 
       handler(SettingsEffect.SaveLanguage(language = AppLanguage.ENGLISH)).toList()
 
-      assertEquals(AppLanguage.ENGLISH, savedLanguage)
+      assertEquals(AppLanguage.ENGLISH, prefsRepo.stored.language)
     }
 
   @Test
   fun `SaveTheme calls saveTheme function`() =
     runTest {
-      var savedTheme: AppTheme? = null
-      val handler =
-        createHandler(
-          saveTheme = { savedTheme = it },
-        )
+      val prefsRepo = FakePreferencesRepository()
+      val handler = createHandler(preferencesRepository = prefsRepo)
 
       handler(SettingsEffect.SaveTheme(theme = AppTheme.DARK)).toList()
 
-      assertEquals(AppTheme.DARK, savedTheme)
+      assertEquals(AppTheme.DARK, prefsRepo.stored.theme)
     }
 
   @Test
@@ -157,20 +150,18 @@ class SettingsEffectHandlerTest {
     }
 
   private fun createHandler(
-    validateResult: Result<Unit> = Result.success(Unit),
-    switchAppMode: suspend (AppMode) -> Unit = {},
-    saveCredentials: (Credentials) -> Unit = {},
-    resetApp: suspend () -> Unit = {},
-    saveLanguage: (AppLanguage) -> Boolean = { false },
-    saveTheme: (AppTheme) -> Unit = {},
+    memosApi: FakeMemosApiClient = FakeMemosApiClient(),
+    appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),
+    credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
+    preferencesRepository: FakePreferencesRepository = FakePreferencesRepository(),
   ): SettingsEffectHandler {
     return SettingsEffectHandler(
-      validateCredentials = { _, _ -> validateResult },
-      switchAppMode = switchAppMode,
-      saveCredentials = saveCredentials,
-      resetApp = resetApp,
-      saveLanguage = saveLanguage,
-      saveTheme = saveTheme,
+      validateCredentials = ValidateCredentialsUseCase(memosApi),
+      switchAppMode = SwitchAppModeUseCase(appModeRepository),
+      saveCredentials = SaveCredentialsUseCase(credentialsRepository),
+      resetApp = ResetAppUseCase(appModeRepository, credentialsRepository, preferencesRepository),
+      saveLanguage = SaveLanguageUseCase(preferencesRepository, LocaleProvider()),
+      saveTheme = SaveThemeUseCase(preferencesRepository),
     )
   }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.shared.test
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.shared.feature.memos.data.platform.MemoCache
+import space.be1ski.vibits.shared.feature.memos.data.remote.MemosApiClient
 import space.be1ski.vibits.shared.feature.memos.data.remote.dto.ListMemosResponseDto
-import space.be1ski.vibits.shared.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
@@ -143,55 +143,13 @@ class FakePreferencesRepository(
   }
 }
 
-// Fake Use Cases for EffectHandler tests
-
-class FakeValidateCredentialsUseCase(
-  private val result: Result<Unit> = Result.success(Unit),
-) {
-  var invokedWith: Pair<String, String>? = null
-    private set
-
-  suspend operator fun invoke(
-    baseUrl: String,
-    token: String,
-  ): Result<Unit> {
-    invokedWith = baseUrl to token
-    return result
-  }
-}
-
-class FakeModeAwareMemosRepository : MemosRepository {
-  var clearCacheOnModeChangeCalls: Int = 0
-    private set
-
-  override suspend fun listMemos(): List<Memo> = emptyList()
-
-  override suspend fun cachedMemos(): List<Memo> = emptyList()
-
-  override suspend fun updateMemo(
-    name: String,
-    content: String,
-  ): Memo = Memo()
-
-  override suspend fun createMemo(content: String): Memo = Memo()
-
-  override suspend fun deleteMemo(name: String) {}
-
-  suspend fun clearCacheOnModeChange() {
-    clearCacheOnModeChangeCalls++
-  }
-}
-
-/**
- * Fake MemosApi for testing ValidateCredentialsUseCase.
- */
-class FakeMemosApi(
+class FakeMemosApiClient(
   var listMemosResult: Result<ListMemosResponseDto> = Result.success(ListMemosResponseDto()),
-) {
+) : MemosApiClient {
   var listMemosCalls: Int = 0
     private set
 
-  suspend fun listMemos(
+  override suspend fun listMemos(
     baseUrl: String,
     token: String,
     pageSize: Int,
@@ -202,34 +160,6 @@ class FakeMemosApi(
   }
 }
 
-/**
- * Fake DemoMemosRepository for testing ResetAppUseCase.
- */
-class FakeDemoMemosRepository : MemosRepository {
-  var resetCalls: Int = 0
-    private set
-
-  fun reset() {
-    resetCalls++
-  }
-
-  override suspend fun listMemos(): List<Memo> = emptyList()
-
-  override suspend fun cachedMemos(): List<Memo> = emptyList()
-
-  override suspend fun updateMemo(
-    name: String,
-    content: String,
-  ): Memo = Memo()
-
-  override suspend fun createMemo(content: String): Memo = Memo()
-
-  override suspend fun deleteMemo(name: String) {}
-}
-
-/**
- * Fake LocaleProvider for testing SaveLanguageUseCase.
- */
 class FakeLocaleProvider(
   private val systemLocale: String = "en",
   private val requiresRestart: Boolean = false,


### PR DESCRIPTION
## Summary

- Remove `fun interface` pattern from all use cases, replacing with plain `@Inject class` per AGENTS.md guidelines
- Remove `CacheInvalidator` and `DemoDataResettable` interfaces (cache clearing now automatic via `ModeAwareMemosRepository.checkModeChange()`)
- Add `MemosApiClient` interface for `ValidateCredentialsUseCase` testability
- Simplify `ResetAppUseCase` and `SwitchAppModeUseCase` to use only domain layer dependencies (clean architecture)
- Update tests to use real UseCases with fake repositories instead of lambdas
- Remove useless KDoc comments that just restate method names

## Why

The `fun interface` + `class` pattern was causing:
1. IDE "Find Usages" not working properly (usages lost through SAM conversion)
2. Inconsistent naming (`SwitchAppMode` interface vs `SwitchAppModeUseCase` class)
3. Domain layer leaking data layer dependencies (`MemoCache`, `DemoMemosRepository`)

## Test plan

- [x] `./gradlew checkAll` passes
- [x] All existing tests updated and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)