### PR TITLE
Remove codecov token from badge URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Vibits
 
 [![CI](https://github.com/be1ski/vibits/actions/workflows/ci.yml/badge.svg)](https://github.com/be1ski/vibits/actions/workflows/ci.yml)
-[![codecov](https://codecov.io/gh/be1ski/vibits/graph/badge.svg?token=63WZCYQE5I)](https://codecov.io/gh/be1ski/vibits)
+[![codecov](https://codecov.io/gh/be1ski/vibits/graph/badge.svg)](https://codecov.io/gh/be1ski/vibits)
 [![Release](https://img.shields.io/github/v/release/be1ski/vibits)](https://github.com/be1ski/vibits/releases/latest)
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://be1ski.github.io/vibits/)
 


### PR DESCRIPTION
## Summary

Remove codecov token from the badge URL. Since the repository is now public, the token is no longer required for the badge to display correctly.

### Files Modified
- `README.md` — removed `?token=...` parameter from codecov badge URL

### Before
```markdown
[![codecov](https://codecov.io/gh/be1ski/vibits/graph/badge.svg?token=63WZCYQE5I)](https://codecov.io/gh/be1ski/vibits)
```

### After
```markdown
[![codecov](https://codecov.io/gh/be1ski/vibits/graph/badge.svg)](https://codecov.io/gh/be1ski/vibits)
```

## Test plan
- [ ] Verify codecov badge still displays correctly in README after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)