### PR TITLE
Fix demo mode not initializing features correctly

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
@@ -34,7 +34,11 @@ fun AppRoot(dependencies: AppDependencies) {
   var appLanguage by remember { mutableStateOf(initialPrefs.language) }
   var featuresVersion by remember { mutableIntStateOf(0) }
   val darkTheme = resolveDarkTheme(appTheme)
-  val modeSelectionFeature = rememberModeSelectionFeature(dependencies) { appMode = it }
+  val modeSelectionFeature =
+    rememberModeSelectionFeature(dependencies) {
+      featuresVersion++
+      appMode = it
+    }
   val features = rememberAppFeatures(featuresVersion)
 
   key(appLanguage) {


### PR DESCRIPTION
## Summary

- Fix bug where selecting Demo mode from ModeSelectionScreen caused settings dialog to auto-open
- Root cause: AppFeatures were created with cached NOT_SELECTED mode instead of the newly selected DEMO mode
- Fix increments `featuresVersion` when mode is selected, forcing recreation of AppFeatures with correct mode

## Technical Details

When user selects Demo mode:
1. `ModeSelectionEffect.NotifyModeSelected(DEMO)` is emitted
2. AppRoot's `appMode` state is updated to DEMO
3. VibitsApp is shown but `rememberAppFeatures(featuresVersion)` returns cached features
4. Cached features have `appState.appMode = NOT_SELECTED` from initial creation
5. FeatureCoordinator's `skipCredentialsCheck` is false, causing auto-open of settings

The fix ensures features are recreated with the correct mode by incrementing `featuresVersion` in the `onModeSelected` callback.

## Test plan

- [ ] Open web app in fresh browser (incognito/clear localStorage)
- [ ] Select Demo mode
- [ ] Verify app shows demo data without opening settings
- [ ] Verify settings shows Demo mode when opened manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)