### PR TITLE
Decompose VibitsApp into feature-based architecture

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppFeatures.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppFeatures.kt
@@ -1,0 +1,94 @@
+package space.be1ski.vibits.shared.app.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import space.be1ski.vibits.shared.app.di.AppDependencies
+import space.be1ski.vibits.shared.app.domain.model.AppDetails
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
+import space.be1ski.vibits.shared.core.elm.Feature
+import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
+import space.be1ski.vibits.shared.feature.habits.di.createHabitsFeature
+import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
+import space.be1ski.vibits.shared.feature.habits.presentation.HabitsEffect
+import space.be1ski.vibits.shared.feature.habits.presentation.HabitsState
+import space.be1ski.vibits.shared.feature.habits.view.components.ActivityWeekDataCache
+import space.be1ski.vibits.shared.feature.memos.di.createMemosFeature
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosEffect
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.settings.di.createSettingsFeature
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsAction
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsEffect
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsState
+
+internal class AppFeatures(
+  val memos: Feature<MemosAction, MemosState, MemosEffect>,
+  val habits: Feature<HabitsAction, HabitsState, HabitsEffect>,
+  val settings: Feature<SettingsAction, SettingsState, SettingsEffect>,
+  val appState: VibitsAppUiState,
+  val appDetails: AppDetails,
+  val cache: ActivityWeekDataCache,
+)
+
+@Composable
+internal fun rememberAppFeatures(dependencies: AppDependencies): AppFeatures {
+  val initialPrefs = remember { dependencies.loadPreferences() }
+  val initialMode = remember { dependencies.loadAppMode() }
+  val appDetails = remember { dependencies.loadAppDetails() }
+  val cache = remember { ActivityWeekDataCache() }
+
+  val appState =
+    remember {
+      VibitsAppUiState(
+        currentDate = currentLocalDate(),
+        initialHabitsTimeRangeTab = initialPrefs.habitsTimeRangeTab,
+        initialPostsTimeRangeTab = initialPrefs.postsTimeRangeTab,
+      ).also { it.appMode = initialMode }
+    }
+
+  val memosFeature =
+    remember {
+      val skipCredentials = initialMode == AppMode.OFFLINE || initialMode == AppMode.DEMO
+      createMemosFeature(dependencies.memosDependencies, isOfflineMode = skipCredentials)
+    }
+
+  val dispatchMemos: (MemosAction) -> Unit = memosFeature::send
+
+  val habitsFeature =
+    remember {
+      createHabitsFeature(
+        dependencies = dependencies.habitsDependencies,
+        onRefresh = { dispatchMemos(MemosAction.LoadMemos) },
+      )
+    }
+
+  val settingsFeature =
+    remember {
+      createSettingsFeature(
+        dependencies = dependencies.settingsDependencies,
+        initialMode = initialMode,
+        appDetails = appDetails,
+      )
+    }
+
+  val scope = rememberCoroutineScope()
+  LaunchedEffect(Unit) {
+    memosFeature.launchIn(scope)
+    habitsFeature.launchIn(scope)
+    settingsFeature.launchIn(scope)
+  }
+
+  return remember(memosFeature, habitsFeature, settingsFeature, appState, appDetails, cache) {
+    AppFeatures(
+      memos = memosFeature,
+      habits = habitsFeature,
+      settings = settingsFeature,
+      appState = appState,
+      appDetails = appDetails,
+      cache = cache,
+    )
+  }
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
@@ -1,0 +1,64 @@
+package space.be1ski.vibits.shared.app.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsAction
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsEffect
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsState
+
+@Composable
+internal fun FeatureCoordinator(
+  features: AppFeatures,
+  memosState: MemosState,
+  settingsState: SettingsState,
+  currentLanguage: AppLanguage,
+  currentTheme: AppTheme,
+  onResetApp: () -> Unit,
+  onThemeChanged: (AppTheme) -> Unit,
+  onLanguageChanged: (AppLanguage) -> Unit,
+) {
+  val dispatchMemos = features.memos::send
+
+  // Handle settings effects
+  LaunchedEffect(features.settings) {
+    features.settings.effects.collect { effect ->
+      when (effect) {
+        is SettingsEffect.NotifyModeChanged -> {
+          features.appState.appMode = effect.newMode
+          dispatchMemos(MemosAction.LoadMemos)
+        }
+        is SettingsEffect.NotifyResetCompleted -> onResetApp()
+        is SettingsEffect.NotifyCredentialsSaved -> {
+          dispatchMemos(MemosAction.UpdateBaseUrl(effect.baseUrl))
+          dispatchMemos(MemosAction.UpdateToken(effect.token))
+          dispatchMemos(MemosAction.LoadMemos)
+        }
+        is SettingsEffect.NotifyThemeChanged -> onThemeChanged(effect.theme)
+        is SettingsEffect.NotifyLanguageChanged -> onLanguageChanged(effect.language)
+        is SettingsEffect.NotifyDialogClosed -> Unit
+        else -> Unit
+      }
+    }
+  }
+
+  // Auto-open settings when credentials required
+  LaunchedEffect(memosState.credentialsMode, settingsState.isOpen) {
+    if (memosState.credentialsMode && !settingsState.isOpen) {
+      features.settings.send(
+        SettingsAction.Open(
+          baseUrl = memosState.baseUrl,
+          token = memosState.token,
+          appMode = features.appState.appMode,
+          language = currentLanguage,
+          theme = currentTheme,
+        ),
+      )
+    }
+  }
+
+  SyncAutoLoad(memosState, features.appState, dispatchMemos)
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsApp.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsApp.kt
@@ -1,65 +1,13 @@
 package space.be1ski.vibits.shared.app.view
 
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.rememberLazyListState
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.AddTask
-import androidx.compose.material.icons.filled.Edit
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.ui.Modifier
-import kotlinx.coroutines.launch
-import kotlinx.datetime.TimeZone
-import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.shared.Res
-import space.be1ski.vibits.shared.action_create_memo
-import space.be1ski.vibits.shared.action_track_today
 import space.be1ski.vibits.shared.app.di.AppDependencies
-import space.be1ski.vibits.shared.app.view.model.MemosFabMode
-import space.be1ski.vibits.shared.app.view.model.MemosScreen
-import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
-import space.be1ski.vibits.shared.app.view.model.memosFabModeForScreen
-import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
-import space.be1ski.vibits.shared.core.ui.ActivityRange
-import space.be1ski.vibits.shared.core.ui.Indent
-import space.be1ski.vibits.shared.feature.habits.di.createHabitsFeature
-import space.be1ski.vibits.shared.feature.habits.domain.usecase.BuildActivityDataUseCase
-import space.be1ski.vibits.shared.feature.habits.domain.usecase.CalculateSuccessRateUseCase
-import space.be1ski.vibits.shared.feature.habits.domain.usecase.EarliestMemoDateUseCase
-import space.be1ski.vibits.shared.feature.habits.domain.usecase.ExtractDailyMemosUseCase
-import space.be1ski.vibits.shared.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
-import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
-import space.be1ski.vibits.shared.feature.habits.presentation.HabitsState
-import space.be1ski.vibits.shared.feature.habits.view.buildHabitDay
-import space.be1ski.vibits.shared.feature.habits.view.components.ActivityWeekDataCache
-import space.be1ski.vibits.shared.feature.habits.view.components.rememberHabitsConfigTimeline
-import space.be1ski.vibits.shared.feature.memos.di.createMemosFeature
-import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
-import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
-import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
-import space.be1ski.vibits.shared.feature.settings.di.createSettingsFeature
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
-import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveTimeRangeTabUseCase
-import space.be1ski.vibits.shared.feature.settings.domain.usecase.TimeRangeScreen
-import space.be1ski.vibits.shared.feature.settings.presentation.SettingsAction
-import space.be1ski.vibits.shared.feature.settings.presentation.SettingsEffect
 import space.be1ski.vibits.shared.feature.settings.view.SettingsDialog
 
-@Suppress("LongMethod", "LongParameterList")
 @Composable
 fun VibitsApp(
   dependencies: AppDependencies,
@@ -69,298 +17,32 @@ fun VibitsApp(
   onThemeChanged: (AppTheme) -> Unit = {},
   onLanguageChanged: (AppLanguage) -> Unit = {},
 ) {
-  val initialPrefs = remember { dependencies.loadPreferences() }
-  val initialMode = remember { dependencies.loadAppMode() }
-  val appState =
-    remember {
-      VibitsAppUiState(
-        currentDate = currentLocalDate(),
-        initialHabitsTimeRangeTab = initialPrefs.habitsTimeRangeTab,
-        initialPostsTimeRangeTab = initialPrefs.postsTimeRangeTab,
-      ).also { it.appMode = initialMode }
-    }
+  val features = rememberAppFeatures(dependencies)
+  val memosState by features.memos.state.collectAsState()
+  val habitsState by features.habits.state.collectAsState()
+  val settingsState by features.settings.state.collectAsState()
 
-  // MemosFeature
-  val memosFeature =
-    remember {
-      val skipCredentials = initialMode == AppMode.OFFLINE || initialMode == AppMode.DEMO
-      createMemosFeature(dependencies.memosDependencies, isOfflineMode = skipCredentials)
-    }
-  val scope = rememberCoroutineScope()
-  LaunchedEffect(memosFeature) {
-    memosFeature.launchIn(scope)
-  }
-  val memosState by memosFeature.state.collectAsState()
-  val dispatchMemos: (MemosAction) -> Unit = memosFeature::send
-
-  // HabitsFeature
-  val habitsFeature =
-    remember {
-      createHabitsFeature(
-        dependencies = dependencies.habitsDependencies,
-        onRefresh = { dispatchMemos(MemosAction.LoadMemos) },
-      )
-    }
-  LaunchedEffect(habitsFeature) {
-    habitsFeature.launchIn(scope)
-  }
-  val habitsState by habitsFeature.state.collectAsState()
-
-  val appDetails = remember { dependencies.loadAppDetails() }
-  val activityWeekDataCache = remember { ActivityWeekDataCache() }
-
-  // SettingsFeature
-  val settingsFeature =
-    remember {
-      createSettingsFeature(
-        dependencies = dependencies.settingsDependencies,
-        initialMode = initialMode,
-        appDetails = appDetails,
-      )
-    }
-  LaunchedEffect(settingsFeature) {
-    settingsFeature.launchIn(scope)
-  }
-  val settingsState by settingsFeature.state.collectAsState()
-  val dispatchSettings: (SettingsAction) -> Unit = settingsFeature::send
-
-  // Observe settings effects for parent coordination
-  LaunchedEffect(settingsFeature) {
-    settingsFeature.effects.collect { effect ->
-      when (effect) {
-        is SettingsEffect.NotifyModeChanged -> {
-          appState.appMode = effect.newMode
-          dispatchMemos(MemosAction.LoadMemos)
-        }
-        is SettingsEffect.NotifyResetCompleted -> onResetApp()
-        is SettingsEffect.NotifyCredentialsSaved -> {
-          dispatchMemos(MemosAction.UpdateBaseUrl(effect.baseUrl))
-          dispatchMemos(MemosAction.UpdateToken(effect.token))
-          dispatchMemos(MemosAction.LoadMemos)
-        }
-        is SettingsEffect.NotifyThemeChanged -> {
-          onThemeChanged(effect.theme)
-        }
-        is SettingsEffect.NotifyLanguageChanged -> {
-          onLanguageChanged(effect.language)
-        }
-        is SettingsEffect.NotifyDialogClosed -> {
-          // Dialog closed, nothing extra needed
-        }
-        else -> {
-          // Internal effects handled by EffectHandler
-        }
-      }
-    }
-  }
-
-  // Open settings when credentials are required
-  LaunchedEffect(memosState.credentialsMode, settingsState.isOpen) {
-    if (memosState.credentialsMode && !settingsState.isOpen) {
-      dispatchSettings(
-        SettingsAction.Open(
-          baseUrl = memosState.baseUrl,
-          token = memosState.token,
-          appMode = appState.appMode,
-          language = currentLanguage,
-          theme = currentTheme,
-        ),
-      )
-    }
-  }
-
-  SyncAutoLoad(memosState, appState, dispatchMemos)
-
-  VibitsAppContent(
+  FeatureCoordinator(
+    features = features,
     memosState = memosState,
-    appState = appState,
-    dispatchMemos = dispatchMemos,
-    dispatchSettings = dispatchSettings,
-    saveTimeRangeTab = dependencies.saveTimeRangeTab,
+    settingsState = settingsState,
+    currentLanguage = currentLanguage,
+    currentTheme = currentTheme,
+    onResetApp = onResetApp,
+    onThemeChanged = onThemeChanged,
+    onLanguageChanged = onLanguageChanged,
+  )
+
+  VibitsAppScaffold(
+    features = features,
+    dependencies = dependencies,
+    memosState = memosState,
     habitsState = habitsState,
-    onHabitsAction = habitsFeature::send,
-    calculateSuccessRate = dependencies.calculateSuccessRate,
-    buildActivityDataUseCase = dependencies.buildActivityData,
-    cache = activityWeekDataCache,
-    language = currentLanguage,
-    theme = currentTheme,
+    currentLanguage = currentLanguage,
+    currentTheme = currentTheme,
   )
-  SettingsDialog(
-    state = settingsState,
-    dispatch = dispatchSettings,
-  )
-  MemoCreateDialog(appState, dispatchMemos)
-  MemoEditDialog(appState, dispatchMemos)
-}
 
-@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
-@Composable
-private fun VibitsAppContent(
-  memosState: MemosState,
-  appState: VibitsAppUiState,
-  dispatchMemos: (MemosAction) -> Unit,
-  dispatchSettings: (SettingsAction) -> Unit,
-  saveTimeRangeTab: SaveTimeRangeTabUseCase,
-  habitsState: HabitsState,
-  onHabitsAction: (HabitsAction) -> Unit,
-  calculateSuccessRate: CalculateSuccessRateUseCase,
-  buildActivityDataUseCase: BuildActivityDataUseCase,
-  cache: ActivityWeekDataCache,
-  language: AppLanguage,
-  theme: AppTheme,
-) {
-  val timeZone = remember { TimeZone.currentSystemDefault() }
-  val today = currentLocalDate()
-  val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
-  val todayConfig =
-    remember(habitsTimeline, today) {
-      ExtractHabitsConfigUseCase.forDate(habitsTimeline, today)?.habits.orEmpty()
-    }
-  val todayMemo =
-    remember(memosState.memos, today) {
-      ExtractDailyMemosUseCase.forDate(memosState.memos, timeZone, today)
-    }
-  val todayDay =
-    remember(todayConfig, todayMemo, today) {
-      buildHabitDay(date = today, habitsConfig = todayConfig, dailyMemo = todayMemo)
-    }
-
-  val feedListState = rememberLazyListState()
-  val scope = rememberCoroutineScope()
-
-  val onClearSelection =
-    remember(onHabitsAction) {
-      { onHabitsAction(HabitsAction.ClearSelection) }
-    }
-  val onFeedScrollToTop: () -> Unit =
-    remember(feedListState, scope) {
-      {
-        scope.launch { feedListState.animateScrollToItem(0) }
-      }
-    }
-  val onShowCreateMemoDialog =
-    remember(appState) {
-      { appState.showCreateMemoDialog = true }
-    }
-  val onOpenTodayEditor =
-    remember(onHabitsAction, todayDay, todayConfig) {
-      { if (todayDay != null) onHabitsAction(HabitsAction.OpenEditor(todayDay, todayConfig)) }
-    }
-  val onRangeChange =
-    remember(onHabitsAction, appState) {
-      { range: ActivityRange ->
-        onHabitsAction(HabitsAction.ClearSelection)
-        updateTimeRangeState(appState, range)
-      }
-    }
-  val onTabChange =
-    remember(onHabitsAction, appState, saveTimeRangeTab) {
-      { newTab: TimeRangeTab ->
-        onHabitsAction(HabitsAction.ClearSelection)
-        when (appState.selectedScreen) {
-          MemosScreen.HABITS -> {
-            adjustDateForTabChange(appState, appState.habitsTimeRangeTab, newTab)
-            appState.habitsTimeRangeTab = newTab
-            saveTimeRangeTab(TimeRangeScreen.HABITS, newTab)
-          }
-          MemosScreen.STATS -> {
-            adjustDateForTabChange(appState, appState.postsTimeRangeTab, newTab)
-            appState.postsTimeRangeTab = newTab
-            saveTimeRangeTab(TimeRangeScreen.POSTS, newTab)
-          }
-          MemosScreen.FEED -> {}
-        }
-      }
-    }
-
-  Scaffold(
-    floatingActionButton = {
-      when (memosFabModeForScreen(appState.selectedScreen)) {
-        MemosFabMode.MEMO -> {
-          FloatingActionButton(
-            onClick = onShowCreateMemoDialog,
-          ) {
-            Icon(
-              imageVector = Icons.Filled.Edit,
-              contentDescription = stringResource(Res.string.action_create_memo),
-            )
-          }
-        }
-        MemosFabMode.HABITS -> {
-          if (todayConfig.isNotEmpty() && todayDay != null) {
-            FloatingActionButton(
-              onClick = onOpenTodayEditor,
-            ) {
-              Icon(
-                imageVector = Icons.Filled.AddTask,
-                contentDescription = stringResource(Res.string.action_track_today),
-              )
-            }
-          }
-        }
-      }
-    },
-    bottomBar = {
-      MemosBottomNavigation(appState, onClearSelection, onFeedScrollToTop)
-    },
-  ) { padding ->
-    val selectedTab =
-      when (appState.selectedScreen) {
-        MemosScreen.HABITS -> appState.habitsTimeRangeTab
-        MemosScreen.STATS -> appState.postsTimeRangeTab
-        MemosScreen.FEED -> appState.habitsTimeRangeTab
-      }
-    val currentRange = currentRangeForTab(selectedTab, today)
-    val activityRange = activityRangeForState(appState)
-    val earliestDate = remember(memosState.memos) { EarliestMemoDateUseCase(memosState.memos, timeZone) }
-    val minRange = minRangeForTab(selectedTab, earliestDate)
-    Column(
-      modifier =
-        Modifier
-          .padding(padding)
-          .padding(Indent.m)
-          .fillMaxSize(),
-      verticalArrangement = Arrangement.spacedBy(Indent.s),
-    ) {
-      MemosHeader(memosState, appState, dispatchMemos, dispatchSettings, language, theme)
-      memosState.errorMessage?.let { message ->
-        Text(message, color = MaterialTheme.colorScheme.error)
-      }
-      if (appState.selectedScreen != MemosScreen.FEED) {
-        val successRate =
-          if (appState.selectedScreen == MemosScreen.HABITS) {
-            val hasHabits = remember(habitsTimeline) { habitsTimeline.lastOrNull()?.habits?.isNotEmpty() == true }
-            if (hasHabits) {
-              rememberSuccessRate(memosState.memos, activityRange, calculateSuccessRate, buildActivityDataUseCase, cache)
-            } else {
-              null
-            }
-          } else {
-            null
-          }
-        TimeRangeControls(
-          selectedTab = selectedTab,
-          selectedRange = activityRange,
-          currentRange = currentRange,
-          minRange = minRange,
-          successRate = successRate,
-          onTabChange = onTabChange,
-          onRangeChange = onRangeChange,
-        )
-      }
-      SwipeableTabContent(
-        memosState = memosState,
-        appState = appState,
-        currentRange = currentRange,
-        minRange = minRange,
-        habitsState = habitsState,
-        onHabitsAction = onHabitsAction,
-        calculateSuccessRate = calculateSuccessRate,
-        buildActivityDataUseCase = buildActivityDataUseCase,
-        cache = cache,
-        dispatchMemos = dispatchMemos,
-        feedListState = feedListState,
-      )
-    }
-  }
+  SettingsDialog(state = settingsState, dispatch = features.settings::send)
+  MemoCreateDialog(features.appState, features.memos::send)
+  MemoEditDialog(features.appState, features.memos::send)
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
@@ -1,0 +1,322 @@
+package space.be1ski.vibits.shared.app.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AddTask
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material3.FloatingActionButton
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Modifier
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.shared.Res
+import space.be1ski.vibits.shared.action_create_memo
+import space.be1ski.vibits.shared.action_track_today
+import space.be1ski.vibits.shared.app.di.AppDependencies
+import space.be1ski.vibits.shared.app.view.model.MemosFabMode
+import space.be1ski.vibits.shared.app.view.model.MemosScreen
+import space.be1ski.vibits.shared.app.view.model.VibitsAppUiState
+import space.be1ski.vibits.shared.app.view.model.memosFabModeForScreen
+import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
+import space.be1ski.vibits.shared.core.ui.ActivityRange
+import space.be1ski.vibits.shared.core.ui.Indent
+import space.be1ski.vibits.shared.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.shared.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.shared.feature.habits.domain.model.HabitsConfigEntry
+import space.be1ski.vibits.shared.feature.habits.domain.usecase.EarliestMemoDateUseCase
+import space.be1ski.vibits.shared.feature.habits.domain.usecase.ExtractDailyMemosUseCase
+import space.be1ski.vibits.shared.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
+import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
+import space.be1ski.vibits.shared.feature.habits.presentation.HabitsState
+import space.be1ski.vibits.shared.feature.habits.view.buildHabitDay
+import space.be1ski.vibits.shared.feature.habits.view.components.rememberHabitsConfigTimeline
+import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
+import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
+import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
+import space.be1ski.vibits.shared.feature.settings.domain.usecase.TimeRangeScreen
+import space.be1ski.vibits.shared.feature.settings.presentation.SettingsAction
+
+@Composable
+internal fun VibitsAppScaffold(
+  features: AppFeatures,
+  dependencies: AppDependencies,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  currentLanguage: AppLanguage,
+  currentTheme: AppTheme,
+) {
+  val appState = features.appState
+  val onHabitsAction = features.habits::send
+
+  val timeZone = remember { TimeZone.currentSystemDefault() }
+  val today = currentLocalDate()
+  val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
+  val todayData = rememberTodayData(habitsTimeline, memosState.memos, timeZone, today)
+
+  val feedListState = rememberLazyListState()
+  val scope = rememberCoroutineScope()
+  val callbacks = rememberScaffoldCallbacks(appState, onHabitsAction, feedListState, scope, todayData, dependencies)
+
+  Scaffold(
+    floatingActionButton = { AppFab(appState, todayData, callbacks) },
+    bottomBar = { MemosBottomNavigation(appState, callbacks.onClearSelection, callbacks.onFeedScrollToTop) },
+  ) { padding ->
+    ScaffoldContent(
+      padding = padding,
+      features = features,
+      dependencies = dependencies,
+      memosState = memosState,
+      habitsState = habitsState,
+      habitsTimeline = habitsTimeline,
+      timeZone = timeZone,
+      today = today,
+      callbacks = callbacks,
+      currentLanguage = currentLanguage,
+      currentTheme = currentTheme,
+      feedListState = feedListState,
+    )
+  }
+}
+
+private class TodayData(
+  val config: List<HabitConfig>,
+  val day: ContributionDay?,
+)
+
+@Composable
+private fun rememberTodayData(
+  habitsTimeline: List<HabitsConfigEntry>,
+  memos: List<Memo>,
+  timeZone: TimeZone,
+  today: LocalDate,
+): TodayData {
+  val todayConfig =
+    remember(habitsTimeline, today) {
+      ExtractHabitsConfigUseCase.forDate(habitsTimeline, today)?.habits.orEmpty()
+    }
+  val todayMemo =
+    remember(memos, today) {
+      ExtractDailyMemosUseCase.forDate(memos, timeZone, today)
+    }
+  val todayDay =
+    remember(todayConfig, todayMemo, today) {
+      buildHabitDay(date = today, habitsConfig = todayConfig, dailyMemo = todayMemo)
+    }
+  return TodayData(config = todayConfig, day = todayDay)
+}
+
+internal class ScaffoldCallbacks(
+  val onClearSelection: () -> Unit,
+  val onFeedScrollToTop: () -> Unit,
+  val onShowCreateMemoDialog: () -> Unit,
+  val onOpenTodayEditor: () -> Unit,
+  val onRangeChange: (ActivityRange) -> Unit,
+  val onTabChange: (TimeRangeTab) -> Unit,
+)
+
+@Composable
+private fun rememberScaffoldCallbacks(
+  appState: VibitsAppUiState,
+  onHabitsAction: (HabitsAction) -> Unit,
+  feedListState: LazyListState,
+  scope: CoroutineScope,
+  todayData: TodayData,
+  dependencies: AppDependencies,
+): ScaffoldCallbacks {
+  val onClearSelection = remember(onHabitsAction) { { onHabitsAction(HabitsAction.ClearSelection) } }
+  val onFeedScrollToTop: () -> Unit =
+    remember(feedListState, scope) {
+      {
+        scope.launch { feedListState.animateScrollToItem(0) }
+        Unit
+      }
+    }
+  val onShowCreateMemoDialog = remember(appState) { { appState.showCreateMemoDialog = true } }
+  val onOpenTodayEditor: () -> Unit =
+    remember(onHabitsAction, todayData) {
+      {
+        todayData.day?.let { onHabitsAction(HabitsAction.OpenEditor(it, todayData.config)) }
+        Unit
+      }
+    }
+  val onRangeChange =
+    remember(onHabitsAction, appState) {
+      { range: ActivityRange ->
+        onHabitsAction(HabitsAction.ClearSelection)
+        updateTimeRangeState(appState, range)
+      }
+    }
+  val onTabChange =
+    remember(onHabitsAction, appState, dependencies.saveTimeRangeTab) {
+      { newTab: TimeRangeTab ->
+        onHabitsAction(HabitsAction.ClearSelection)
+        handleTabChange(appState, newTab, dependencies)
+      }
+    }
+  return ScaffoldCallbacks(
+    onClearSelection = onClearSelection,
+    onFeedScrollToTop = onFeedScrollToTop,
+    onShowCreateMemoDialog = onShowCreateMemoDialog,
+    onOpenTodayEditor = onOpenTodayEditor,
+    onRangeChange = onRangeChange,
+    onTabChange = onTabChange,
+  )
+}
+
+private fun handleTabChange(
+  appState: VibitsAppUiState,
+  newTab: TimeRangeTab,
+  dependencies: AppDependencies,
+) {
+  when (appState.selectedScreen) {
+    MemosScreen.HABITS -> {
+      adjustDateForTabChange(appState, appState.habitsTimeRangeTab, newTab)
+      appState.habitsTimeRangeTab = newTab
+      dependencies.saveTimeRangeTab(TimeRangeScreen.HABITS, newTab)
+    }
+    MemosScreen.STATS -> {
+      adjustDateForTabChange(appState, appState.postsTimeRangeTab, newTab)
+      appState.postsTimeRangeTab = newTab
+      dependencies.saveTimeRangeTab(TimeRangeScreen.POSTS, newTab)
+    }
+    MemosScreen.FEED -> {}
+  }
+}
+
+@Composable
+private fun AppFab(
+  appState: VibitsAppUiState,
+  todayData: TodayData,
+  callbacks: ScaffoldCallbacks,
+) {
+  when (memosFabModeForScreen(appState.selectedScreen)) {
+    MemosFabMode.MEMO -> {
+      FloatingActionButton(onClick = callbacks.onShowCreateMemoDialog) {
+        Icon(Icons.Filled.Edit, contentDescription = stringResource(Res.string.action_create_memo))
+      }
+    }
+    MemosFabMode.HABITS -> {
+      if (todayData.config.isNotEmpty() && todayData.day != null) {
+        FloatingActionButton(onClick = callbacks.onOpenTodayEditor) {
+          Icon(Icons.Filled.AddTask, contentDescription = stringResource(Res.string.action_track_today))
+        }
+      }
+    }
+  }
+}
+
+@Suppress("LongMethod")
+@Composable
+private fun ScaffoldContent(
+  padding: PaddingValues,
+  features: AppFeatures,
+  dependencies: AppDependencies,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  habitsTimeline: List<HabitsConfigEntry>,
+  timeZone: TimeZone,
+  today: LocalDate,
+  callbacks: ScaffoldCallbacks,
+  currentLanguage: AppLanguage,
+  currentTheme: AppTheme,
+  feedListState: LazyListState,
+) {
+  val appState = features.appState
+  val selectedTab =
+    when (appState.selectedScreen) {
+      MemosScreen.HABITS -> appState.habitsTimeRangeTab
+      MemosScreen.STATS -> appState.postsTimeRangeTab
+      MemosScreen.FEED -> appState.habitsTimeRangeTab
+    }
+  val currentRange = currentRangeForTab(selectedTab, today)
+  val activityRange = activityRangeForState(appState)
+  val earliestDate = remember(memosState.memos) { EarliestMemoDateUseCase(memosState.memos, timeZone) }
+  val minRange = minRangeForTab(selectedTab, earliestDate)
+
+  Column(
+    modifier = Modifier.padding(padding).padding(Indent.m).fillMaxSize(),
+    verticalArrangement = Arrangement.spacedBy(Indent.s),
+  ) {
+    MemosHeader(
+      memosState,
+      appState,
+      features.memos::send,
+      features.settings::send,
+      currentLanguage,
+      currentTheme,
+    )
+    memosState.errorMessage?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+
+    if (appState.selectedScreen != MemosScreen.FEED) {
+      val successRate =
+        rememberSuccessRateIfNeeded(
+          appState,
+          habitsTimeline,
+          memosState.memos,
+          activityRange,
+          dependencies,
+          features.cache,
+        )
+      TimeRangeControls(
+        selectedTab = selectedTab,
+        selectedRange = activityRange,
+        currentRange = currentRange,
+        minRange = minRange,
+        successRate = successRate,
+        onTabChange = callbacks.onTabChange,
+        onRangeChange = callbacks.onRangeChange,
+      )
+    }
+
+    SwipeableTabContent(
+      memosState = memosState,
+      appState = appState,
+      currentRange = currentRange,
+      minRange = minRange,
+      habitsState = habitsState,
+      onHabitsAction = features.habits::send,
+      calculateSuccessRate = dependencies.calculateSuccessRate,
+      buildActivityDataUseCase = dependencies.buildActivityData,
+      cache = features.cache,
+      dispatchMemos = features.memos::send,
+      feedListState = feedListState,
+    )
+  }
+}
+
+@Composable
+private fun rememberSuccessRateIfNeeded(
+  appState: VibitsAppUiState,
+  habitsTimeline: List<HabitsConfigEntry>,
+  memos: List<Memo>,
+  activityRange: ActivityRange,
+  dependencies: AppDependencies,
+  cache: space.be1ski.vibits.shared.feature.habits.view.components.ActivityWeekDataCache,
+): Float? {
+  val isHabitsScreen = appState.selectedScreen == MemosScreen.HABITS
+  val hasHabits = remember(habitsTimeline) { habitsTimeline.lastOrNull()?.habits?.isNotEmpty() == true }
+  val shouldCalculate = isHabitsScreen && hasHabits
+  return if (shouldCalculate) {
+    rememberSuccessRate(memos, activityRange, dependencies.calculateSuccessRate, dependencies.buildActivityData, cache)
+  } else {
+    null
+  }
+}


### PR DESCRIPTION
## Summary

Refactor VibitsApp to be a simple feature assembler following the principle that the application layer should only compose features together without containing business logic.

### Architecture Changes

**Before:** VibitsApp was a monolithic composable (~360 lines) containing:
- Feature creation and lifecycle management
- Settings effects handling (mode changes, credentials, theme)
- Auto-open settings logic
- Auto-load logic
- All UI rendering

**After:** Clear separation into focused components:

```
VibitsApp.kt (48 lines)
├── rememberAppFeatures()  → Creates and manages all features
├── FeatureCoordinator()   → Handles inter-feature communication
├── VibitsAppScaffold()    → Pure UI rendering
└── Dialogs
```

### New Files

**`AppFeatures.kt`** — Feature container and factory
- `AppFeatures` class: holds all feature instances + shared state
- `rememberAppFeatures()`: creates and launches features with proper lifecycle

**`FeatureCoordinator.kt`** — Inter-feature communication
- Handles settings effects (mode changes, credentials, theme/language)
- Auto-opens settings when credentials required
- Triggers SyncAutoLoad

**`VibitsAppScaffold.kt`** — UI layer
- Pure UI rendering extracted from old VibitsApp
- Helper classes: `TodayData`, `ScaffoldCallbacks`
- Composables: `AppFab`, `ScaffoldContent`

### Modified Files

**`VibitsApp.kt`** — Now a simple assembler:
```kotlin
@Composable
fun VibitsApp(...) {
  val features = rememberAppFeatures(dependencies)
  val memosState by features.memos.state.collectAsState()
  val habitsState by features.habits.state.collectAsState()
  val settingsState by features.settings.state.collectAsState()

  FeatureCoordinator(features, ...)
  VibitsAppScaffold(features, ...)
  SettingsDialog(...)
  MemoCreateDialog(...)
  MemoEditDialog(...)
}
```

## Test plan
- [x] Verify compilation passes (`./gradlew :shared:compileKotlinDesktop`)
- [x] Verify linting passes (`./gradlew checkAll`)
- [ ] Manual testing of all app functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)