### PR TITLE
Remove unused Koin proguard rules

### DIFF
--- a/androidApp/proguard-rules.pro
+++ b/androidApp/proguard-rules.pro
@@ -1,11 +1,2 @@
 # Keep Kotlin metadata for reflection
 -keep class kotlin.Metadata { *; }
-
-# Koin
--keep class org.koin.** { *; }
--keepclassmembers class * {
-    @org.koin.core.annotation.* <methods>;
-}
-
-# Keep classes used by Koin for dependency injection
--keepnames class * extends androidx.lifecycle.ViewModel


### PR DESCRIPTION
## Summary

Remove unused Koin proguard rules. Koin was replaced with Metro for compile-time DI, making these rules obsolete.

### Files Modified
- `androidApp/proguard-rules.pro` — removed Koin-specific keep rules

### Before
```pro
# Keep Kotlin metadata for reflection
-keep class kotlin.Metadata { *; }

# Koin
-keep class org.koin.** { *; }
-keepclassmembers class * {
    @org.koin.core.annotation.* <methods>;
}

# Keep classes used by Koin for dependency injection
-keepnames class * extends androidx.lifecycle.ViewModel
```

### After
```pro
# Keep Kotlin metadata for reflection
-keep class kotlin.Metadata { *; }
```

## Test plan
- [ ] Verify release build still works (`./gradlew :androidApp:assembleRelease`)
- [ ] Confirm no runtime crashes related to proguard

🤖 Generated with [Claude Code](https://claude.com/claude-code)