### PR TITLE
Improve translations for better natural language

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -197,6 +197,7 @@ We use [Metro](https://zacsweers.github.io/metro/) for compile-time DI.
 
 - **Never hardcode user-facing strings.** All text displayed to users must use string resources from `composeResources/values/strings.xml`.
 - **Always add translations for ALL supported locales immediately.** When adding a new string resource, add proper native translations to all locale files in `composeResources/values-*/strings.xml`. Use professional native translations, not English fallbacks.
+- **Terminology:** In this app, “Memo” must be translated as **«Воспоминание»** in Russian. Do not use «Заметка» for memos.
 - String resource names use `snake_case` with semantic prefixes: `action_`, `label_`, `msg_`, `title_`, `hint_`, `format_`, etc.
 
 ## Testing Guidelines

--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">إلغاء</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">إنشاء تكوين جديد (موصى به)</string>
+    <string name="action_edit_anyway">تحرير على أي حال</string>
     <string name="action_clear">مسح</string>
     <string name="action_close">إغلاق</string>
     <string name="action_copied">تم النسخ</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">عادي</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">نشط منذ %1$s</string>
     <string name="msg_connection_failed">فشل الاتصال</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">أنت على وشك تعديل تكوين موجود. سيؤثر ذلك على جميع البيانات التاريخية.
+
+لا يُنصح بتعديل تكوين قديم لأنه يغيّر كيفية ظهور بياناتك السابقة. على سبيل المثال، إذا أضفت عادة جديدة فستظهر جميع الأيام السابقة على أنها «غير مكتملة» رغم أنها لم تكن موجودة حينها.
+
+أفضل ممارسة: أنشئ تكوينًا جديدًا. ستبقى بياناتك التاريخية على التكوين القديم، وستستخدم البيانات الجديدة التكوين الجديد.</string>
     <string name="msg_delete_config_warning">هل أنت متأكد من حذف هذه الإعدادات؟ سيتم حذف منشور التكوين من مذكراتك نهائيًا.</string>
     <string name="msg_delete_day_confirm">لم يتم اختيار عادات. سيتم حذف إدخال اليوم.</string>
     <string name="msg_delete_day_warning">هل أنت متأكد من رغبتك في حذف إدخال هذا اليوم؟ سيؤدي هذا إلى إزالة منشور التتبع من مذكراتك بشكل دائم.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">حذف الإعدادات؟</string>
     <string name="title_delete_day">حذف اليوم؟</string>
     <string name="title_delete_memo">حذف المذكرة؟</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">تعديل تكوين موجود؟</string>
     <string name="title_edit_day">تعديل اليوم</string>
     <string name="title_edit_memo">تعديل المذكرة</string>
     <string name="title_empty_state_no_habits">لا توجد عادات حتى الآن</string>

--- a/shared/src/commonMain/composeResources/values-az/strings.xml
+++ b/shared/src/commonMain/composeResources/values-az/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Ləğv et</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Yeni konfiqurasiya yarat (tövsiyə olunur)</string>
+    <string name="action_edit_anyway">Yenə də redaktə et</string>
     <string name="action_clear">Təmizlə</string>
     <string name="action_close">Bağla</string>
     <string name="action_copied">Kopyalandı</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Adi</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s-dən aktiv</string>
     <string name="msg_connection_failed">Əlaqə xətası</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Mövcud konfiqurasiyanı redaktə etmək üzrəsiniz. Bu, bütün tarixi məlumatlara təsir edəcək.
+
+Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlki məlumatların görünüşünü dəyişir. Məsələn, yeni bir vərdiş əlavə etsəniz, keçmiş günlərin hamısında o, «tamamlanmayıb» kimi görünəcək, halbuki o vaxt mövcud deyildi.
+
+Ən yaxşı təcrübə: yeni konfiqurasiya yaradın. Tarixi məlumatlar köhnə konfiqurasiyada qalacaq, yeni məlumatlar isə yenisini istifadə edəcək.</string>
     <string name="msg_delete_config_warning">Bu konfiqurasiyanı silmək istədiyinizə əminsiniz? Bu, konfiqurasiya yazısını qeydlərinizdən birdəfəlik siləcək.</string>
     <string name="msg_delete_day_confirm">Vərdiş seçilməyib. Günlük qeyd silinəcək.</string>
     <string name="msg_delete_day_warning">Bu günün qeydini silmək istədiyinizdən əminsiniz? Bu, izləmə yazısını qeydlərinizdən birdəfəlik siləcək.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Konfiqurasiyanı silinsin?</string>
     <string name="title_delete_day">Günü sil?</string>
     <string name="title_delete_memo">Qeydi sil?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Mövcud konfiqurasiyanı redaktə edək?</string>
     <string name="title_edit_day">Günü redaktə et</string>
     <string name="title_edit_memo">Qeydi redaktə et</string>
     <string name="title_empty_state_no_habits">Vərdişlər hələ yoxdur</string>

--- a/shared/src/commonMain/composeResources/values-be/strings.xml
+++ b/shared/src/commonMain/composeResources/values-be/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Скасаваць</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Стварыць новую канфігурацыю (рэкамендавана)</string>
+    <string name="action_edit_anyway">Рэдагаваць усё адно</string>
     <string name="action_clear">Ачысціць</string>
     <string name="action_close">Закрыць</string>
     <string name="action_copied">Скапіявана</string>
@@ -118,9 +118,13 @@
     <string name="filter_regular">Звычайныя</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Актыўна з %1$s</string>
     <string name="msg_connection_failed">Памылка падключэння</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Вы збіраецеся рэдагаваць існуючую канфігурацыю. Гэта паўплывае на ўсе гістарычныя даныя.
+
+Рэдагаваць старую канфігурацыю не рэкамендуецца, бо гэта змяняе адлюстраванне вашых мінулых даных. Напрыклад, калі дадаць новую звычку, усе мінулыя дні пакажуць яе як «не выканана», хоць тады яе яшчэ не існавала.
+
+Лепшая практыка: стварыце новую канфігурацыю. Вашы гістарычныя даныя захаваюць старую канфігурацыю, а новыя даныя будуць выкарыстоўваць новую.</string>
     <string name="msg_delete_config_warning">Вы ўпэўненыя, што хочаце выдаліць гэты канфіг? Допіс з канфігурацыяй будзе выдалены з вашых нататак назаўжды.</string>
     <string name="msg_delete_day_confirm">Звычкі не абраны. Запіс за гэты дзень будзе выдалены.</string>
     <string name="msg_delete_day_warning">Вы ўпэўнены, што жадаеце выдаліць запіс за гэты дзень? Допіс з адзнакамі будзе выдалены з вашых нататак назаўсёды.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Выдаліць канфіг?</string>
     <string name="title_delete_day">Выдаліць дзень?</string>
     <string name="title_delete_memo">Выдаліць нататку?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Рэдагаваць існуючую канфігурацыю?</string>
     <string name="title_edit_day">Рэдагаваць дзень</string>
     <string name="title_edit_memo">Рэдагаваць нататку</string>
     <string name="title_empty_state_no_habits">Звычак пакуль няма</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Abbrechen</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Neue Konfiguration erstellen (empfohlen)</string>
+    <string name="action_edit_anyway">Trotzdem bearbeiten</string>
     <string name="action_clear">Löschen</string>
     <string name="action_close">Schließen</string>
     <string name="action_copied">Kopiert</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Normal</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Aktiv seit %1$s</string>
     <string name="msg_connection_failed">Verbindung fehlgeschlagen</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Du bist dabei, eine bestehende Konfiguration zu bearbeiten. Das wirkt sich auf alle historischen Daten aus.
+
+Das Bearbeiten einer alten Konfiguration wird nicht empfohlen, weil es die Darstellung früherer Daten verändert. Wenn du zum Beispiel eine neue Gewohnheit hinzufügst, werden alle vergangenen Tage sie als „nicht erledigt“ anzeigen, obwohl sie damals noch nicht existierte.
+
+Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Daten behalten die alte Konfiguration, und neue Daten verwenden die neue.</string>
     <string name="msg_delete_config_warning">Sind Sie sicher, dass Sie diese Konfiguration löschen möchten? Der Konfigurationsbeitrag wird dauerhaft aus Ihren Notizen entfernt.</string>
     <string name="msg_delete_day_confirm">Keine Gewohnheiten ausgewählt. Der Tageseintrag wird gelöscht.</string>
     <string name="msg_delete_day_warning">Sind Sie sicher, dass Sie den Eintrag für diesen Tag löschen möchten? Der Tracking-Beitrag wird dauerhaft aus Ihren Notizen entfernt.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Konfiguration löschen?</string>
     <string name="title_delete_day">Tag löschen?</string>
     <string name="title_delete_memo">Notiz löschen?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Bestehende Konfiguration bearbeiten?</string>
     <string name="title_edit_day">Tag bearbeiten</string>
     <string name="title_edit_memo">Notiz bearbeiten</string>
     <string name="title_empty_state_no_habits">Noch keine Gewohnheiten</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Annuler</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Créer une nouvelle configuration (recommandé)</string>
+    <string name="action_edit_anyway">Modifier quand même</string>
     <string name="action_clear">Effacer</string>
     <string name="action_close">Fermer</string>
     <string name="action_copied">Copié</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Normaux</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Actif depuis %1$s</string>
     <string name="msg_connection_failed">Échec de la connexion</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Vous êtes sur le point de modifier une configuration existante. Cela affectera toutes les données historiques.
+
+Modifier une ancienne configuration n’est pas recommandé, car cela change l’affichage de vos données passées. Par exemple, si vous ajoutez une nouvelle habitude, tous les jours passés l’afficheront comme « non effectuée », même si elle n’existait pas à l’époque.
+
+Bonne pratique : créez une nouvelle configuration. Vos données historiques conserveront l’ancienne configuration et les nouvelles données utiliseront la nouvelle.</string>
     <string name="msg_delete_config_warning">Êtes-vous sûr de vouloir supprimer cette configuration ? Cela supprimera définitivement la publication de configuration de vos notes.</string>
     <string name="msg_delete_day_confirm">Aucune habitude sélectionnée. L\'entrée du jour sera supprimée.</string>
     <string name="msg_delete_day_warning">Êtes-vous sûr de vouloir supprimer l\'entrée de ce jour ? Cela supprimera définitivement la publication de suivi de vos notes.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Supprimer la configuration ?</string>
     <string name="title_delete_day">Supprimer le jour ?</string>
     <string name="title_delete_memo">Supprimer la note ?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Modifier la configuration existante ?</string>
     <string name="title_edit_day">Modifier le jour</string>
     <string name="title_edit_memo">Modifier la note</string>
     <string name="title_empty_state_no_habits">Pas encore d\'habitudes</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">रद्द करें</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">नई कॉन्फ़िगरेशन बनाएँ (अनुशंसित)</string>
+    <string name="action_edit_anyway">फिर भी संपादित करें</string>
     <string name="action_clear">साफ़ करें</string>
     <string name="action_close">बंद करें</string>
     <string name="action_copied">कॉपी हुआ</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">सामान्य</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s से सक्रिय</string>
     <string name="msg_connection_failed">कनेक्शन विफल</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">आप एक मौजूदा कॉन्फ़िगरेशन संपादित करने वाले हैं। इससे सभी ऐतिहासिक डेटा प्रभावित होगा।
+
+पुरानी कॉन्फ़िगरेशन संपादित करना अनुशंसित नहीं है, क्योंकि इससे आपके पुराने डेटा का दिखना बदल जाता है। उदाहरण के लिए, यदि आप एक नया habit जोड़ते हैं, तो सभी पुराने दिनों में वह "पूरा नहीं" दिखेगा, जबकि उस समय वह मौजूद नहीं था।
+
+बेहतर तरीका: नई कॉन्फ़िगरेशन बनाएँ। आपका ऐतिहासिक डेटा पुरानी कॉन्फ़िगरेशन के साथ रहेगा और नया डेटा नई कॉन्फ़िगरेशन का उपयोग करेगा।</string>
     <string name="msg_delete_config_warning">क्या आप वाकई इस कॉन्फ़िग को हटाना चाहते हैं? यह आपके मेमो से कॉन्फ़िगरेशन पोस्ट को स्थायी रूप से हटा देगा।</string>
     <string name="msg_delete_day_confirm">कोई आदत चयनित नहीं। दैनिक प्रविष्टि हटा दी जाएगी।</string>
     <string name="msg_delete_day_warning">क्या आप वाकई इस दिन की प्रविष्टि को हटाना चाहते हैं? यह ट्रैकिंग पोस्ट को आपके मेमो से स्थायी रूप से हटा देगा।</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">कॉन्फ़िग हटाएं?</string>
     <string name="title_delete_day">दिन हटाएं?</string>
     <string name="title_delete_memo">मेमो हटाएं?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">मौजूदा कॉन्फ़िगरेशन संपादित करें?</string>
     <string name="title_edit_day">दिन संपादित करें</string>
     <string name="title_edit_memo">मेमो संपादित करें</string>
     <string name="title_empty_state_no_habits">अभी कोई आदत नहीं</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">キャンセル</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">新しい設定を作成（推奨）</string>
+    <string name="action_edit_anyway">それでも編集</string>
     <string name="action_clear">クリア</string>
     <string name="action_close">閉じる</string>
     <string name="action_copied">コピー済み</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">通常</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s からアクティブ</string>
     <string name="msg_connection_failed">接続に失敗しました</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">既存の設定を編集しようとしています。これは過去のすべてのデータに影響します。
+
+古い設定の編集はおすすめしません。過去のデータの見え方が変わってしまうためです。たとえば新しい習慣を追加すると、当時存在しなかったにもかかわらず過去の日付が「未完了」と表示されます。
+
+推奨: 新しい設定を作成してください。過去データは古い設定のまま保持され、新しいデータは新しい設定を使用します。</string>
     <string name="msg_delete_config_warning">この設定を削除してもよろしいですか？これにより、メモから設定投稿が完全に削除されます。</string>
     <string name="msg_delete_day_confirm">習慣が選択されていません。この日のエントリは削除されます。</string>
     <string name="msg_delete_day_warning">この日のエントリーを削除してもよろしいですか？トラッキング投稿がメモから完全に削除されます。</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">設定を削除しますか？</string>
     <string name="title_delete_day">日を削除しますか？</string>
     <string name="title_delete_memo">メモを削除しますか？</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">既存の設定を編集しますか？</string>
     <string name="title_edit_day">日を編集</string>
     <string name="title_edit_memo">メモを編集</string>
     <string name="title_empty_state_no_habits">習慣がありません</string>

--- a/shared/src/commonMain/composeResources/values-ka/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">გაუქმება</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">ახალი კონფიგურაციის შექმნა (რეკომენდებულია)</string>
+    <string name="action_edit_anyway">მაინც რედაქტირება</string>
     <string name="action_clear">გასუფთავება</string>
     <string name="action_close">დახურვა</string>
     <string name="action_copied">კოპირებულია</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">ჩვეულებრივი</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">აქტიური %1$s-დან</string>
     <string name="msg_connection_failed">კავშირის შეცდომა</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">თქვენ აპირებთ არსებული კონფიგურაციის რედაქტირებას. ეს ყველა ისტორიულ მონაცემზე იმოქმედებს.
+
+ძველი კონფიგურაციის რედაქტირება არ არის რეკომენდებული, რადგან ეს ცვლის წარსული მონაცემების ჩვენებას. მაგალითად, თუ დაამატებთ ახალ ჩვევას, ყველა წარსული დღე მას «შეუსრულებლად» აჩვენებს, მიუხედავად იმისა, რომ მაშინ ის არ არსებობდა.
+
+საუკეთესო პრაქტიკა: შექმენით ახალი კონფიგურაცია. ისტორიული მონაცემები დარჩება ძველ კონფიგურაციაზე, ხოლო ახალი მონაცემები გამოიყენებს ახალს.</string>
     <string name="msg_delete_config_warning">დარწმუნებული ხართ, რომ გსურთ ამ კონფიგურაციის წაშლა? ეს სამუდამოდ წაშლის კონფიგურაციის ჩანაწერს თქვენი შენიშვნებიდან.</string>
     <string name="msg_delete_day_confirm">ჩვევები არ არის არჩეული. დღიური ჩანაწერი წაიშლება.</string>
     <string name="msg_delete_day_warning">დარწმუნებული ხართ, რომ გსურთ ამ დღის ჩანაწერის წაშლა? ეს სამუდამოდ წაშლის თვალთვალის ჩანაწერს თქვენი შენიშვნებიდან.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">წაიშალოს კონფიგურაცია?</string>
     <string name="title_delete_day">დღის წაშლა?</string>
     <string name="title_delete_memo">ჩანაწერის წაშლა?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">არსებული კონფიგურაციის რედაქტირება?</string>
     <string name="title_edit_day">დღის რედაქტირება</string>
     <string name="title_edit_memo">ჩანაწერის რედაქტირება</string>
     <string name="title_empty_state_no_habits">ჩვევები ჯერ არ არის</string>

--- a/shared/src/commonMain/composeResources/values-kk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-kk/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Болдырмау</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Жаңа конфигурация жасау (ұсынылады)</string>
+    <string name="action_edit_anyway">Бәрібір өңдеу</string>
     <string name="action_clear">Тазалау</string>
     <string name="action_close">Жабу</string>
     <string name="action_copied">Көшірілді</string>
@@ -118,9 +118,13 @@
     <string name="filter_regular">Қарапайым</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s бастап белсенді</string>
     <string name="msg_connection_failed">Қосылу қатесі</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Сіз қолданыстағы конфигурацияны өңдемекшісіз. Бұл барлық тарихи деректерге әсер етеді.
+
+Ескі конфигурацияны өңдеу ұсынылмайды, өйткені бұл өткен деректердің көрінісін өзгертеді. Мысалы, жаңа әдет қоссanız, өткен күндердің бәрі оны «орындалмаған» деп көрсетеді, ол кезде ол әлі жоқ еді.
+
+Ең дұрыс тәсіл: жаңа конфигурация жасаңыз. Тарихи деректер ескі конфигурацияда қалады, ал жаңа деректер жаңасын қолданады.</string>
     <string name="msg_delete_config_warning">Бұл конфигті жойғыңыз келетініне сенімдісіз бе? Бұл конфигурация жазбасын жазбаларыңыздан біржола жояды.</string>
     <string name="msg_delete_day_confirm">Әдеттер таңдалмаған. Күндік жазба жойылады.</string>
     <string name="msg_delete_day_warning">Осы күннің жазбасын жоюға сенімдісіз бе? Бұл бақылау жазбасын жазбаларыңыздан біржола жояды.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Конфигті жою керек пе?</string>
     <string name="title_delete_day">Күнді жою?</string>
     <string name="title_delete_memo">Жазбаны жою?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Қолданыстағы конфигурацияны өңдеу керек пе?</string>
     <string name="title_edit_day">Күнді өңдеу</string>
     <string name="title_edit_memo">Жазбаны өңдеу</string>
     <string name="title_empty_state_no_habits">Әдеттер әлі жоқ</string>

--- a/shared/src/commonMain/composeResources/values-ky/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ky/strings.xml
@@ -4,8 +4,8 @@
     <string name="action_cancel">Жокко чыгаруу</string>
     <string name="action_clear">Тазалоо</string>
     <string name="action_continue">Улантуу</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Жаңы конфигурация түзүү (сунушталат)</string>
+    <string name="action_edit_anyway">Баары бир түзөтүү</string>
     <string name="action_close">Жабуу</string>
     <string name="action_copied">Көчүрүлдү</string>
     <string name="action_configure_habits">Адаттарды тууралоо</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Кадимки</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$sдөн бери активдүү</string>
     <string name="msg_connection_failed">Байланыш катасы</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Сиз бар болгон конфигурацияны түзөтүүгө баратасыз. Бул бардык тарыхый маалыматтарга таасир этет.
+
+Эски конфигурацияны түзөтүү сунушталбайт, анткени бул мурунку маалыматтардын көрүнүшүн өзгөртөт. Мисалы, жаңы адат кошсоңуз, өткөн күндөрдүн баары аны «аткарылган жок» деп көрсөтөт, ал убакта ал жок болчу.
+
+Эң туурасы: жаңы конфигурация түзүңүз. Тарыхый маалыматтар эски конфигурацияда калат, ал эми жаңы маалыматтар жаңысын колдонушат.</string>
     <string name="msg_delete_config_warning">Бул конфигди өчүргүңүз келгеніне ишенесизби? Бул конфигурация постун жазууларыңыздан биротоло өчүрөт.</string>
     <string name="msg_delete_day_confirm">Адаттар тандалган эмес. Күндүк жазуу өчүрүлөт.</string>
     <string name="msg_delete_day_warning">Бул күндүн жазуусун өчүргүңүз келгенине ишенесизби? Бул көзөмөл постун эстеликтериңизден биротоло өчүрөт.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Конфигди өчүрүү керекпи?</string>
     <string name="title_delete_day">Күндү өчүрүү?</string>
     <string name="title_delete_memo">Жазууну өчүрүү?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Бар болгон конфигурацияны түзөтөлү?</string>
     <string name="title_edit_day">Күндү түзөтүү</string>
     <string name="title_edit_memo">Жазууну түзөтүү</string>
     <string name="title_empty_state_no_habits">Адаттар али жок</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Cancelar</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Criar nova configuração (recomendado)</string>
+    <string name="action_edit_anyway">Editar mesmo assim</string>
     <string name="action_clear">Limpar</string>
     <string name="action_close">Fechar</string>
     <string name="action_copied">Copiado</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Normais</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Ativo desde %1$s</string>
     <string name="msg_connection_failed">Falha na conexão</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Você está prestes a editar uma configuração existente. Isso afetará todos os dados históricos.
+
+Editar uma configuração antiga não é recomendado, pois altera a forma como seus dados anteriores aparecem. Por exemplo, se você adicionar um novo hábito, todos os dias anteriores o mostrarão como "não concluído", mesmo que ele não existisse na época.
+
+Melhor prática: crie uma nova configuração. Seus dados históricos manterão a configuração antiga, e os dados novos usarão a nova.</string>
     <string name="msg_delete_config_warning">Tem certeza de que deseja excluir esta configuração? Isso removerá permanentemente a publicação de configuração de suas notas.</string>
     <string name="msg_delete_day_confirm">Nenhum hábito selecionado. A entrada diária será excluída.</string>
     <string name="msg_delete_day_warning">Tem certeza de que deseja excluir a entrada deste dia? Isso removerá permanentemente a publicação de rastreamento das suas notas.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Excluir configuração?</string>
     <string name="title_delete_day">Excluir dia?</string>
     <string name="title_delete_memo">Excluir nota?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Editar configuração existente?</string>
     <string name="title_edit_day">Editar dia</string>
     <string name="title_edit_memo">Editar nota</string>
     <string name="title_empty_state_no_habits">Ainda sem hábitos</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -4,8 +4,8 @@
     <string name="action_cancel">Anulare</string>
     <string name="action_clear">Curăță</string>
     <string name="action_continue">Continuă</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Creează o configurație nouă (recomandat)</string>
+    <string name="action_edit_anyway">Editează oricum</string>
     <string name="action_close">Închide</string>
     <string name="action_copied">Copiat</string>
     <string name="action_configure_habits">Configurare obiceiuri</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Obișnuite</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Activ din %1$s</string>
     <string name="msg_connection_failed">Conexiune eșuată</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Ești pe cale să editezi o configurație existentă. Acest lucru va afecta toate datele istorice.
+
+Editarea unei configurații vechi nu este recomandată, deoarece schimbă modul în care apar datele tale anterioare. De exemplu, dacă adaugi un obicei nou, toate zilele trecute îl vor arăta ca «nefinalizat», deși atunci nu exista.
+
+Cea mai bună practică: creează o configurație nouă. Datele tale istorice vor păstra configurația veche, iar datele noi vor folosi configurația nouă.</string>
     <string name="msg_delete_config_warning">Sigur doriți să ștergeți această configurație? Aceasta va elimina definitiv postarea de configurare din notele dvs.</string>
     <string name="msg_delete_day_confirm">Niciun obicei selectat. Înregistrarea zilnică va fi ștearsă.</string>
     <string name="msg_delete_day_warning">Sunteți sigur că doriți să ștergeți înregistrarea acestei zile? Aceasta va elimina definitiv postarea de urmărire din notițele dumneavoastră.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Ștergeți configurația?</string>
     <string name="title_delete_day">Șterge ziua?</string>
     <string name="title_delete_memo">Șterge nota?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Editezi configurația existentă?</string>
     <string name="title_edit_day">Editează ziua</string>
     <string name="title_edit_memo">Editează nota</string>
     <string name="title_empty_state_no_habits">Încă niciun obicei</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -7,23 +7,23 @@
     <string name="action_configure_habits">Настроить привычки</string>
     <string name="action_create">Создать</string>
     <string name="action_create_first_habit">Создать первую привычку</string>
-    <string name="action_create_memo">Создать заметку</string>
-    <string name="action_create_new_config">Создать новый конфиг (рекомендуется)</string>
+    <string name="action_create_memo">Создать воспоминание</string>
+    <string name="action_create_new_config">Создать новую конфигурацию (рекомендуется)</string>
     <string name="action_continue">Продолжить</string>
     <string name="action_delete">Удалить</string>
     <string name="action_add_first_habit">Добавить первую привычку</string>
-    <string name="action_edit_anyway">Все равно редактировать</string>
+    <string name="action_edit_anyway">Всё равно редактировать</string>
     <string name="action_go_to_dashboard">Перейти к панели</string>
-    <string name="action_hide_details">Скрыть детали</string>
-    <string name="action_mark_first_checkin">Отметить первую запись</string>
-    <string name="action_maybe_later">Может быть позже</string>
-    <string name="action_next">Вперед</string>
+    <string name="action_hide_details">Скрыть детали привычки</string>
+    <string name="action_mark_first_checkin">Сделать первую отметку</string>
+    <string name="action_maybe_later">Позже</string>
+    <string name="action_next">Далее</string>
     <string name="action_previous">Назад</string>
     <string name="action_refresh">Обновить</string>
     <string name="action_reset">Сбросить</string>
-    <string name="action_reset_app">Сбросить</string>
+    <string name="action_reset_app">Сбросить приложение</string>
     <string name="action_save">Сохранить</string>
-    <string name="action_show_details">Показать детали</string>
+    <string name="action_show_details">Показать детали привычки</string>
     <string name="action_start_tracking">Начать отслеживание</string>
     <string name="action_track">Отметить</string>
     <string name="action_track_today">Отметить сегодня</string>
@@ -64,35 +64,35 @@
     <!-- Format strings -->
     <string name="format_active_since">Активно с %1$s</string>
     <string name="format_app_version">Версия: %1$s</string>
-    <string name="format_credentials">Креденшелы: %1$s</string>
+    <string name="format_credentials">Учётные данные: %1$s</string>
     <string name="format_environment">Окружение: %1$s</string>
     <string name="format_habits_progress">Выполнено привычек: %1$d из %2$d</string>
-    <string name="format_memos_db">Memos DB: %1$s</string>
+    <string name="format_memos_db">База Memos: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
-    <string name="format_tooltip_habits">%1$s: привычек %2$d/%3$d</string>
-    <string name="format_tooltip_memos">%1$s: воспоминаний %2$d</string>
+    <string name="format_tooltip_habits">%1$s: %2$d/%3$d привычек</string>
+    <string name="format_tooltip_memos">%1$s: %2$d воспоминаний</string>
     <string name="format_memos_count">%1$d воспоминаний</string>
     <string name="format_memos_today">%1$d воспоминаний сегодня</string>
     <string name="format_memos_this_week">%1$d воспоминаний за неделю</string>
-    <string name="format_memos_in_month">%1$d воспоминаний за %2$s</string>
-    <string name="format_memos_in_quarter">%1$d воспоминаний за %2$s</string>
+    <string name="format_memos_in_month">%1$d воспоминаний в %2$s</string>
+    <string name="format_memos_in_quarter">%1$d воспоминаний в %2$s</string>
     <string name="format_memos_in_year">%1$d воспоминаний за %2$d</string>
     <string name="action_show_memos">Показать воспоминания</string>
     <string name="action_hide_memos">Скрыть воспоминания</string>
     <string name="action_write">Написать</string>
 
     <!-- Hints -->
-    <string name="hint_add_habits_config">Добавьте заметку с конфигурацией привычек, чтобы начать отслеживание.</string>
+    <string name="hint_add_habits_config">Добавьте воспоминание с конфигурацией привычек, чтобы начать отслеживание.</string>
     <string name="hint_base_url">https://memos.example.com</string>
-    <string name="hint_habit_name">например, Утренняя зарядка</string>
+    <string name="hint_habit_name">Название привычки</string>
     <string name="hint_habits_config">Гимнастика | #habits/gym\nЧтение | #habits/reading</string>
-    <string name="hint_write_memo">Напишите заметку...</string>
+    <string name="hint_write_memo">Напишите воспоминание...</string>
 
     <!-- Labels -->
     <string name="label_access_token">Токен доступа</string>
     <string name="label_activity">Активность</string>
     <string name="label_app_mode">Режим приложения</string>
-    <string name="label_base_url">Base URL</string>
+    <string name="label_base_url">URL сервера</string>
     <string name="label_credentials">Учётные данные</string>
     <string name="label_demo_mode">Демо-режим</string>
     <string name="label_environment">Окружение</string>
@@ -101,10 +101,10 @@
     <string name="label_habit_name">Название привычки</string>
     <string name="label_habit_preset_custom">Создать свою</string>
     <string name="label_language">Язык</string>
-    <string name="label_memos_db">База заметок</string>
-    <string name="label_post_filter">Фильтр</string>
+    <string name="label_memos_db">База воспоминаний</string>
+    <string name="label_post_filter">Фильтр записей</string>
     <string name="label_storage">Хранилище</string>
-    <string name="label_success_rate">Успешность</string>
+    <string name="label_success_rate">Процент выполнения</string>
     <string name="label_time_day">День</string>
     <string name="label_time_evening">Вечер</string>
     <string name="label_time_morning">Утро</string>
@@ -114,30 +114,30 @@
 
     <!-- Filter options -->
     <string name="filter_all">Все</string>
-    <string name="filter_config">Настройки</string>
+    <string name="filter_config">Конфигурации</string>
     <string name="filter_habit_tracking">Отметки</string>
     <string name="filter_regular">Обычные</string>
 
     <!-- Messages -->
     <string name="msg_connection_failed">Ошибка подключения</string>
-    <string name="msg_delete_config_warning">Вы уверены, что хотите удалить этот конфиг? Пост с конфигурацией будет удален из ваших заметок навсегда.</string>
+    <string name="msg_delete_config_warning">Вы уверены, что хотите удалить эту конфигурацию? Запись с конфигурацией будет навсегда удалена из ваших воспоминаний.</string>
     <string name="msg_delete_day_confirm">Привычки не выбраны. Запись за этот день будет удалена.</string>
-    <string name="msg_delete_day_warning">Вы уверены, что хотите удалить запись за этот день? Пост с отметками будет удален из ваших заметок навсегда.</string>
-    <string name="msg_edit_config_warning">Вы собираетесь перезаписать существующий конфиг. Это повлияет на все исторические данные.\n\nРедактирование старого конфига не рекомендуется, так как это изменит отображение прошлых данных. Например, если вы добавите новую привычку, все прошлые дни покажут её как "не выполненную", хотя её тогда еще не существовало.\n\nЛучшая практика: Создайте новый конфиг. Ваши исторические данные сохранят старый конфиг, а новые данные будут использовать новый конфиг.</string>
-    <string name="msg_empty_state_no_habits">Создайте привычку, чтобы начать отслеживание в оффлайн-режиме.</string>
+    <string name="msg_delete_day_warning">Вы уверены, что хотите удалить запись за этот день? Запись с отметками будет навсегда удалена из ваших воспоминаний.</string>
+    <string name="msg_edit_config_warning">Вы собираетесь отредактировать существующую конфигурацию. Это повлияет на все исторические данные.\n\nРедактировать старую конфигурацию не рекомендуется, потому что это меняет отображение прошлых данных. Например, если добавить новую привычку, прошлые дни покажут её как «не выполнено», хотя тогда её ещё не существовало.\n\nЛучшее решение: создайте новую конфигурацию. Исторические данные сохранят старую конфигурацию, а новые данные будут использовать новую.</string>
+    <string name="msg_empty_state_no_habits">Создайте привычку, чтобы начать отслеживание офлайн.</string>
     <string name="msg_fill_all_fields">Заполните все поля</string>
     <string name="msg_habit_name_required">Название привычки обязательно</string>
     <string name="msg_habit_setup">Придумайте осмысленное название для вашей привычки.</string>
-    <string name="msg_no_habits_yet">Привычки еще не настроены.</string>
+    <string name="msg_no_habits_yet">Привычки ещё не настроены.</string>
     <string name="msg_no_logs">Логов пока нет</string>
-    <string name="msg_no_memos_yet">Нет записей за этот период.</string>
+    <string name="msg_no_memos_yet">Нет воспоминаний за этот период.</string>
     <string name="msg_reset_confirm">Вы уверены, что хотите сбросить приложение? Все данные будут удалены.</string>
     <string name="msg_select_habit">Выберите хотя бы одну привычку.</string>
     <string name="msg_mark_done_confirm">Отметить «%1$s» как выполненную за %2$s?</string>
     <string name="msg_mark_not_done_confirm">Снять отметку с «%1$s» за %2$s?</string>
-    <string name="msg_offline_onboarding_success">Все готово. Отметьте первую запись сегодня.</string>
+    <string name="msg_offline_onboarding_success">Всё готово. Сделайте первую отметку сегодня.</string>
     <string name="msg_offline_onboarding_welcome">Отслеживайте привычки локально на вашем устройстве. Аккаунт не требуется.</string>
-    <string name="msg_restart_required">Для применения требуется перезапуск</string>
+    <string name="msg_restart_required">Перезапустите приложение, чтобы применить язык</string>
 
     <!-- Language selection -->
     <string name="language_system">Системный</string>
@@ -176,9 +176,9 @@
     <string name="mode_offline_title">Офлайн</string>
     <string name="mode_offline_desc">Хранение данных локально без подключения к серверу</string>
     <string name="mode_demo_title">Демо</string>
-    <string name="mode_demo_desc">Попробовать приложение с примером данных</string>
-    <string name="mode_quick_online_title">Найдены учетные данные</string>
-    <string name="mode_quick_online_desc">Обнаружены сохраненные учетные данные. Использовать их для быстрого подключения?</string>
+    <string name="mode_demo_desc">Попробовать приложение с примерными данными</string>
+    <string name="mode_quick_online_title">Найдены учётные данные</string>
+    <string name="mode_quick_online_desc">Найдены сохранённые учётные данные. Использовать их для быстрого подключения?</string>
     <string name="action_use_saved">Использовать</string>
 
     <!-- Navigation -->
@@ -204,19 +204,19 @@
     <!-- Titles -->
     <string name="title_choose_starter_habit">Выберите начальную привычку</string>
     <string name="title_create_day">Создать день</string>
-    <string name="title_delete_config">Удалить конфиг?</string>
+    <string name="title_delete_config">Удалить конфигурацию?</string>
     <string name="title_delete_day">Удалить день?</string>
-    <string name="title_delete_memo">Удалить заметку?</string>
-    <string name="title_edit_config_warning">Редактировать существующий конфиг?</string>
+    <string name="title_delete_memo">Удалить воспоминание?</string>
+    <string name="title_edit_config_warning">Редактировать существующую конфигурацию?</string>
     <string name="title_edit_day">Изменить день</string>
-    <string name="title_edit_memo">Редактировать заметку</string>
+    <string name="title_edit_memo">Редактировать воспоминание</string>
     <string name="title_empty_state_no_habits">Привычек пока нет</string>
-    <string name="title_habit_setup">Настройте вашу привычку</string>
+    <string name="title_habit_setup">Настройте привычку</string>
     <string name="title_logs">Логи (%1$d)</string>
-    <string name="title_new_memo">Новая заметка</string>
+    <string name="title_new_memo">Новое воспоминание</string>
     <string name="title_offline_onboarding_success">Отличная работа!</string>
-    <string name="title_offline_onboarding_welcome">Оффлайн-режим готов</string>
-    <string name="title_mark_done">Отметить выполнение?</string>
+    <string name="title_offline_onboarding_welcome">Офлайн-режим готов</string>
+    <string name="title_mark_done">Отметить как выполнено?</string>
     <string name="title_mark_not_done">Снять отметку?</string>
     <string name="title_update_day">Обновить день</string>
 
@@ -224,9 +224,9 @@
     <string name="demo_habit_exercise">Зарядка</string>
     <string name="demo_habit_reading">Чтение</string>
     <string name="demo_habit_meditation">Медитация</string>
-    <string name="demo_habit_water">Вода</string>
-    <string name="demo_habit_learning">Обучение</string>
+    <string name="demo_habit_water">Пить воду</string>
+    <string name="demo_habit_learning">Обучаться</string>
     <string name="demo_habit_walking">10К шагов</string>
     <string name="demo_habit_no_sugar">Без сахара</string>
-    <string name="demo_habit_early_sleep">Сон до 23:00</string>
+    <string name="demo_habit_early_sleep">Лечь до 23:00</string>
 </resources>

--- a/shared/src/commonMain/composeResources/values-tg/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tg/strings.xml
@@ -4,8 +4,8 @@
     <string name="action_cancel">Бекор кардан</string>
     <string name="action_clear">Тоза кардан</string>
     <string name="action_continue">Идома додан</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Эҷоди конфигуратсияи нав (тавсия мешавад)</string>
+    <string name="action_edit_anyway">Бо вуҷуди ин таҳрир кардан</string>
     <string name="action_close">Пӯшидан</string>
     <string name="action_copied">Нусхабардорӣ шуд</string>
     <string name="action_configure_habits">Танзими одатҳо</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Оддӣ</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Фаъол аз %1$s</string>
     <string name="msg_connection_failed">Хатои пайвастшавӣ</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Шумо мехоҳед конфигуратсияи мавҷударо таҳрир кунед. Ин ба ҳамаи маълумоти таърихӣ таъсир мерасонад.
+
+Таҳрири конфигуратсияи кӯҳна тавсия намешавад, зеро он намуди маълумоти гузаштаатонро тағйир медиҳад. Масалан, агар одати нав илова кунед, ҳамаи рӯзҳои гузашта онро ҳамчун «иҷро нашудааст» нишон медиҳанд, гарчанде он вақт вуҷуд надошт.
+
+Амали беҳтарин: конфигуратсияи нав эҷод кунед. Маълумоти таърихӣ бо конфигуратсияи кӯҳна мемонад, маълумоти нав бошад конфигуратсияи навро истифода мебарад.</string>
     <string name="msg_delete_config_warning">Шумо мутмаин ҳастед, ки мехоҳед ин конфигро нест кунед? Ин постро аз хотиротҳои шумо назди ҳамеша нест мекунад.</string>
     <string name="msg_delete_day_confirm">Одат интихоб нашудааст. Сабти рӯзона нест мешавад.</string>
     <string name="msg_delete_day_warning">Оё шумо мутмаин ҳастед, ки мехоҳед сабти ин рӯзро нест кунед? Ин постро аз ёддоштҳои шумо ҳамешагӣ нест мекунад.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Конфигро нест кунем?</string>
     <string name="title_delete_day">Рӯзро нест кунем?</string>
     <string name="title_delete_memo">Ёддоштро нест кунем?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Конфигуратсияи мавҷударо таҳрир мекунед?</string>
     <string name="title_edit_day">Таҳрири рӯз</string>
     <string name="title_edit_memo">Таҳрири ёддошт</string>
     <string name="title_empty_state_no_habits">Одатҳо ҳанӯз нестанд</string>

--- a/shared/src/commonMain/composeResources/values-tk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tk/strings.xml
@@ -4,8 +4,8 @@
     <string name="action_cancel">Ýatyr</string>
     <string name="action_clear">Arassala</string>
     <string name="action_continue">Dowam et</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Täze konfigurasiýa döretmek (maslahat berilýär)</string>
+    <string name="action_edit_anyway">Şonda-da redaktirlemek</string>
     <string name="action_close">Ýap</string>
     <string name="action_copied">Göçürildi</string>
     <string name="action_configure_habits">Endikleri düz</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Adaty</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s-den bäri işjeň</string>
     <string name="msg_connection_failed">Baglanşyk ýalňyşlygy</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Bar bolan konfigurasiýany redaktirlemekçi bolýarsyňyz. Bu ähli taryhy maglumatlara täsir eder.
+
+Köne konfigurasiýany redaktirlemek maslahat berilmeýär, sebäbi bu geçmişdäki maglumatlaryň görünüşini üýtgedýär. Mysal üçin, täze endik goşsaňyz, öňki günleriň hemmesi ony «tamamlanmady» diýip görkezer, ol wagtda bolsa ol ýokdy.
+
+Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigurasiýada galar, täze maglumatlar bolsa täzesini ulanar.</string>
     <string name="msg_delete_config_warning">Bu konfigurasiýany öçürmek isleýärsiňizmi? Bu ýazgy postyny ýazgylardan hemişelik aýyrar.</string>
     <string name="msg_delete_day_confirm">Endik saýlanmady. Gündelik ýazgy öçüriler.</string>
     <string name="msg_delete_day_warning">Bu günüň ýazgysyny öçürmek isleýärsiňizmi? Bu yzarlamak ýazgysyny belliklerňizden hemişelik aýyrar.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Konfigurasiýany öçürmeli?</string>
     <string name="title_delete_day">Güni poz?</string>
     <string name="title_delete_memo">Belligi poz?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Bar bolan konfigurasiýany redaktirleýärsiňizmi?</string>
     <string name="title_edit_day">Güni redaktirle</string>
     <string name="title_edit_memo">Belligi redaktirle</string>
     <string name="title_empty_state_no_habits">Endikler heniz ýok</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Скасувати</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Створити нову конфігурацію (рекомендовано)</string>
+    <string name="action_edit_anyway">Редагувати все одно</string>
     <string name="action_clear">Очистити</string>
     <string name="action_close">Закрити</string>
     <string name="action_copied">Скопійовано</string>
@@ -118,9 +118,13 @@
     <string name="filter_regular">Звичайні</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">Активно з %1$s</string>
     <string name="msg_connection_failed">Помилка підключення</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Ви збираєтеся редагувати наявну конфігурацію. Це вплине на всі історичні дані.
+
+Редагувати стару конфігурацію не рекомендується, бо це змінює відображення ваших минулих даних. Наприклад, якщо додати нову звичку, усі минулі дні покажуть її як «не виконано», хоча тоді її ще не існувало.
+
+Найкраща практика: створіть нову конфігурацію. Історичні дані збережуть стару конфігурацію, а нові дані використовуватимуть нову.</string>
     <string name="msg_delete_config_warning">Ви впевнені, що хочете видалити цей конфіг? Пост з конфігурацією буде видалено з ваших нотаток назавжди.</string>
     <string name="msg_delete_day_confirm">Звички не обрано. Запис за цей день буде видалено.</string>
     <string name="msg_delete_day_warning">Ви впевнені, що хочете видалити запис за цей день? Пост з відмітками буде видалено з ваших нотаток назавжди.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Видалити конфіг?</string>
     <string name="title_delete_day">Видалити день?</string>
     <string name="title_delete_memo">Видалити нотатку?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Редагувати наявну конфігурацію?</string>
     <string name="title_edit_day">Редагувати день</string>
     <string name="title_edit_memo">Редагувати нотатку</string>
     <string name="title_empty_state_no_habits">Звичок поки немає</string>

--- a/shared/src/commonMain/composeResources/values-uz/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uz/strings.xml
@@ -1,8 +1,8 @@
 <resources>
     <!-- Actions -->
     <string name="action_cancel">Bekor qilish</string>
-    <string name="action_create_new_config">Create New Config (Recommended)</string>
-    <string name="action_edit_anyway">Edit Anyway</string>
+    <string name="action_create_new_config">Yangi konfiguratsiya yaratish (tavsiya etiladi)</string>
+    <string name="action_edit_anyway">Baribir tahrirlash</string>
     <string name="action_clear">Tozalash</string>
     <string name="action_close">Yopish</string>
     <string name="action_copied">Nusxalandi</string>
@@ -119,9 +119,13 @@
     <string name="filter_regular">Oddiy</string>
 
     <!-- Messages -->
-    <string name="format_active_since">Active since %1$s</string>
+    <string name="format_active_since">%1$s dan beri faol</string>
     <string name="msg_connection_failed">Ulanish xatosi</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Siz mavjud konfiguratsiyani tahrirlash arafasidiz. Bu barcha tarixiy ma'lumotlarga ta'sir qiladi.
+
+Eski konfiguratsiyani tahrirlash tavsiya etilmaydi, chunki bu o'tgan ma'lumotlarning ko'rinishini o'zgartiradi. Masalan, yangi odat qo'shsangiz, o'tgan kunlarning barchasi uni «bajarilmagan» deb ko'rsatadi, garchi u o'shanda mavjud bo'lmagan.
+
+Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfiguratsiyada qoladi, yangi ma'lumotlar esa yangisini ishlatadi.</string>
     <string name="msg_delete_config_warning">Ushbu konfigni o'chirishga ishonchingiz komilmi? Bu konfiguratsiya postini eslatmalaringizdan butunlay o'chiradi.</string>
     <string name="msg_delete_day_confirm">Odatlar tanlanmagan. Kunlik yozuv o\'chiriladi.</string>
     <string name="msg_delete_day_warning">Ushbu kunning yozuvini o\'chirishga aminmisiz? Bu kuzatuv postini eslatmalaringizdan butunlay olib tashlaydi.</string>
@@ -207,7 +211,7 @@
     <string name="title_delete_config">Konfigni o'chirish kerakmi?</string>
     <string name="title_delete_day">Kunni o\'chirish?</string>
     <string name="title_delete_memo">Eslatmani o\'chirish?</string>
-    <string name="title_edit_config_warning">Edit Existing Config?</string>
+    <string name="title_edit_config_warning">Mavjud konfiguratsiyani tahrirlash kerakmi?</string>
     <string name="title_edit_day">Kunni tahrirlash</string>
     <string name="title_edit_memo">Eslatmani tahrirlash</string>
     <string name="title_empty_state_no_habits">Odatlar hali yo'q</string>


### PR DESCRIPTION
## Summary
Improve translations across all locales for more natural and accurate phrasing.

## Changes
- Update Russian translations for better natural language (заметка → воспоминание, креденшелы → учётные данные, etc.)
- Improve consistency and readability across 17 locale files
- Update AGENTS.md documentation

## Test plan
- [x] All 20 locales still have 197 strings
- [x] Pre-commit checks pass
- [ ] Verify translations in app

🤖 Generated with [Claude Code](https://claude.com/claude-code)