### PR TITLE
Fix swipe navigation not updating TimeRangeControls

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
@@ -6,9 +6,11 @@ import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.rememberPagerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
@@ -93,6 +95,7 @@ internal fun SwipeableTabContent(
   }
 }
 
+@Suppress("LongMethod")
 @Composable
 private fun SwipeablePagerContent(
   memosState: MemosState,
@@ -108,6 +111,7 @@ private fun SwipeablePagerContent(
   cache: ActivityWeekDataCache,
 ) {
   val activityRange = activityRangeForAppState(appState)
+  val currentActivityRange by rememberUpdatedState(activityRange)
   val currentDelta =
     remember(activityRange, currentRange) {
       navigateRange.calculateDelta(currentRange, activityRange)
@@ -140,7 +144,7 @@ private fun SwipeablePagerContent(
     snapshotFlow { pagerState.settledPage }.collect { page ->
       val delta = page + minDelta
       val newRange = navigateRange(currentRange, delta)
-      if (newRange != activityRangeForAppState(appState)) {
+      if (newRange != currentActivityRange) {
         onAppAction(AppAction.SetActivityRange(newRange))
         onHabitsAction(HabitsAction.ClearSelection)
       }


### PR DESCRIPTION
## Summary

Fixes a bug where swiping right to navigate forward in time (e.g., 2025 → 2026) wouldn't update the TimeRangeControls header.

**Root cause:** The `LaunchedEffect` in `SwipeablePagerContent` captured `appState` at initialization and never updated it. When swiping back and forth, the stale state caused the comparison `newRange != activityRangeForAppState(appState)` to fail, preventing the action from being dispatched.

**Fix:** Use `rememberUpdatedState` to always have the latest `activityRange` value for comparison inside the coroutine.

## Test plan

- [ ] Navigate to Habits/Stats screen
- [ ] Swipe left to go to previous year (2025)
- [ ] Swipe right to return to current year (2026)
- [ ] Verify TimeRangeControls shows correct year after swiping back

🤖 Generated with [Claude Code](https://claude.com/claude-code)