### PR TITLE
Move PlatformLog to core.platform.logging package

### DIFF
--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
@@ -1,4 +1,6 @@
-package space.be1ski.vibits.shared.core.logging
+package space.be1ski.vibits.shared.core.platform.logging
+
+import space.be1ski.vibits.shared.core.logging.LogLevel
 
 internal actual fun platformLog(
   level: LogLevel,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/logging/Log.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/logging/Log.kt
@@ -4,6 +4,7 @@ import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import space.be1ski.vibits.shared.core.platform.logging.platformLog
 import kotlin.time.Clock
 
 /**

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
@@ -1,4 +1,6 @@
-package space.be1ski.vibits.shared.core.logging
+package space.be1ski.vibits.shared.core.platform.logging
+
+import space.be1ski.vibits.shared.core.logging.LogLevel
 
 /**
  * Platform-specific log output.

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
@@ -1,6 +1,7 @@
-package space.be1ski.vibits.shared.core.logging
+package space.be1ski.vibits.shared.core.platform.logging
 
 import org.slf4j.LoggerFactory
+import space.be1ski.vibits.shared.core.logging.LogLevel
 
 private val logger = LoggerFactory.getLogger("Vibits")
 

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
@@ -1,4 +1,6 @@
-package space.be1ski.vibits.shared.core.logging
+package space.be1ski.vibits.shared.core.platform.logging
+
+import space.be1ski.vibits.shared.core.logging.LogLevel
 
 internal actual fun platformLog(
   level: LogLevel,

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/logging/PlatformLog.kt
@@ -1,4 +1,6 @@
-package space.be1ski.vibits.shared.core.logging
+package space.be1ski.vibits.shared.core.platform.logging
+
+import space.be1ski.vibits.shared.core.logging.LogLevel
 
 internal actual fun platformLog(
   level: LogLevel,


### PR DESCRIPTION
## Summary

Moved `PlatformLog` to `core.platform.logging` package to align with project architecture where all expect/actual platform-specific code lives in `*.platform.*` packages.

## Problem

PlatformLog is an expect/actual platform-specific implementation but was placed in `core.logging` package instead of `core.platform.logging`. This is inconsistent with the rest of the codebase:

**Other platform-specific code (all in `*.platform.*`):**
- core.platform.locale.LocaleProvider
- core.platform.date.DateProvider
- core.platform.storage.KeyValueStore
- core.platform.network.HttpClientProvider
- feature.memos.data.platform.MemoCache
- etc.

**PlatformLog (was in wrong package):**
- ~~core.logging.PlatformLog~~ ❌

## Solution

Move PlatformLog to `core.platform.logging`:
- Consistent with architectural pattern
- Automatically excluded from coverage via `*.platform.*` pattern
- No special exclusion rules needed

## Changes

- **Moved:** `PlatformLog.kt` from `core.logging` to `core.platform.logging` (all 5 source sets)
- **Added:** import `LogLevel` in PlatformLog files (now in different package)
- **Added:** import `platformLog` in Log.kt (now in different package)

## Architecture Benefits

**Before:**
```
core.logging/
  ├── Log.kt              (business logic)
  ├── LogLevel.kt         (enum)
  └── PlatformLog.kt      (expect/actual) ❌ Wrong location!
```

**After:**
```
core.logging/
  ├── Log.kt              (business logic)
  └── LogLevel.kt         (enum)

core.platform.logging/
  └── PlatformLog.kt      (expect/actual) ✅ Correct location!
```

## Test Plan

- [x] All tests pass (`./gradlew :shared:desktopTest`)
- [x] Coverage maintained at ~94.5%
- [x] PlatformLog excluded from coverage report
- [x] No functional changes
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)