### PR TITLE
Move AppState to domain layer

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeatureFactory.kt
@@ -1,10 +1,10 @@
 package space.be1ski.vibits.shared.app.di
 
 import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.presentation.AppAction
 import space.be1ski.vibits.shared.app.presentation.AppEffect
 import space.be1ski.vibits.shared.app.presentation.AppEffectHandler
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.app.presentation.appReducer
 import space.be1ski.vibits.shared.core.elm.Feature
 import space.be1ski.vibits.shared.core.elm.FeatureImpl

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/domain/model/AppState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/domain/model/AppState.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.shared.app.presentation
+package space.be1ski.vibits.shared.app.domain.model
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.shared.app.domain.model.Screen

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppFeatures.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppFeatures.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.shared.app.presentation
 
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.core.elm.Feature
 import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
 import space.be1ski.vibits.shared.feature.habits.presentation.HabitsEffect

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducer.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.shared.app.presentation
 
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.app.domain.usecase.AdjustDateForTabChangeUseCase
 import space.be1ski.vibits.shared.app.domain.usecase.GetActivityRangeStartDateUseCase

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.shared.app.view
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.presentation.AppAction
 import space.be1ski.vibits.shared.app.presentation.AppFeatures
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosState
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/HabitsDialogs.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/HabitsDialogs.kt
@@ -13,7 +13,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.shared.app.presentation.AppState
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
 import space.be1ski.vibits.shared.feature.habits.presentation.HabitsState

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/ScaffoldCallbacks.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/ScaffoldCallbacks.kt
@@ -6,9 +6,9 @@ import androidx.compose.runtime.remember
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import space.be1ski.vibits.shared.app.domain.model.ActivityRange
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.app.presentation.AppAction
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.feature.habits.domain.usecase.NavigateActivityRangeUseCase
 import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
@@ -17,9 +17,9 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.shared.app.domain.model.ActivityMode
 import space.be1ski.vibits.shared.app.domain.model.ActivityRange
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.app.presentation.AppAction
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.core.platform.isDesktop
 import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.date.DateFormatter

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppComponents.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppComponents.kt
@@ -22,9 +22,9 @@ import androidx.compose.ui.Modifier
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.shared.app.domain.model.ActivityMode
 import space.be1ski.vibits.shared.app.domain.model.ActivityRange
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.app.presentation.AppAction
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
 import space.be1ski.vibits.shared.core.platform.isDesktop
 import space.be1ski.vibits.shared.core.ui.Indent

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
@@ -24,9 +24,9 @@ import kotlinx.datetime.TimeZone
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.shared.app.di.AppDependencies
 import space.be1ski.vibits.shared.app.domain.model.ActivityRange
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.app.presentation.AppFeatures
-import space.be1ski.vibits.shared.app.presentation.AppState
 import space.be1ski.vibits.shared.core.platform.date.currentLocalDate
 import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.date.DateFormatter

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducerTest.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.shared.app.presentation
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import space.be1ski.vibits.shared.app.domain.model.ActivityRange
+import space.be1ski.vibits.shared.app.domain.model.AppState
 import space.be1ski.vibits.shared.app.domain.model.Screen
 import space.be1ski.vibits.shared.core.elm.test
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode


### PR DESCRIPTION
## Summary
Move `AppState` from `app.presentation` to `app.domain.model` package.

## Changes
- Move `AppState.kt` to domain layer
- Update imports in 10 files (presentation, view, DI, tests)
- Fix import ordering with ktlint

## Rationale
`AppState` is a domain model - it contains only domain concepts (AppMode, Screen, TimeRangeTab, LocalDate) and computed properties with business logic (isDemoMode, skipCredentialsCheck). It has no UI or framework dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)