### PR TITLE
Add automatic credentials initialization from local.properties and quick online dialog

### DIFF
--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
@@ -1,0 +1,3 @@
+package space.be1ski.vibits.shared.core.platform.env
+
+actual fun createLocalConfigProvider(): LocalConfigProvider = LocalConfigProvider { null }

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">تخزين البيانات محليًا بدون اتصال بالخادم</string>
     <string name="mode_demo_title">تجريبي</string>
     <string name="mode_demo_desc">جرب التطبيق مع بيانات نموذجية</string>
+    <string name="mode_quick_online_title">تم العثور على بيانات الاعتماد</string>
+    <string name="mode_quick_online_desc">تم اكتشاف بيانات اعتماد محفوظة. استخدامها للاتصال بسرعة؟</string>
+    <string name="action_use_saved">استخدام المحفوظة</string>
 
     <!-- Navigation -->
     <string name="nav_feed">الرئيسية</string>

--- a/shared/src/commonMain/composeResources/values-az/strings.xml
+++ b/shared/src/commonMain/composeResources/values-az/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Serverə qoşulmadan məlumatları lokal saxlayın</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Tətbiqi nümunə məlumatlarla sınayın</string>
+    <string name="mode_quick_online_title">Etimadnamələr tapıldı</string>
+    <string name="mode_quick_online_desc">Saxlanmış etimadnamələr aşkar edildi. Sürətli qoşulmaq üçün onlardan istifadə edilsin?</string>
+    <string name="action_use_saved">Saxlanmışdan istifadə et</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lent</string>

--- a/shared/src/commonMain/composeResources/values-be/strings.xml
+++ b/shared/src/commonMain/composeResources/values-be/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Захоўванне даных лакальна без падключэння да сервера</string>
     <string name="mode_demo_title">Дэма</string>
     <string name="mode_demo_desc">Паспрабаваць праграму з прыкладам даных</string>
+    <string name="mode_quick_online_title">Знойдзены ўліковыя даныя</string>
+    <string name="mode_quick_online_desc">Выяўлены захаваныя ўліковыя даныя. Выкарыстаць іх для хуткага падключэння?</string>
+    <string name="action_use_saved">Выкарыстаць</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Стужка</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Daten lokal ohne Serververbindung speichern</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">App mit Beispieldaten testen</string>
+    <string name="mode_quick_online_title">Anmeldedaten gefunden</string>
+    <string name="mode_quick_online_desc">Gespeicherte Anmeldedaten erkannt. Diese für schnelle Verbindung verwenden?</string>
+    <string name="action_use_saved">Gespeicherte verwenden</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Almacenar datos localmente sin conexión al servidor</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Probar la app con datos de ejemplo</string>
+    <string name="mode_quick_online_title">Credenciales encontradas</string>
+    <string name="mode_quick_online_desc">Se detectaron credenciales guardadas. ¿Usarlas para conectarse rápidamente?</string>
+    <string name="action_use_saved">Usar guardadas</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Inicio</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Stockez les données localement sans connexion au serveur</string>
     <string name="mode_demo_title">Démo</string>
     <string name="mode_demo_desc">Essayez l\'app avec des données d\'exemple</string>
+    <string name="mode_quick_online_title">Identifiants trouvés</string>
+    <string name="mode_quick_online_desc">Identifiants sauvegardés détectés. Les utiliser pour une connexion rapide ?</string>
+    <string name="action_use_saved">Utiliser sauvegardés</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Fil</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">सर्वर कनेक्शन के बिना स्थानीय रूप से डेटा स्टोर करें</string>
     <string name="mode_demo_title">डेमो</string>
     <string name="mode_demo_desc">नमूना डेटा के साथ ऐप आज़माएं</string>
+    <string name="mode_quick_online_title">क्रेडेंशियल मिले</string>
+    <string name="mode_quick_online_desc">सहेजे गए क्रेडेंशियल मिले। तेज़ी से कनेक्ट करने के लिए उनका उपयोग करें?</string>
+    <string name="action_use_saved">सहेजा उपयोग करें</string>
 
     <!-- Navigation -->
     <string name="nav_feed">फ़ीड</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">サーバー接続なしでローカルにデータを保存</string>
     <string name="mode_demo_title">デモ</string>
     <string name="mode_demo_desc">サンプルデータでアプリを試す</string>
+    <string name="mode_quick_online_title">認証情報が見つかりました</string>
+    <string name="mode_quick_online_desc">保存された認証情報が検出されました。それらを使用して素早く接続しますか？</string>
+    <string name="action_use_saved">保存済みを使用</string>
 
     <!-- Navigation -->
     <string name="nav_feed">フィード</string>

--- a/shared/src/commonMain/composeResources/values-ka/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ka/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">შეინახეთ მონაცემები ლოკალურად სერვერთან კავშირის გარეშე</string>
     <string name="mode_demo_title">დემო</string>
     <string name="mode_demo_desc">სცადეთ აპი სადემონსტრაციო მონაცემებით</string>
+    <string name="mode_quick_online_title">ნაპოვნია უფლებამოსილებები</string>
+    <string name="mode_quick_online_desc">აღმოჩენილია შენახული უფლებამოსილებები. გამოვიყენოთ სწრაფი დაკავშირებისთვის?</string>
+    <string name="action_use_saved">შენახულის გამოყენება</string>
 
     <!-- Navigation -->
     <string name="nav_feed">ფიდი</string>

--- a/shared/src/commonMain/composeResources/values-kk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-kk/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Серверге қосылусыз деректерді жергілікті сақтау</string>
     <string name="mode_demo_title">Демо</string>
     <string name="mode_demo_desc">Қолданбаны үлгі деректермен байқап көру</string>
+    <string name="mode_quick_online_title">Тіркелгі деректері табылды</string>
+    <string name="mode_quick_online_desc">Сақталған тіркелгі деректері табылды. Оларды жылдам қосылу үшін пайдалану керек пе?</string>
+    <string name="action_use_saved">Сақталғанды пайдалану</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/shared/src/commonMain/composeResources/values-ky/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ky/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Серверге туташуусуз маалыматтарды жергиликтүү сактоо</string>
     <string name="mode_demo_title">Демо</string>
     <string name="mode_demo_desc">Колдонмону үлгү маалыматтар менен сынап көрүү</string>
+    <string name="mode_quick_online_title">Эсеп маалыматтары табылды</string>
+    <string name="mode_quick_online_desc">Сакталган эсеп маалыматтары табылды. Аларды тез туташуу үчүн колдонулсунбу?</string>
+    <string name="action_use_saved">Сакталганды колдон</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Armazene dados localmente sem conexão com servidor</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Experimente o app com dados de exemplo</string>
+    <string name="mode_quick_online_title">Credenciais encontradas</string>
+    <string name="mode_quick_online_desc">Credenciais salvas detectadas. Usá-las para conectar rapidamente?</string>
+    <string name="action_use_saved">Usar salvas</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Stocați datele local fără conexiune la server</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Încercați aplicația cu date demonstrative</string>
+    <string name="mode_quick_online_title">Credențiale găsite</string>
+    <string name="mode_quick_online_desc">Credențiale salvate detectate. Le folosim pentru conectare rapidă?</string>
+    <string name="action_use_saved">Folosește salvate</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Flux</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -161,6 +161,9 @@
     <string name="mode_offline_desc">Хранение данных локально без подключения к серверу</string>
     <string name="mode_demo_title">Демо</string>
     <string name="mode_demo_desc">Попробовать приложение с примером данных</string>
+    <string name="mode_quick_online_title">Найдены учетные данные</string>
+    <string name="mode_quick_online_desc">Обнаружены сохраненные учетные данные. Использовать их для быстрого подключения?</string>
+    <string name="action_use_saved">Использовать</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/shared/src/commonMain/composeResources/values-tg/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tg/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Маълумотро бе пайвастшавӣ ба сервер маҳаллӣ нигоҳ доред</string>
     <string name="mode_demo_title">Намоишӣ</string>
     <string name="mode_demo_desc">Барномаро бо маълумоти намунавӣ санҷед</string>
+    <string name="mode_quick_online_title">Маълумоти ҳисоб ёфт шуд</string>
+    <string name="mode_quick_online_desc">Маълумоти ҳисоби захирашуда ошкор шуд. Барои пайваст шудани зуд истифода бурда шавад?</string>
+    <string name="action_use_saved">Захирашударо истифода бур</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/shared/src/commonMain/composeResources/values-tk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tk/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Maglumatlary ýerli ýerde server birikmezden saklaň</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Programmany nusga maglumatlar bilen synag ediň</string>
+    <string name="mode_quick_online_title">Hasap maglumatlary tapyldy</string>
+    <string name="mode_quick_online_desc">Saklanýan hasap maglumatlary tapyldy. Olary çalt birikdirmek üçün ulanmalymy?</string>
+    <string name="action_use_saved">Saklananyny ulan</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lenta</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Зберігання даних локально без підключення до сервера</string>
     <string name="mode_demo_title">Демо</string>
     <string name="mode_demo_desc">Спробувати додаток із прикладом даних</string>
+    <string name="mode_quick_online_title">Знайдено облікові дані</string>
+    <string name="mode_quick_online_desc">Виявлено збережені облікові дані. Використати їх для швидкого підключення?</string>
+    <string name="action_use_saved">Використати</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Стрічка</string>

--- a/shared/src/commonMain/composeResources/values-uz/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uz/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Serverga ulanmasdan ma\'lumotlarni mahalliy saqlash</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Ilovani namuna ma\'lumotlar bilan sinab ko\'rish</string>
+    <string name="mode_quick_online_title">Hisob ma\'lumotlari topildi</string>
+    <string name="mode_quick_online_desc">Saqlangan hisob ma\'lumotlari aniqlandi. Ularni tez ulanish uchun ishlatilsinmi?</string>
+    <string name="action_use_saved">Saqlanganni ishlat</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lenta</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">本地存储数据，无需服务器连接</string>
     <string name="mode_demo_title">演示</string>
     <string name="mode_demo_desc">使用示例数据体验应用</string>
+    <string name="mode_quick_online_title">找到凭证</string>
+    <string name="mode_quick_online_desc">检测到已保存的凭证。使用它们快速连接？</string>
+    <string name="action_use_saved">使用已保存</string>
 
     <!-- Navigation -->
     <string name="nav_feed">动态</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -162,6 +162,9 @@
     <string name="mode_offline_desc">Store data locally without server connection</string>
     <string name="mode_demo_title">Demo</string>
     <string name="mode_demo_desc">Try the app with sample data</string>
+    <string name="mode_quick_online_title">Credentials Found</string>
+    <string name="mode_quick_online_desc">Saved credentials detected. Use them to quickly connect online?</string>
+    <string name="action_use_saved">Use Saved</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/AppInitializer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/AppInitializer.kt
@@ -1,0 +1,17 @@
+package space.be1ski.vibits.shared.app
+
+import dev.zacsweers.metro.Inject
+import dev.zacsweers.metro.SingleIn
+import space.be1ski.vibits.shared.app.di.AppScope
+
+/**
+ * Application initialization orchestrator.
+ * Handles startup tasks like cache warming, migrations, etc.
+ */
+@Inject
+@SingleIn(AppScope::class)
+class AppInitializer {
+  operator fun invoke() {
+    // Reserved for future startup tasks (cache warming, migrations, etc.)
+  }
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
@@ -9,6 +9,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import space.be1ski.vibits.shared.core.platform.app.AppDetailsProvider
+import space.be1ski.vibits.shared.core.platform.env.LocalConfigProvider
+import space.be1ski.vibits.shared.core.platform.env.createLocalConfigProvider
 import space.be1ski.vibits.shared.core.platform.export.FileExporter
 import space.be1ski.vibits.shared.core.platform.export.createFileExporter
 import space.be1ski.vibits.shared.core.platform.locale.LocaleProvider
@@ -23,12 +25,14 @@ import space.be1ski.vibits.shared.feature.mode.data.platform.AppModeStore
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStore
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStoreImpl
 
+@Suppress("TooManyFunctions")
 @SingleIn(AppScope::class)
 @DependencyGraph(AppScope::class)
 abstract class AppGraph {
   abstract val appDependencies: AppDependencies
   abstract val appFeaturesFactory: AppFeaturesFactory
   abstract val appCoroutineScope: CoroutineScope
+  abstract val appInitializer: space.be1ski.vibits.shared.app.AppInitializer
 
   companion object {
     private var instance: AppGraph? = null
@@ -40,6 +44,10 @@ abstract class AppGraph {
     fun getFeaturesFactory(): AppFeaturesFactory = getGraph().appFeaturesFactory
 
     fun getAppScope(): CoroutineScope = getGraph().appCoroutineScope
+
+    fun initializeApp() {
+      getGraph().appInitializer()
+    }
 
     fun resetGraph() {
       instance = null
@@ -81,6 +89,10 @@ abstract class AppGraph {
   @Provides
   @SingleIn(AppScope::class)
   fun fileExporter(): FileExporter = createFileExporter()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun localConfigProvider(): LocalConfigProvider = createLocalConfigProvider()
 
   @Provides
   @SingleIn(AppScope::class)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
@@ -1,7 +1,11 @@
 package space.be1ski.vibits.shared.app.view
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
@@ -9,6 +13,8 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import space.be1ski.vibits.shared.app.di.AppDependencies
 import space.be1ski.vibits.shared.app.di.AppGraph
 import space.be1ski.vibits.shared.app.presentation.AppFeatures
@@ -46,11 +52,11 @@ fun AppRoot(dependencies: AppDependencies) {
       when (appMode) {
         AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = modeSelectionFeature)
         AppMode.ONLINE, AppMode.OFFLINE, AppMode.DEMO -> {
-          VibitsApp(
+          AppWithLoadingScreen(
             dependencies = dependencies,
             features = features,
-            currentTheme = appTheme,
-            currentLanguage = appLanguage,
+            appTheme = appTheme,
+            appLanguage = appLanguage,
             onResetApp = {
               appTheme = AppTheme.SYSTEM
               appLanguage = AppLanguage.SYSTEM
@@ -68,6 +74,44 @@ fun AppRoot(dependencies: AppDependencies) {
         }
       }
     }
+  }
+}
+
+@Composable
+private fun AppWithLoadingScreen(
+  dependencies: AppDependencies,
+  features: AppFeatures,
+  appTheme: AppTheme,
+  appLanguage: AppLanguage,
+  onResetApp: () -> Unit,
+  onThemeChanged: (AppTheme) -> Unit,
+  onLanguageChanged: (AppLanguage) -> Unit,
+) {
+  val memosState by features.memos.state.collectAsState()
+
+  if (!memosState.initialDataLoaded) {
+    // Show loading screen while initial data is loading
+    LoadingScreen()
+  } else {
+    VibitsApp(
+      dependencies = dependencies,
+      features = features,
+      currentTheme = appTheme,
+      currentLanguage = appLanguage,
+      onResetApp = onResetApp,
+      onThemeChanged = onThemeChanged,
+      onLanguageChanged = onLanguageChanged,
+    )
+  }
+}
+
+@Composable
+private fun LoadingScreen() {
+  Box(
+    modifier = Modifier.fillMaxSize(),
+    contentAlignment = Alignment.Center,
+  ) {
+    CircularProgressIndicator()
   }
 }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
@@ -3,6 +3,8 @@ package space.be1ski.vibits.shared.app.view
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -107,11 +109,16 @@ private fun AppWithLoadingScreen(
 
 @Composable
 private fun LoadingScreen() {
-  Box(
+  Surface(
     modifier = Modifier.fillMaxSize(),
-    contentAlignment = Alignment.Center,
+    color = MaterialTheme.colorScheme.background,
   ) {
-    CircularProgressIndicator()
+    Box(
+      modifier = Modifier.fillMaxSize(),
+      contentAlignment = Alignment.Center,
+    ) {
+      CircularProgressIndicator()
+    }
   }
 }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
@@ -83,6 +83,7 @@ private fun handleNotification(
   when (effect) {
     is SettingsEffect.Notification.ModeChanged -> {
       dispatchApp(AppAction.SetAppMode(effect.newMode))
+      dispatchMemos(MemosAction.ResetForModeChange)
       dispatchMemos(MemosAction.LoadMemos)
     }
     is SettingsEffect.Notification.ResetCompleted -> onResetApp()

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
@@ -1,0 +1,17 @@
+package space.be1ski.vibits.shared.core.platform.env
+
+/**
+ * Provides access to local configuration (local.properties, environment variables, etc).
+ */
+fun interface LocalConfigProvider {
+  /**
+   * Reads a configuration value by key.
+   * Returns null if the key is not set.
+   */
+  fun get(key: String): String?
+}
+
+/**
+ * Creates platform-specific LocalConfigProvider.
+ */
+expect fun createLocalConfigProvider(): LocalConfigProvider

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCase.kt
@@ -1,0 +1,45 @@
+package space.be1ski.vibits.shared.feature.auth.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.shared.core.logging.Log
+import space.be1ski.vibits.shared.core.platform.env.LocalConfigProvider
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+
+private const val TAG = "InitCredentialsFromConfig"
+private const val CONFIG_MEMOS_BASE_URL = "memos.baseUrl"
+private const val CONFIG_MEMOS_TOKEN = "memos.token"
+private const val LOG_URL_MAX_LENGTH = 20
+
+/**
+ * Initializes credentials from local configuration on first launch.
+ * Checks if credentials are already saved. If not, attempts to load from local.properties.
+ */
+@Inject
+class InitializeCredentialsFromEnvUseCase(
+  private val loadCredentials: LoadCredentialsUseCase,
+  private val saveCredentials: SaveCredentialsUseCase,
+  private val localConfigProvider: LocalConfigProvider,
+) {
+  operator fun invoke() {
+    val existing = loadCredentials()
+    if (existing.baseUrl.isNotBlank() || existing.token.isNotBlank()) {
+      Log.i(TAG, "Credentials already saved, skipping initialization")
+      return
+    }
+
+    val baseUrl = localConfigProvider.get(CONFIG_MEMOS_BASE_URL)
+    val token = localConfigProvider.get(CONFIG_MEMOS_TOKEN)
+
+    val maskedUrl = baseUrl?.take(LOG_URL_MAX_LENGTH) ?: "null"
+    val maskedToken = if (token.isNullOrBlank()) "null" else "***"
+    Log.i(TAG, "Checking config: baseUrl=$maskedUrl token=$maskedToken")
+
+    if (baseUrl.isNullOrBlank() || token.isNullOrBlank()) {
+      Log.i(TAG, "Config not set, skipping initialization")
+      return
+    }
+
+    Log.i(TAG, "Initializing credentials from local config")
+    saveCredentials(Credentials(baseUrl = baseUrl, token = token))
+  }
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/ContributionGridState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/ContributionGridState.kt
@@ -36,7 +36,8 @@ data class ActivityWeekDataState(
 
 /**
  * Runtime cache for ActivityWeekData.
- * Clears automatically when memos list changes (by reference).
+ * When memos list changes, saves snapshot of old cache before clearing.
+ * Snapshot is used to prevent UI flashing while recalculating new data.
  * Exposes [version] to trigger LaunchedEffect restart when memos reference changes.
  */
 @Inject
@@ -44,6 +45,7 @@ data class ActivityWeekDataState(
 class ActivityWeekDataCache {
   private var lastMemos: List<Memo>? = null
   private val cache = mutableMapOf<Pair<ActivityRange, ActivityMode>, ActivityWeekData>()
+  private var snapshot = mutableMapOf<Pair<ActivityRange, ActivityMode>, ActivityWeekData>()
 
   /**
    * Increments when memos reference changes.
@@ -59,12 +61,22 @@ class ActivityWeekDataCache {
   ): ActivityWeekData? {
     val sameRef = memos === lastMemos
     if (!sameRef) {
+      // Save snapshot before clearing to prevent UI flashing
+      snapshot = cache.toMutableMap()
       cache.clear()
       lastMemos = memos
       version++
-      return null
     }
-    return cache[range to mode]
+    // Return from cache if available, otherwise from snapshot
+    return cache[range to mode] ?: snapshot[range to mode]
+  }
+
+  fun isFresh(
+    memos: List<Memo>,
+    range: ActivityRange,
+    mode: ActivityMode,
+  ): Boolean {
+    return memos === lastMemos && cache.containsKey(range to mode)
   }
 
   fun put(
@@ -74,15 +86,19 @@ class ActivityWeekDataCache {
     data: ActivityWeekData,
   ) {
     if (memos !== lastMemos) {
+      snapshot = cache.toMutableMap()
       cache.clear()
       lastMemos = memos
       version++
     }
     cache[range to mode] = data
+    // Clear snapshot for this key once new data is ready
+    snapshot.remove(range to mode)
   }
 
   fun clear() {
     cache.clear()
+    snapshot.clear()
     lastMemos = null
     version++
   }
@@ -92,6 +108,7 @@ class ActivityWeekDataCache {
  * Memoized builder for [ActivityWeekData].
  * Pre-extracts config and daily memos (cached by memos only), then builds range-dependent data.
  * Computation runs in background thread; caches results per range for instant switching.
+ * Never shows loading state for background recalculation to prevent UI flashing.
  */
 @Composable
 fun rememberActivityWeekData(
@@ -107,21 +124,23 @@ fun rememberActivityWeekData(
   val configTimeline = rememberHabitsConfigTimeline(memos)
   val dailyMemos = rememberDailyMemos(memos)
 
-  // Check cache SYNCHRONOUSLY on every composition
-  // This ensures we pick up cached data even if local state got reset during recomposition
+  // CRITICAL: Capture cacheVersion first, then get data
+  // This ensures remember() key matches the data we're initializing with
+  val cacheVersion = cache.version
   val cachedData = cache.get(memos, range, mode)
 
-  // If cache has data, return immediately - no shimmer needed
-  if (cachedData != null) {
-    return ActivityWeekDataState(data = cachedData, isLoading = false)
+  // Always use remember to hold current data, initializing with cached/snapshot data
+  var currentData by remember(cacheVersion, range, mode) {
+    mutableStateOf(cachedData ?: emptyWeekData)
   }
 
-  // Cache miss - need to load in background
-  val cacheVersion = cache.version
-  var currentData by remember(cacheVersion, range, mode) { mutableStateOf(emptyWeekData) }
-  var isLoading by remember(cacheVersion, range, mode) { mutableStateOf(true) }
-
+  // Trigger background recalculation if data is not fresh
   LaunchedEffect(cacheVersion, range, mode) {
+    // Skip if we already have fresh data in main cache
+    if (cache.isFresh(memos, range, mode)) {
+      return@LaunchedEffect
+    }
+
     val result =
       withContext(Dispatchers.Default) {
         buildActivityDataUseCase.buildWeekData(
@@ -136,10 +155,9 @@ fun rememberActivityWeekData(
       }
     cache.put(memos, range, mode, result)
     currentData = result
-    isLoading = false
   }
 
-  return ActivityWeekDataState(data = currentData, isLoading = isLoading)
+  return ActivityWeekDataState(data = currentData, isLoading = false)
 }
 
 /**

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosAction.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosAction.kt
@@ -23,6 +23,8 @@ sealed interface MemosAction {
 
   data object LoadCachedMemos : MemosAction
 
+  data object ResetForModeChange : MemosAction
+
   // Filtering
   data class ChangePostFilter(
     val filter: PostFilter,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
@@ -51,8 +51,18 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
       }
 
       is MemosAction.CachedMemosLoaded -> {
-        if (state.memos.isEmpty() && action.memos.isNotEmpty()) {
+        if (state.memos.isNotEmpty()) {
+          // Already have memos, don't overwrite with cache
+          return@reducer
+        }
+
+        if (action.memos.isNotEmpty()) {
+          // Cache has data, use it
           state { copy(memos = sortedMemos(action.memos)) }
+        } else if (!state.isOfflineMode) {
+          // Cache is empty and we're online - load from server immediately
+          state { copy(isLoading = true) }
+          effect(MemosEffect.LoadRemoteMemos)
         }
       }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
@@ -45,6 +45,10 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
         effect(MemosEffect.LoadCachedMemos)
       }
 
+      is MemosAction.ResetForModeChange -> {
+        state { copy(memos = emptyList(), initialDataLoaded = false, isLoading = false) }
+      }
+
       // Filtering
       is MemosAction.ChangePostFilter -> {
         state { copy(activePostFilter = action.filter) }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
@@ -58,16 +58,26 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
 
         if (action.memos.isNotEmpty()) {
           // Cache has data, use it
-          state { copy(memos = sortedMemos(action.memos)) }
+          state { copy(memos = sortedMemos(action.memos), initialDataLoaded = true) }
         } else if (!state.isOfflineMode) {
           // Cache is empty and we're online - load from server immediately
           state { copy(isLoading = true) }
           effect(MemosEffect.LoadRemoteMemos)
+        } else {
+          // Offline mode with no cache - mark as loaded
+          state { copy(initialDataLoaded = true) }
         }
       }
 
       is MemosAction.MemosLoaded -> {
-        state { copy(memos = sortedMemos(action.memos), isLoading = false, errorMessage = null) }
+        state {
+          copy(
+            memos = sortedMemos(action.memos),
+            isLoading = false,
+            errorMessage = null,
+            initialDataLoaded = true,
+          )
+        }
       }
 
       // CRUD

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosState.kt
@@ -15,6 +15,7 @@ data class MemosState(
   val token: String = "",
   val isOfflineMode: Boolean = false,
   val activePostFilter: PostFilter = PostFilter.ALL,
+  val initialDataLoaded: Boolean = false,
   // Create dialog
   val showCreateDialog: Boolean = false,
   val createDialogContent: String = "",

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionDependencies.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionDependencies.kt
@@ -1,6 +1,8 @@
 package space.be1ski.vibits.shared.feature.mode.di
 
 import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.LoadCredentialsUseCase
 import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
@@ -8,6 +10,8 @@ import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
 @Inject
 class ModeSelectionDependencies(
   val connectionTester: ConnectionTester,
+  val initializeCredentialsFromEnv: InitializeCredentialsFromEnvUseCase,
+  val loadCredentials: LoadCredentialsUseCase,
   val saveCredentials: SaveCredentialsUseCase,
   val saveAppMode: SaveAppModeUseCase,
 )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
@@ -18,7 +18,10 @@ fun createModeSelectionFeature(
     effectHandler =
       ModeSelectionEffectHandler(
         connectionTester = dependencies.connectionTester,
+        initializeCredentialsFromEnv = dependencies.initializeCredentialsFromEnv,
+        loadCredentials = dependencies.loadCredentials,
         saveCredentials = dependencies.saveCredentials,
         saveAppMode = dependencies.saveAppMode,
       ),
+    initialEffects = listOf(ModeSelectionEffect.InitializeFromLocalConfig),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionAction.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionAction.kt
@@ -3,6 +3,16 @@ package space.be1ski.vibits.shared.feature.mode.presentation
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
 sealed interface ModeSelectionAction {
+  // Stored credentials check
+  data object StoredCredentialsFound : ModeSelectionAction
+
+  data object StoredCredentialsNotFound : ModeSelectionAction
+
+  // Quick online dialog
+  data object DismissQuickOnlineDialog : ModeSelectionAction
+
+  data object UseStoredCredentials : ModeSelectionAction
+
   // Dialog lifecycle
   data object ShowCredentialsDialog : ModeSelectionAction
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffect.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffect.kt
@@ -4,6 +4,12 @@ import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
 sealed interface ModeSelectionEffect {
   // Async operations (handled by EffectHandler)
+  data object InitializeFromLocalConfig : ModeSelectionEffect
+
+  data object CheckStoredCredentials : ModeSelectionEffect
+
+  data object UseStoredCredentialsWithValidation : ModeSelectionEffect
+
   data class ValidateCredentials(
     val baseUrl: String,
     val token: String,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -6,24 +6,66 @@ import kotlinx.coroutines.flow.flow
 import space.be1ski.vibits.shared.core.elm.EffectHandler
 import space.be1ski.vibits.shared.core.logging.Log
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.feature.auth.domain.usecase.LoadCredentialsUseCase
 import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
+import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
 
 private const val TAG = "ModeEffect"
 
 class ModeSelectionEffectHandler(
   private val connectionTester: ConnectionTester,
+  private val initializeCredentialsFromEnv: space.be1ski.vibits.shared.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase,
+  private val loadCredentials: LoadCredentialsUseCase,
   private val saveCredentials: SaveCredentialsUseCase,
   private val saveAppMode: SaveAppModeUseCase,
 ) : EffectHandler<ModeSelectionEffect, ModeSelectionAction> {
   override fun invoke(effect: ModeSelectionEffect): Flow<ModeSelectionAction> =
     when (effect) {
+      is ModeSelectionEffect.InitializeFromLocalConfig -> handleInitializeFromLocalConfig()
+      is ModeSelectionEffect.CheckStoredCredentials -> handleCheckStoredCredentials()
+      is ModeSelectionEffect.UseStoredCredentialsWithValidation -> handleUseStoredCredentials()
       is ModeSelectionEffect.ValidateCredentials -> handleValidateCredentials(effect)
       is ModeSelectionEffect.SaveCredentials -> handleSaveCredentials(effect)
       is ModeSelectionEffect.SaveMode -> handleSaveMode(effect)
       // Parent notification effects are not handled here - they flow through to AppRoot
       is ModeSelectionEffect.NotifyModeSelected -> emptyFlow()
+    }
+
+  private fun handleInitializeFromLocalConfig(): Flow<ModeSelectionAction> =
+    flow {
+      initializeCredentialsFromEnv()
+      // After initialization, check if credentials were loaded
+      val credentials = loadCredentials()
+      if (credentials.baseUrl.isNotBlank() && credentials.token.isNotBlank()) {
+        Log.d(TAG, "Stored credentials found after initialization")
+        emit(ModeSelectionAction.StoredCredentialsFound)
+      } else {
+        Log.d(TAG, "No stored credentials after initialization")
+        emit(ModeSelectionAction.StoredCredentialsNotFound)
+      }
+    }
+
+  private fun handleCheckStoredCredentials(): Flow<ModeSelectionAction> =
+    flow {
+      val credentials = loadCredentials()
+      if (credentials.baseUrl.isNotBlank() && credentials.token.isNotBlank()) {
+        Log.d(TAG, "Stored credentials found")
+        emit(ModeSelectionAction.StoredCredentialsFound)
+      } else {
+        Log.d(TAG, "No stored credentials")
+        emit(ModeSelectionAction.StoredCredentialsNotFound)
+      }
+    }
+
+  private fun handleUseStoredCredentials(): Flow<ModeSelectionAction> =
+    flow {
+      val credentials = loadCredentials()
+      Log.d(TAG, "Using stored credentials")
+      connectionTester(credentials.baseUrl, credentials.token)
+        .onSuccess { emit(ModeSelectionAction.ValidationSucceeded) }
+        .onFailure { emit(ModeSelectionAction.ValidationFailed) }
     }
 
   private fun handleValidateCredentials(effect: ModeSelectionEffect.ValidateCredentials): Flow<ModeSelectionAction> =

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -13,6 +13,7 @@ import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
 
 private const val TAG = "ModeEffect"
+private const val LOG_URL_MAX_LENGTH = 20
 
 class ModeSelectionEffectHandler(
   private val connectionTester: ConnectionTester,
@@ -61,8 +62,10 @@ class ModeSelectionEffectHandler(
 
   private fun handleUseStoredCredentials(): Flow<ModeSelectionAction> =
     flow {
+      // Ensure credentials are loaded from local config (in case of app reset)
+      initializeCredentialsFromEnv()
       val credentials = loadCredentials()
-      Log.d(TAG, "Using stored credentials")
+      Log.d(TAG, "Using stored credentials: baseUrl=${credentials.baseUrl.take(LOG_URL_MAX_LENGTH)}")
       connectionTester(credentials.baseUrl, credentials.token)
         .onSuccess { emit(ModeSelectionAction.ValidationSucceeded) }
         .onFailure { emit(ModeSelectionAction.ValidationFailed) }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
@@ -7,6 +7,23 @@ import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect> =
   reducer { action, state ->
     when (action) {
+      is ModeSelectionAction.StoredCredentialsFound -> {
+        state { copy(hasStoredCredentials = true, showQuickOnlineDialog = true) }
+      }
+
+      is ModeSelectionAction.StoredCredentialsNotFound -> {
+        state { copy(hasStoredCredentials = false) }
+      }
+
+      is ModeSelectionAction.DismissQuickOnlineDialog -> {
+        state { copy(showQuickOnlineDialog = false) }
+      }
+
+      is ModeSelectionAction.UseStoredCredentials -> {
+        state { copy(showQuickOnlineDialog = false, isValidating = true) }
+        effect(ModeSelectionEffect.UseStoredCredentialsWithValidation)
+      }
+
       is ModeSelectionAction.ShowCredentialsDialog -> {
         state { copy(showCredentialsDialog = true, error = null) }
       }
@@ -52,7 +69,10 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
             error = null,
           )
         }
-        effect(ModeSelectionEffect.SaveCredentials(state.baseUrl.trim(), state.token.trim()))
+        // Only save credentials if they were manually entered
+        if (state.baseUrl.isNotBlank() && state.token.isNotBlank()) {
+          effect(ModeSelectionEffect.SaveCredentials(state.baseUrl.trim(), state.token.trim()))
+        }
         effect(ModeSelectionEffect.SaveMode(AppMode.ONLINE))
         effect(ModeSelectionEffect.NotifyModeSelected(AppMode.ONLINE))
       }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
@@ -60,6 +60,11 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
       }
 
       is ModeSelectionAction.ValidationSucceeded -> {
+        // Capture credentials before clearing state
+        val wasManuallyEntered = state.baseUrl.isNotBlank() && state.token.isNotBlank()
+        val capturedBaseUrl = state.baseUrl.trim()
+        val capturedToken = state.token.trim()
+
         state {
           copy(
             showCredentialsDialog = false,
@@ -70,8 +75,8 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
           )
         }
         // Only save credentials if they were manually entered
-        if (state.baseUrl.isNotBlank() && state.token.isNotBlank()) {
-          effect(ModeSelectionEffect.SaveCredentials(state.baseUrl.trim(), state.token.trim()))
+        if (wasManuallyEntered) {
+          effect(ModeSelectionEffect.SaveCredentials(capturedBaseUrl, capturedToken))
         }
         effect(ModeSelectionEffect.SaveMode(AppMode.ONLINE))
         effect(ModeSelectionEffect.NotifyModeSelected(AppMode.ONLINE))
@@ -82,6 +87,7 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
       }
 
       is ModeSelectionAction.SelectMode -> {
+        state { copy(showQuickOnlineDialog = false) }
         effect(ModeSelectionEffect.SaveMode(action.mode))
         effect(ModeSelectionEffect.NotifyModeSelected(action.mode))
       }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionState.kt
@@ -2,6 +2,8 @@ package space.be1ski.vibits.shared.feature.mode.presentation
 
 data class ModeSelectionState(
   val showCredentialsDialog: Boolean = false,
+  val showQuickOnlineDialog: Boolean = false,
+  val hasStoredCredentials: Boolean = false,
   val baseUrl: String = "",
   val token: String = "",
   val isValidating: Boolean = false,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
@@ -36,6 +36,7 @@ import space.be1ski.vibits.shared.feature.mode.presentation.ModeSelectionState
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_cancel
 import space.be1ski.vibits.shared.generated.action_save
+import space.be1ski.vibits.shared.generated.action_use_saved
 import space.be1ski.vibits.shared.generated.hint_base_url
 import space.be1ski.vibits.shared.generated.label_access_token
 import space.be1ski.vibits.shared.generated.label_base_url
@@ -45,6 +46,8 @@ import space.be1ski.vibits.shared.generated.mode_offline_desc
 import space.be1ski.vibits.shared.generated.mode_offline_title
 import space.be1ski.vibits.shared.generated.mode_online_desc
 import space.be1ski.vibits.shared.generated.mode_online_title
+import space.be1ski.vibits.shared.generated.mode_quick_online_desc
+import space.be1ski.vibits.shared.generated.mode_quick_online_title
 import space.be1ski.vibits.shared.generated.mode_select_subtitle
 import space.be1ski.vibits.shared.generated.mode_select_title
 import space.be1ski.vibits.shared.generated.msg_connection_failed
@@ -103,12 +106,55 @@ fun ModeSelectionScreen(feature: Feature<ModeSelectionAction, ModeSelectionState
     )
   }
 
+  if (state.showQuickOnlineDialog) {
+    QuickOnlineDialog(
+      state = state,
+      dispatch = dispatch,
+    )
+  }
+
   if (state.showCredentialsDialog) {
     CredentialsSetupDialog(
       state = state,
       dispatch = dispatch,
     )
   }
+}
+
+@Composable
+private fun QuickOnlineDialog(
+  state: ModeSelectionState,
+  dispatch: (ModeSelectionAction) -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.DismissQuickOnlineDialog) },
+    title = { Text(stringResource(Res.string.mode_quick_online_title)) },
+    text = { Text(stringResource(Res.string.mode_quick_online_desc)) },
+    confirmButton = {
+      Button(
+        onClick = { dispatch(ModeSelectionAction.UseStoredCredentials) },
+        enabled = !state.isValidating,
+      ) {
+        if (state.isValidating) {
+          CircularProgressIndicator(
+            modifier = Modifier.size(16.dp),
+            strokeWidth = 2.dp,
+            color = MaterialTheme.colorScheme.onPrimary,
+          )
+        } else {
+          Text(stringResource(Res.string.action_use_saved))
+        }
+      }
+    },
+    dismissButton = {
+      TextButton(
+        onClick = { dispatch(ModeSelectionAction.DismissQuickOnlineDialog) },
+        enabled = !state.isValidating,
+      ) {
+        Text(stringResource(Res.string.action_cancel))
+      }
+    },
+  )
 }
 
 @Suppress("LongMethod")

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCaseTest.kt
@@ -1,0 +1,115 @@
+package space.be1ski.vibits.shared.feature.auth.domain.usecase
+
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import space.be1ski.vibits.shared.test.createFakeLocalConfigProvider
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class InitializeCredentialsFromEnvUseCaseTest {
+  @Test
+  fun `when credentials already exist then does not initialize from config`() {
+    val existingCredentials = Credentials(baseUrl = "https://existing.com", token = "existing-token")
+    val repository = FakeCredentialsRepository(initial = existingCredentials)
+    val configProvider =
+      createFakeLocalConfigProvider(
+        config =
+          mapOf(
+            "memos.baseUrl" to "https://config.com",
+            "memos.token" to "config-token",
+          ),
+      )
+    val useCase =
+      InitializeCredentialsFromEnvUseCase(
+        loadCredentials = LoadCredentialsUseCase(repository),
+        saveCredentials = SaveCredentialsUseCase(repository),
+        localConfigProvider = configProvider,
+      )
+
+    useCase()
+
+    assertEquals(existingCredentials, repository.stored)
+    assertEquals(0, repository.saveCount)
+  }
+
+  @Test
+  fun `when credentials empty and config set then initializes from config`() {
+    val repository = FakeCredentialsRepository()
+    val configProvider =
+      createFakeLocalConfigProvider(
+        config =
+          mapOf(
+            "memos.baseUrl" to "https://config.com",
+            "memos.token" to "config-token",
+          ),
+      )
+    val useCase =
+      InitializeCredentialsFromEnvUseCase(
+        loadCredentials = LoadCredentialsUseCase(repository),
+        saveCredentials = SaveCredentialsUseCase(repository),
+        localConfigProvider = configProvider,
+      )
+
+    useCase()
+
+    assertEquals(Credentials(baseUrl = "https://config.com", token = "config-token"), repository.stored)
+    assertEquals(1, repository.saveCount)
+  }
+
+  @Test
+  fun `when credentials empty and config missing then does not initialize`() {
+    val repository = FakeCredentialsRepository()
+    val configProvider = createFakeLocalConfigProvider(config = emptyMap())
+    val useCase =
+      InitializeCredentialsFromEnvUseCase(
+        loadCredentials = LoadCredentialsUseCase(repository),
+        saveCredentials = SaveCredentialsUseCase(repository),
+        localConfigProvider = configProvider,
+      )
+
+    useCase()
+
+    assertEquals(Credentials(baseUrl = "", token = ""), repository.stored)
+    assertEquals(0, repository.saveCount)
+  }
+
+  @Test
+  fun `when credentials empty and only base url set then does not initialize`() {
+    val repository = FakeCredentialsRepository()
+    val configProvider =
+      createFakeLocalConfigProvider(
+        config = mapOf("memos.baseUrl" to "https://config.com"),
+      )
+    val useCase =
+      InitializeCredentialsFromEnvUseCase(
+        loadCredentials = LoadCredentialsUseCase(repository),
+        saveCredentials = SaveCredentialsUseCase(repository),
+        localConfigProvider = configProvider,
+      )
+
+    useCase()
+
+    assertEquals(Credentials(baseUrl = "", token = ""), repository.stored)
+    assertEquals(0, repository.saveCount)
+  }
+
+  @Test
+  fun `when credentials empty and only token set then does not initialize`() {
+    val repository = FakeCredentialsRepository()
+    val configProvider =
+      createFakeLocalConfigProvider(
+        config = mapOf("memos.token" to "config-token"),
+      )
+    val useCase =
+      InitializeCredentialsFromEnvUseCase(
+        loadCredentials = LoadCredentialsUseCase(repository),
+        saveCredentials = SaveCredentialsUseCase(repository),
+        localConfigProvider = configProvider,
+      )
+
+    useCase()
+
+    assertEquals(Credentials(baseUrl = "", token = ""), repository.stored)
+    assertEquals(0, repository.saveCount)
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/LoadCredentialsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/LoadCredentialsUseCaseTest.kt
@@ -1,0 +1,19 @@
+package space.be1ski.vibits.shared.feature.auth.domain.usecase
+
+import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class LoadCredentialsUseCaseTest {
+  @Test
+  fun `when invoke then returns credentials from repository`() {
+    val expectedCredentials = Credentials(baseUrl = "https://example.com", token = "token123")
+    val repository = FakeCredentialsRepository(initial = expectedCredentials)
+    val useCase = LoadCredentialsUseCase(repository)
+
+    val result = useCase()
+
+    assertEquals(expectedCredentials, result)
+  }
+}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCaseTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/auth/domain/usecase/SaveCredentialsUseCaseTest.kt
@@ -18,16 +18,3 @@ class SaveCredentialsUseCaseTest {
     assertEquals(1, repository.saveCount)
   }
 }
-
-class LoadCredentialsUseCaseTest {
-  @Test
-  fun `when invoke then returns credentials from repository`() {
-    val expectedCredentials = Credentials(baseUrl = "https://example.com", token = "token123")
-    val repository = FakeCredentialsRepository(initial = expectedCredentials)
-    val useCase = LoadCredentialsUseCase(repository)
-
-    val result = useCase()
-
-    assertEquals(expectedCredentials, result)
-  }
-}

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducerTest.kt
@@ -84,7 +84,7 @@ class MemosReducerTest {
     memosReducer.test(MemosState()) {
       send(MemosAction.CachedMemosLoaded(listOf(testMemo)))
 
-      assertState { memos.size == 1 && memos.first().name == testMemo.name }
+      assertState { memos.size == 1 && memos.first().name == testMemo.name && initialDataLoaded }
       assertNoEffects()
     }
 
@@ -98,11 +98,38 @@ class MemosReducerTest {
     }
 
   @Test
+  fun `when CachedMemosLoaded with empty cache in offline mode then marks as loaded`() =
+    memosReducer.test(MemosState(isOfflineMode = true)) {
+      send(MemosAction.CachedMemosLoaded(emptyList()))
+
+      assertState { memos.isEmpty() && initialDataLoaded }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when CachedMemosLoaded with empty cache in online mode then loads from server`() =
+    memosReducer.test(MemosState(isOfflineMode = false)) {
+      send(MemosAction.CachedMemosLoaded(emptyList()))
+
+      assertState { memos.isEmpty() && !initialDataLoaded && isLoading }
+      assertEffects(MemosEffect.LoadRemoteMemos)
+    }
+
+  @Test
+  fun `when ResetForModeChange then clears memos and resets initialDataLoaded`() =
+    memosReducer.test(MemosState(memos = listOf(testMemo), initialDataLoaded = true, isLoading = true)) {
+      send(MemosAction.ResetForModeChange)
+
+      assertState { memos.isEmpty() && !initialDataLoaded && !isLoading }
+      assertNoEffects()
+    }
+
+  @Test
   fun `when MemosLoaded then updates memos and stops loading`() =
     memosReducer.test(MemosState(isLoading = true, errorMessage = "old error")) {
       send(MemosAction.MemosLoaded(listOf(testMemo)))
 
-      assertState { memos.size == 1 && !isLoading && errorMessage == null }
+      assertState { memos.size == 1 && !isLoading && errorMessage == null && initialDataLoaded }
       assertNoEffects()
     }
 

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -77,6 +77,104 @@ class ModeSelectionEffectHandlerTest {
       assertTrue(actions.isEmpty())
     }
 
+  @Test
+  fun `when InitializeFromLocalConfig with credentials then emits StoredCredentialsFound`() =
+    runTest {
+      val credentialsRepo = FakeCredentialsRepository()
+      val configProvider =
+        space.be1ski.vibits.shared.test.createFakeLocalConfigProvider(
+          config =
+            mapOf(
+              "memos.baseUrl" to "https://config.com",
+              "memos.token" to "config-token",
+            ),
+        )
+      val handler = createHandler(credentialsRepository = credentialsRepo, localConfigProvider = configProvider)
+
+      val actions = handler(ModeSelectionEffect.InitializeFromLocalConfig).toList()
+
+      assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
+    }
+
+  @Test
+  fun `when InitializeFromLocalConfig without credentials then emits StoredCredentialsNotFound`() =
+    runTest {
+      val credentialsRepo = FakeCredentialsRepository()
+      val configProvider =
+        space.be1ski.vibits.shared.test
+          .createFakeLocalConfigProvider(config = emptyMap())
+      val handler = createHandler(credentialsRepository = credentialsRepo, localConfigProvider = configProvider)
+
+      val actions = handler(ModeSelectionEffect.InitializeFromLocalConfig).toList()
+
+      assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
+    }
+
+  @Test
+  fun `when CheckStoredCredentials with credentials then emits StoredCredentialsFound`() =
+    runTest {
+      val credentialsRepo =
+        FakeCredentialsRepository(
+          initial =
+            space.be1ski.vibits.shared.feature.auth.domain.model.Credentials(
+              baseUrl = "https://existing.com",
+              token = "existing-token",
+            ),
+        )
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(ModeSelectionEffect.CheckStoredCredentials).toList()
+
+      assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
+    }
+
+  @Test
+  fun `when CheckStoredCredentials without credentials then emits StoredCredentialsNotFound`() =
+    runTest {
+      val credentialsRepo = FakeCredentialsRepository()
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(ModeSelectionEffect.CheckStoredCredentials).toList()
+
+      assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
+    }
+
+  @Test
+  fun `when UseStoredCredentialsWithValidation succeeds then emits ValidationSucceeded`() =
+    runTest {
+      val credentialsRepo =
+        FakeCredentialsRepository(
+          initial =
+            space.be1ski.vibits.shared.feature.auth.domain.model.Credentials(
+              baseUrl = "https://existing.com",
+              token = "existing-token",
+            ),
+        )
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(ModeSelectionEffect.UseStoredCredentialsWithValidation).toList()
+
+      assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
+    }
+
+  @Test
+  fun `when UseStoredCredentialsWithValidation fails then emits ValidationFailed`() =
+    runTest {
+      val credentialsRepo =
+        FakeCredentialsRepository(
+          initial =
+            space.be1ski.vibits.shared.feature.auth.domain.model.Credentials(
+              baseUrl = "https://existing.com",
+              token = "existing-token",
+            ),
+        )
+      val handler = createHandler(connectionResult = Result.failure(Exception("Failed")), credentialsRepository = credentialsRepo)
+
+      val actions = handler(ModeSelectionEffect.UseStoredCredentialsWithValidation).toList()
+
+      assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
+    }
+
   private fun createHandler(
     connectionResult: Result<Unit> = Result.success(Unit),
     credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -81,9 +81,23 @@ class ModeSelectionEffectHandlerTest {
     connectionResult: Result<Unit> = Result.success(Unit),
     credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
     appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),
+    localConfigProvider: space.be1ski.vibits.shared.core.platform.env.LocalConfigProvider =
+      space.be1ski.vibits.shared.test
+        .createFakeLocalConfigProvider(),
   ): ModeSelectionEffectHandler {
     return ModeSelectionEffectHandler(
       connectionTester = ConnectionTester { _, _ -> connectionResult },
+      initializeCredentialsFromEnv =
+        space.be1ski.vibits.shared.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase(
+          loadCredentials =
+            space.be1ski.vibits.shared.feature.auth.domain.usecase
+              .LoadCredentialsUseCase(credentialsRepository),
+          saveCredentials = SaveCredentialsUseCase(credentialsRepository),
+          localConfigProvider = localConfigProvider,
+        ),
+      loadCredentials =
+        space.be1ski.vibits.shared.feature.auth.domain.usecase
+          .LoadCredentialsUseCase(credentialsRepository),
       saveCredentials = SaveCredentialsUseCase(credentialsRepository),
       saveAppMode = SaveAppModeUseCase(appModeRepository),
     )

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -197,4 +197,60 @@ class ModeSelectionReducerTest {
       val notifyEffect = assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
       assertEquals(AppMode.DEMO, notifyEffect.mode)
     }
+
+  @Test
+  fun `when StoredCredentialsFound then sets flag and shows quick online dialog`() =
+    modeSelectionReducer.test(ModeSelectionState()) {
+      send(ModeSelectionAction.StoredCredentialsFound)
+
+      assertState { hasStoredCredentials && showQuickOnlineDialog }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when StoredCredentialsNotFound then clears flag`() =
+    modeSelectionReducer.test(ModeSelectionState(hasStoredCredentials = true)) {
+      send(ModeSelectionAction.StoredCredentialsNotFound)
+
+      assertState { !hasStoredCredentials }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when DismissQuickOnlineDialog then hides dialog`() =
+    modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
+      send(ModeSelectionAction.DismissQuickOnlineDialog)
+
+      assertState { !showQuickOnlineDialog }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when UseStoredCredentials then closes dialog and starts validation`() =
+    modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
+      send(ModeSelectionAction.UseStoredCredentials)
+
+      assertState { !showQuickOnlineDialog && isValidating }
+      assertEffects(ModeSelectionEffect.UseStoredCredentialsWithValidation)
+    }
+
+  @Test
+  fun `when ValidationSucceeded with empty state then does not save credentials`() =
+    modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
+      send(ModeSelectionAction.ValidationSucceeded)
+
+      assertState { !isValidating && baseUrl == "" && token == "" }
+      assertEffectCount(2)
+      assertHasEffect<ModeSelectionEffect.SaveMode>()
+      assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
+    }
+
+  @Test
+  fun `when SelectMode then closes quick online dialog`() =
+    modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
+      send(ModeSelectionAction.SelectMode(AppMode.DEMO))
+
+      assertState { !showQuickOnlineDialog }
+      assertEffectCount(2)
+    }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.shared.test
 
+import space.be1ski.vibits.shared.core.platform.env.LocalConfigProvider
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.shared.feature.memos.data.platform.MemoCache
@@ -139,3 +140,6 @@ class FakePreferencesRepository(
     saveCalls += 1
   }
 }
+
+fun createFakeLocalConfigProvider(config: Map<String, String> = emptyMap()): LocalConfigProvider =
+  LocalConfigProvider { key -> config[key] }

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
@@ -1,0 +1,21 @@
+package space.be1ski.vibits.shared.core.platform.env
+
+import java.io.File
+import java.util.Properties
+
+actual fun createLocalConfigProvider(): LocalConfigProvider {
+  val properties = Properties()
+  val localPropertiesFile = File("../local.properties")
+  if (localPropertiesFile.exists()) {
+    localPropertiesFile.inputStream().use { properties.load(it) }
+  }
+
+  return LocalConfigProvider { key ->
+    // 1. Try local.properties with dot notation (memos.baseUrl)
+    properties.getProperty(key)
+      // 2. Try ENV with dot notation (memos.baseUrl)
+      ?: System.getenv(key)
+      // 3. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
+      ?: System.getenv(key.replace('.', '_').uppercase())
+  }
+}

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
@@ -1,0 +1,3 @@
+package space.be1ski.vibits.shared.core.platform.env
+
+actual fun createLocalConfigProvider(): LocalConfigProvider = LocalConfigProvider { null }

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/env/LocalConfigProvider.kt
@@ -1,0 +1,3 @@
+package space.be1ski.vibits.shared.core.platform.env
+
+actual fun createLocalConfigProvider(): LocalConfigProvider = LocalConfigProvider { null }


### PR DESCRIPTION
## Summary

Three major improvements for development workflow and UX:

### 1. Automatic Credentials Initialization
Reads credentials from `local.properties` or ENV variables on first launch, eliminating manual login during development.

**How it works:**
- Reads `memos.baseUrl` and `memos.token` from `local.properties`
- Also supports ENV variables: `MEMOS_BASE_URL`, `MEMOS_TOKEN`
- Initialization happens on ModeSelection screen (not app startup)
- Only initializes if no credentials exist yet

### 2. Quick Online Dialog
Shows "Credentials Found" dialog when saved credentials are detected, allowing instant connection.

**Flow:**
- App reads `local.properties` on mode selection screen
- If credentials found → shows dialog with "Use Saved" and "Cancel" buttons
- "Use Saved" validates credentials and switches to Online mode
- "Cancel" shows normal mode selection (Demo/Offline/Manual entry)

### 3. UI Flashing Fixes
Eliminated visual flashing in habits screen when data updates.

**Problem:** When server data loaded (1-2 seconds after startup or on refresh), the ActivityWeekDataCache cleared all cached data, causing UI to flash empty state while recalculating.

**Solution:** Implemented snapshot caching:
- When memos list changes, save snapshot of old cache before clearing
- Return snapshot data while recalculating new data in background
- Smooth transition from cached to fresh data without flashing
- Also fixed: loading screen now respects dark theme

## Usage

Add to `local.properties` (already in .gitignore):
```properties
memos.baseUrl=https://your-memos-instance.com
memos.token=your-token
```

On first launch or after app reset:
1. App reads `local.properties` and saves credentials
2. Shows "Credentials Found" dialog
3. Click "Use Saved" to instantly connect online
4. Or "Cancel" to choose Demo/Offline/Manual entry

## Changes

**New Features:**
- Add `LocalConfigProvider` fun interface that reads from `local.properties` or ENV
- Add Quick Online dialog with stored credentials detection
- Add snapshot caching to ActivityWeekDataCache for smooth data transitions

**Architecture:**
- Move credentials initialization from app startup to ModeSelection feature
- Update ModeSelection TEA (State, Actions, Effects, Reducer, EffectHandler)
- Add `initialDataLoaded` flag to MemosState
- Add `ResetForModeChange` action to clear stale data on mode switch
- Add loading screen with dark theme support

**Tests:**
- Comprehensive test coverage for ModeSelection reducer and effect handler
- Tests for Quick Online dialog flow
- Tests for credentials initialization scenarios
- Tests for MemosReducer changes (ResetForModeChange, initialDataLoaded)
- Split auth use case tests into separate files

**UI/UX:**
- Add translations for 18 languages (Quick Online dialog strings)
- Eliminate UI flashing on initial load and refresh
- Prevent showing stale data when switching modes

## Test Plan
- [x] All existing tests pass
- [x] New tests cover all initialization scenarios
- [x] ktlint and detekt checks pass
- [x] Quick Online dialog shows when credentials found
- [x] "Use Saved" validates and connects
- [x] "Cancel" shows normal mode selection
- [x] No UI flashing on startup or refresh
- [x] Dark theme works on loading screen
- [x] Mode switching doesn't show stale data
- [x] Codecov patch coverage ~95%

🤖 Generated with [Claude Code](https://claude.com/claude-code)