### PR TITLE
Extract app view models into dedicated package

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/MemoDialogs.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/MemoDialogs.kt
@@ -13,6 +13,7 @@ import space.be1ski.vibits.shared.Res
 import space.be1ski.vibits.shared.action_cancel
 import space.be1ski.vibits.shared.action_create
 import space.be1ski.vibits.shared.action_save
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
 import space.be1ski.vibits.shared.hint_write_memo

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SyncEffects.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SyncEffects.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.shared.app.view
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/TimeRangeNavigation.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/TimeRangeNavigation.kt
@@ -16,6 +16,8 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import space.be1ski.vibits.shared.app.view.model.MemosScreen
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
 import space.be1ski.vibits.shared.core.platform.isDesktop
 import space.be1ski.vibits.shared.core.ui.ActivityMode
 import space.be1ski.vibits.shared.core.ui.ActivityRange

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsApp.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsApp.kt
@@ -14,7 +14,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -28,6 +27,10 @@ import space.be1ski.vibits.shared.Res
 import space.be1ski.vibits.shared.action_create_memo
 import space.be1ski.vibits.shared.action_track_today
 import space.be1ski.vibits.shared.app.di.AppDependencies
+import space.be1ski.vibits.shared.app.view.model.MemosFabMode
+import space.be1ski.vibits.shared.app.view.model.MemosScreen
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
+import space.be1ski.vibits.shared.app.view.model.memosFabModeForScreen
 import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
 import space.be1ski.vibits.shared.core.ui.ActivityRange
 import space.be1ski.vibits.shared.core.ui.Indent

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppComponents.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppComponents.kt
@@ -22,6 +22,8 @@ import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.shared.Res
 import space.be1ski.vibits.shared.action_refresh
+import space.be1ski.vibits.shared.app.view.model.MemosScreen
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
 import space.be1ski.vibits.shared.app_name
 import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
 import space.be1ski.vibits.shared.core.platform.isDesktop

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/MemosFabMode.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/MemosFabMode.kt
@@ -1,6 +1,4 @@
-@file:Suppress("MatchingDeclarationName", "ktlint:standard:filename")
-
-package space.be1ski.vibits.shared.app.view
+package space.be1ski.vibits.shared.app.view.model
 
 internal enum class MemosFabMode {
   HABITS,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/MemosScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/MemosScreen.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.shared.app.view.model
+
+internal enum class MemosScreen {
+  HABITS,
+  STATS,
+  FEED,
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/VibitsAppUiState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/model/VibitsAppUiState.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.shared.app.view
+package space.be1ski.vibits.shared.app.view.model
 
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -7,12 +7,6 @@ import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
-
-internal enum class MemosScreen {
-  HABITS,
-  STATS,
-  FEED,
-}
 
 internal class VibitsAppUiState(
   currentDate: LocalDate,


### PR DESCRIPTION
## Summary

Refactor `app.view` package to separate UI state models from composables. This keeps the application layer focused on feature composition while models live in their own subpackage.

### Pattern Change

**Before:** Models mixed with composables
```
app/view/
  ├── VibitsAppUiState.kt  # Contains MemosScreen enum + VibitsAppUiState class
  ├── VibitsAppFab.kt      # Contains MemosFabMode enum + helper function
  ├── VibitsApp.kt
  └── ...other composables
```

**After:** Models in dedicated subpackage
```
app/view/
  ├── model/
  │   ├── MemosScreen.kt      # Screen navigation enum
  │   ├── MemosFabMode.kt     # FAB mode enum + helper
  │   └── VibitsAppUiState.kt # App-level UI state
  ├── VibitsApp.kt
  └── ...other composables
```

### Files Modified
- `VibitsAppUiState.kt` → `model/VibitsAppUiState.kt` (moved)
- `VibitsAppFab.kt` → `model/MemosFabMode.kt` (moved + renamed)
- New `model/MemosScreen.kt` (extracted from VibitsAppUiState)
- Updated imports in: `VibitsApp.kt`, `VibitsAppComponents.kt`, `TimeRangeNavigation.kt`, `MemoDialogs.kt`, `SyncEffects.kt`

## Test plan
- [x] Verify compilation passes (`./gradlew :shared:compileKotlinDesktop`)
- [ ] Run full check suite (`./gradlew checkAll`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)