### PR TITLE
Add comprehensive tests for AppState computed properties

### DIFF
--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/domain/model/AppStateTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/domain/model/AppStateTest.kt
@@ -1,0 +1,108 @@
+package space.be1ski.vibits.shared.app.domain.model
+
+import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class AppStateTest {
+  private val testDate = LocalDate(2024, 3, 15)
+
+  @Test
+  fun `when selectedScreen is HABITS then currentTimeRangeTab returns habitsTimeRangeTab`() {
+    val state =
+      AppState(
+        selectedScreen = Screen.HABITS,
+        habitsTimeRangeTab = TimeRangeTab.MONTHS,
+        postsTimeRangeTab = TimeRangeTab.WEEKS,
+        periodStartDate = testDate,
+      )
+
+    assertEquals(TimeRangeTab.MONTHS, state.currentTimeRangeTab)
+  }
+
+  @Test
+  fun `when selectedScreen is STATS then currentTimeRangeTab returns postsTimeRangeTab`() {
+    val state =
+      AppState(
+        selectedScreen = Screen.STATS,
+        habitsTimeRangeTab = TimeRangeTab.MONTHS,
+        postsTimeRangeTab = TimeRangeTab.YEARS,
+        periodStartDate = testDate,
+      )
+
+    assertEquals(TimeRangeTab.YEARS, state.currentTimeRangeTab)
+  }
+
+  @Test
+  fun `when selectedScreen is FEED then currentTimeRangeTab returns habitsTimeRangeTab`() {
+    val state =
+      AppState(
+        selectedScreen = Screen.FEED,
+        habitsTimeRangeTab = TimeRangeTab.QUARTERS,
+        postsTimeRangeTab = TimeRangeTab.WEEKS,
+        periodStartDate = testDate,
+      )
+
+    assertEquals(TimeRangeTab.QUARTERS, state.currentTimeRangeTab)
+  }
+
+  @Test
+  fun `when appMode is DEMO then isDemoMode is true`() {
+    val state = AppState(appMode = AppMode.DEMO, periodStartDate = testDate)
+
+    assertTrue(state.isDemoMode)
+  }
+
+  @Test
+  fun `when appMode is ONLINE then isDemoMode is false`() {
+    val state = AppState(appMode = AppMode.ONLINE, periodStartDate = testDate)
+
+    assertFalse(state.isDemoMode)
+  }
+
+  @Test
+  fun `when appMode is OFFLINE then isDemoMode is false`() {
+    val state = AppState(appMode = AppMode.OFFLINE, periodStartDate = testDate)
+
+    assertFalse(state.isDemoMode)
+  }
+
+  @Test
+  fun `when appMode is NOT_SELECTED then isDemoMode is false`() {
+    val state = AppState(appMode = AppMode.NOT_SELECTED, periodStartDate = testDate)
+
+    assertFalse(state.isDemoMode)
+  }
+
+  @Test
+  fun `when appMode is DEMO then skipCredentialsCheck is true`() {
+    val state = AppState(appMode = AppMode.DEMO, periodStartDate = testDate)
+
+    assertTrue(state.skipCredentialsCheck)
+  }
+
+  @Test
+  fun `when appMode is OFFLINE then skipCredentialsCheck is true`() {
+    val state = AppState(appMode = AppMode.OFFLINE, periodStartDate = testDate)
+
+    assertTrue(state.skipCredentialsCheck)
+  }
+
+  @Test
+  fun `when appMode is ONLINE then skipCredentialsCheck is false`() {
+    val state = AppState(appMode = AppMode.ONLINE, periodStartDate = testDate)
+
+    assertFalse(state.skipCredentialsCheck)
+  }
+
+  @Test
+  fun `when appMode is NOT_SELECTED then skipCredentialsCheck is false`() {
+    val state = AppState(appMode = AppMode.NOT_SELECTED, periodStartDate = testDate)
+
+    assertFalse(state.skipCredentialsCheck)
+  }
+}


### PR DESCRIPTION
## Summary
Add comprehensive test coverage for AppState computed properties that contain business logic.

## Changes
- Add AppStateTest with 11 test cases covering:
  - `currentTimeRangeTab` logic (3 tests for each screen type)
  - `isDemoMode` logic (4 tests for all app modes)
  - `skipCredentialsCheck` logic (4 tests for all app modes)

## Rationale
During test suite inspection per updated AGENTS.md guidelines, discovered that AppState (moved to domain in PR #108) has three computed properties with business logic but no tests. These properties determine critical app behavior (credential validation, tab selection) and must be tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)