### PR TITLE
Fix Compose Multiplatform deprecated dependency accessors

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,8 @@ composeBom = "2026.01.00"
 firebaseBom = "34.8.0"
 googleServices = "4.4.4"
 firebaseAppDistribution = "5.2.0"
+composeMaterial3 = "1.9.0"
+composeMaterialIconsExtended = "1.7.3"
 composeMultiplatform = "1.10.0"
 coreKtx = "1.17.0"
 coroutines = "1.10.2"
@@ -40,6 +42,13 @@ androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecyc
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 androidx-sqlite-bundled = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqliteBundled" }
+compose-foundation = { group = "org.jetbrains.compose.foundation", name = "foundation", version.ref = "composeMultiplatform" }
+compose-material = { group = "org.jetbrains.compose.material", name = "material", version.ref = "composeMultiplatform" }
+compose-material-icons-extended = { group = "org.jetbrains.compose.material", name = "material-icons-extended", version.ref = "composeMaterialIconsExtended" }
+compose-material3 = { group = "org.jetbrains.compose.material3", name = "material3", version.ref = "composeMaterial3" }
+compose-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "composeMultiplatform" }
+compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "composeMultiplatform" }
+compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "composeMultiplatform" }
 kotlinx-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "atomicfu" }
 kotlinx-coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-swing = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-swing", version.ref = "coroutines" }

--- a/shared/build.gradle.kts
+++ b/shared/build.gradle.kts
@@ -45,13 +45,13 @@ kotlin {
   sourceSets {
     val commonMain by getting {
       dependencies {
-        implementation(compose.components.resources)
-        implementation(compose.foundation)
-        implementation(compose.material)
-        implementation(compose.material3)
-        implementation(compose.materialIconsExtended)
-        implementation(compose.runtime)
-        implementation(compose.ui)
+        implementation(libs.compose.foundation)
+        implementation(libs.compose.material)
+        implementation(libs.compose.material.icons.extended)
+        implementation(libs.compose.material3)
+        implementation(libs.compose.resources)
+        implementation(libs.compose.runtime)
+        implementation(libs.compose.ui)
         implementation(libs.kotlinx.atomicfu)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.datetime)

--- a/webApp/build.gradle.kts
+++ b/webApp/build.gradle.kts
@@ -18,10 +18,10 @@ kotlin {
   sourceSets {
     val wasmJsMain by getting {
       dependencies {
-        implementation(compose.foundation)
-        implementation(compose.material3)
-        implementation(compose.runtime)
-        implementation(compose.ui)
+        implementation(libs.compose.foundation)
+        implementation(libs.compose.material3)
+        implementation(libs.compose.runtime)
+        implementation(libs.compose.ui)
         implementation(project(":shared"))
       }
     }


### PR DESCRIPTION
## Summary

Fixed deprecation warnings by replacing deprecated Compose Multiplatform dependency accessors with direct dependencies from version catalog.

## Problem

Build showed multiple deprecation warnings:
```
w: file://.../build.gradle.kts:48:32: 'val components: ComposePlugin.CommonComponentsDependencies' is deprecated. Specify dependency directly.
w: file://.../build.gradle.kts:49:32: 'val foundation: String' is deprecated. Specify dependency directly.
w: file://.../build.gradle.kts:50:32: 'val material: String' is deprecated. Specify dependency directly.
... (10+ warnings total)
```

## Solution

Migrated from deprecated `compose.*` accessors to proper version catalog dependencies:

**Before:**
```kotlin
implementation(compose.components.resources)
implementation(compose.foundation)
implementation(compose.material)
// ...
```

**After:**
```kotlin
implementation(libs.compose.foundation)
implementation(libs.compose.material)
implementation(libs.compose.material.icons.extended)
// ...
```

Added all Compose dependencies to `libs.versions.toml`:
- compose-foundation
- compose-material
- compose-material-icons-extended (v1.7.3)
- compose-material3 (v1.9.0)
- compose-resources
- compose-runtime
- compose-ui

## Changes

- **Modified:** `gradle/libs.versions.toml` - added 7 Compose library entries
- **Modified:** `shared/build.gradle.kts` - replaced deprecated accessors
- **Modified:** `webApp/build.gradle.kts` - replaced deprecated accessors
- Dependencies are alphabetically sorted

## Test Plan

- [x] Build completes without deprecation warnings
- [x] All tests pass (`./gradlew :shared:desktopTest`)
- [x] No functional changes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)