### PR TITLE
Replace onboarding preset emojis with Material icons

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/model/DemoHabits.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/model/DemoHabits.kt
@@ -29,6 +29,20 @@ object DemoHabits {
 }
 
 /**
+ * String resource keys for demo habits.
+ */
+object DemoHabitStringKeys {
+  const val EXERCISE = "demo_habit_exercise"
+  const val READING = "demo_habit_reading"
+  const val MEDITATION = "demo_habit_meditation"
+  const val WATER = "demo_habit_water"
+  const val LEARNING = "demo_habit_learning"
+  const val WALKING = "demo_habit_walking"
+  const val NO_SUGAR = "demo_habit_no_sugar"
+  const val EARLY_SLEEP = "demo_habit_early_sleep"
+}
+
+/**
  * Checks if the habit is a predefined demo habit.
  */
 fun HabitConfig.isDemoHabit(): Boolean = DemoHabits.TAGS.contains(tag)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/DemoHabitLabels.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/DemoHabitLabels.kt
@@ -1,19 +1,10 @@
 package space.be1ski.vibits.shared.feature.habits.view.components
 
 import androidx.compose.runtime.Composable
-import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabitStringKeys
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.shared.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.shared.feature.memos.domain.model.PostTags
-import space.be1ski.vibits.shared.generated.Res
-import space.be1ski.vibits.shared.generated.demo_habit_early_sleep
-import space.be1ski.vibits.shared.generated.demo_habit_exercise
-import space.be1ski.vibits.shared.generated.demo_habit_learning
-import space.be1ski.vibits.shared.generated.demo_habit_meditation
-import space.be1ski.vibits.shared.generated.demo_habit_no_sugar
-import space.be1ski.vibits.shared.generated.demo_habit_reading
-import space.be1ski.vibits.shared.generated.demo_habit_walking
-import space.be1ski.vibits.shared.generated.demo_habit_water
 
 /**
  * Returns localized label for demo habits when in demo mode.
@@ -22,19 +13,18 @@ import space.be1ski.vibits.shared.generated.demo_habit_water
 @Composable
 fun HabitConfig.localizedLabel(demoMode: Boolean): String {
   if (!demoMode) return label
-  return demoHabitLabel(tag) ?: label
+  return demoHabitLabel(tag)?.let { localizedDemoHabitName(it) } ?: label
 }
 
-@Composable
 private fun demoHabitLabel(tag: String): String? =
   when (tag) {
-    "${PostTags.HABITS_PREFIX}${DemoHabits.EXERCISE}" -> stringResource(Res.string.demo_habit_exercise)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.READING}" -> stringResource(Res.string.demo_habit_reading)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.MEDITATION}" -> stringResource(Res.string.demo_habit_meditation)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.WATER}" -> stringResource(Res.string.demo_habit_water)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.LEARNING}" -> stringResource(Res.string.demo_habit_learning)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.WALKING}" -> stringResource(Res.string.demo_habit_walking)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.NO_SUGAR}" -> stringResource(Res.string.demo_habit_no_sugar)
-    "${PostTags.HABITS_PREFIX}${DemoHabits.EARLY_SLEEP}" -> stringResource(Res.string.demo_habit_early_sleep)
+    "${PostTags.HABITS_PREFIX}${DemoHabits.EXERCISE}" -> DemoHabitStringKeys.EXERCISE
+    "${PostTags.HABITS_PREFIX}${DemoHabits.READING}" -> DemoHabitStringKeys.READING
+    "${PostTags.HABITS_PREFIX}${DemoHabits.MEDITATION}" -> DemoHabitStringKeys.MEDITATION
+    "${PostTags.HABITS_PREFIX}${DemoHabits.WATER}" -> DemoHabitStringKeys.WATER
+    "${PostTags.HABITS_PREFIX}${DemoHabits.LEARNING}" -> DemoHabitStringKeys.LEARNING
+    "${PostTags.HABITS_PREFIX}${DemoHabits.WALKING}" -> DemoHabitStringKeys.WALKING
+    "${PostTags.HABITS_PREFIX}${DemoHabits.NO_SUGAR}" -> DemoHabitStringKeys.NO_SUGAR
+    "${PostTags.HABITS_PREFIX}${DemoHabits.EARLY_SLEEP}" -> DemoHabitStringKeys.EARLY_SLEEP
     else -> null
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/DemoHabitStrings.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/DemoHabitStrings.kt
@@ -1,0 +1,31 @@
+package space.be1ski.vibits.shared.feature.habits.view.components
+
+import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabitStringKeys
+import space.be1ski.vibits.shared.generated.Res
+import space.be1ski.vibits.shared.generated.demo_habit_early_sleep
+import space.be1ski.vibits.shared.generated.demo_habit_exercise
+import space.be1ski.vibits.shared.generated.demo_habit_learning
+import space.be1ski.vibits.shared.generated.demo_habit_meditation
+import space.be1ski.vibits.shared.generated.demo_habit_no_sugar
+import space.be1ski.vibits.shared.generated.demo_habit_reading
+import space.be1ski.vibits.shared.generated.demo_habit_walking
+import space.be1ski.vibits.shared.generated.demo_habit_water
+
+/**
+ * Returns localized name for a demo habit by its string key.
+ */
+@Composable
+fun localizedDemoHabitName(nameKey: String): String =
+  when (nameKey) {
+    DemoHabitStringKeys.EXERCISE -> stringResource(Res.string.demo_habit_exercise)
+    DemoHabitStringKeys.WATER -> stringResource(Res.string.demo_habit_water)
+    DemoHabitStringKeys.READING -> stringResource(Res.string.demo_habit_reading)
+    DemoHabitStringKeys.MEDITATION -> stringResource(Res.string.demo_habit_meditation)
+    DemoHabitStringKeys.WALKING -> stringResource(Res.string.demo_habit_walking)
+    DemoHabitStringKeys.LEARNING -> stringResource(Res.string.demo_habit_learning)
+    DemoHabitStringKeys.NO_SUGAR -> stringResource(Res.string.demo_habit_no_sugar)
+    DemoHabitStringKeys.EARLY_SLEEP -> stringResource(Res.string.demo_habit_early_sleep)
+    else -> nameKey
+  }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -17,14 +17,14 @@ interface HabitPresetsDataSource {
 class HabitPresetsDataSourceImpl : HabitPresetsDataSource {
   override fun getPresets(): List<HabitPreset> =
     listOf(
-      HabitPreset(id = DemoHabits.EXERCISE, nameKey = "demo_habit_exercise", icon = "🏃"),
-      HabitPreset(id = DemoHabits.WATER, nameKey = "demo_habit_water", icon = "💧"),
-      HabitPreset(id = DemoHabits.READING, nameKey = "demo_habit_reading", icon = "📚"),
-      HabitPreset(id = DemoHabits.MEDITATION, nameKey = "demo_habit_meditation", icon = "🧘"),
-      HabitPreset(id = DemoHabits.WALKING, nameKey = "demo_habit_walking", icon = "🚶"),
-      HabitPreset(id = DemoHabits.LEARNING, nameKey = "demo_habit_learning", icon = "📖"),
-      HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = "demo_habit_no_sugar", icon = "🍬"),
-      HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = "demo_habit_early_sleep", icon = "😴"),
-      HabitPreset(id = "custom", nameKey = "label_habit_preset_custom", icon = "✨"),
+      HabitPreset(id = DemoHabits.EXERCISE, nameKey = "demo_habit_exercise"),
+      HabitPreset(id = DemoHabits.WATER, nameKey = "demo_habit_water"),
+      HabitPreset(id = DemoHabits.READING, nameKey = "demo_habit_reading"),
+      HabitPreset(id = DemoHabits.MEDITATION, nameKey = "demo_habit_meditation"),
+      HabitPreset(id = DemoHabits.WALKING, nameKey = "demo_habit_walking"),
+      HabitPreset(id = DemoHabits.LEARNING, nameKey = "demo_habit_learning"),
+      HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = "demo_habit_no_sugar"),
+      HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = "demo_habit_early_sleep"),
+      HabitPreset(id = "custom", nameKey = "label_habit_preset_custom"),
     )
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -4,6 +4,7 @@ import dev.zacsweers.metro.ContributesBinding
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.shared.app.di.AppScope
+import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabitStringKeys
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 
@@ -17,14 +18,14 @@ interface HabitPresetsDataSource {
 class HabitPresetsDataSourceImpl : HabitPresetsDataSource {
   override fun getPresets(): List<HabitPreset> =
     listOf(
-      HabitPreset(id = DemoHabits.EXERCISE, nameKey = "demo_habit_exercise"),
-      HabitPreset(id = DemoHabits.WATER, nameKey = "demo_habit_water"),
-      HabitPreset(id = DemoHabits.READING, nameKey = "demo_habit_reading"),
-      HabitPreset(id = DemoHabits.MEDITATION, nameKey = "demo_habit_meditation"),
-      HabitPreset(id = DemoHabits.WALKING, nameKey = "demo_habit_walking"),
-      HabitPreset(id = DemoHabits.LEARNING, nameKey = "demo_habit_learning"),
-      HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = "demo_habit_no_sugar"),
-      HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = "demo_habit_early_sleep"),
+      HabitPreset(id = DemoHabits.EXERCISE, nameKey = DemoHabitStringKeys.EXERCISE),
+      HabitPreset(id = DemoHabits.WATER, nameKey = DemoHabitStringKeys.WATER),
+      HabitPreset(id = DemoHabits.READING, nameKey = DemoHabitStringKeys.READING),
+      HabitPreset(id = DemoHabits.MEDITATION, nameKey = DemoHabitStringKeys.MEDITATION),
+      HabitPreset(id = DemoHabits.WALKING, nameKey = DemoHabitStringKeys.WALKING),
+      HabitPreset(id = DemoHabits.LEARNING, nameKey = DemoHabitStringKeys.LEARNING),
+      HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = DemoHabitStringKeys.NO_SUGAR),
+      HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = DemoHabitStringKeys.EARLY_SLEEP),
       HabitPreset(id = "custom", nameKey = "label_habit_preset_custom"),
     )
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/model/HabitPreset.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/model/HabitPreset.kt
@@ -3,5 +3,4 @@ package space.be1ski.vibits.shared.feature.onboarding.domain.model
 data class HabitPreset(
   val id: String,
   val nameKey: String,
-  val icon: String? = null,
 )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
@@ -41,33 +41,18 @@ import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.theme.AppColors
 import space.be1ski.vibits.shared.core.ui.theme.resolve
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
+import space.be1ski.vibits.shared.feature.habits.view.components.localizedDemoHabitName
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_continue
-import space.be1ski.vibits.shared.generated.demo_habit_early_sleep
-import space.be1ski.vibits.shared.generated.demo_habit_exercise
-import space.be1ski.vibits.shared.generated.demo_habit_learning
-import space.be1ski.vibits.shared.generated.demo_habit_meditation
-import space.be1ski.vibits.shared.generated.demo_habit_no_sugar
-import space.be1ski.vibits.shared.generated.demo_habit_reading
-import space.be1ski.vibits.shared.generated.demo_habit_walking
-import space.be1ski.vibits.shared.generated.demo_habit_water
 import space.be1ski.vibits.shared.generated.label_habit_preset_custom
 import space.be1ski.vibits.shared.generated.title_choose_starter_habit
 
 @Composable
 private fun HabitPreset.localizedName(): String =
   when (nameKey) {
-    "demo_habit_exercise" -> stringResource(Res.string.demo_habit_exercise)
-    "demo_habit_water" -> stringResource(Res.string.demo_habit_water)
-    "demo_habit_reading" -> stringResource(Res.string.demo_habit_reading)
-    "demo_habit_meditation" -> stringResource(Res.string.demo_habit_meditation)
-    "demo_habit_walking" -> stringResource(Res.string.demo_habit_walking)
-    "demo_habit_learning" -> stringResource(Res.string.demo_habit_learning)
-    "demo_habit_no_sugar" -> stringResource(Res.string.demo_habit_no_sugar)
-    "demo_habit_early_sleep" -> stringResource(Res.string.demo_habit_early_sleep)
     "label_habit_preset_custom" -> stringResource(Res.string.label_habit_preset_custom)
-    else -> id
+    else -> localizedDemoHabitName(nameKey)
   }
 
 @Composable

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
@@ -14,7 +14,16 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.DirectionsWalk
+import androidx.compose.material.icons.automirrored.filled.MenuBook
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bedtime
 import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.FitnessCenter
+import androidx.compose.material.icons.filled.NoFood
+import androidx.compose.material.icons.filled.School
+import androidx.compose.material.icons.filled.SelfImprovement
+import androidx.compose.material.icons.filled.WaterDrop
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
@@ -25,11 +34,13 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.theme.AppColors
 import space.be1ski.vibits.shared.core.ui.theme.resolve
+import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_continue
@@ -146,11 +157,12 @@ private fun PresetCard(
           .padding(Indent.m),
       verticalAlignment = Alignment.CenterVertically,
     ) {
-      preset.icon?.let { icon ->
-        Text(
-          text = icon,
-          style = MaterialTheme.typography.headlineMedium,
-          modifier = Modifier.size(40.dp),
+      preset.iconVector()?.let { icon ->
+        Icon(
+          imageVector = icon,
+          contentDescription = null,
+          tint = textColor,
+          modifier = Modifier.size(24.dp),
         )
 
         Spacer(modifier = Modifier.size(Indent.m))
@@ -173,3 +185,17 @@ private fun PresetCard(
     }
   }
 }
+
+private fun HabitPreset.iconVector(): ImageVector? =
+  when (id) {
+    DemoHabits.EXERCISE -> Icons.Default.FitnessCenter
+    DemoHabits.WATER -> Icons.Default.WaterDrop
+    DemoHabits.READING -> Icons.AutoMirrored.Filled.MenuBook
+    DemoHabits.MEDITATION -> Icons.Default.SelfImprovement
+    DemoHabits.WALKING -> Icons.AutoMirrored.Filled.DirectionsWalk
+    DemoHabits.LEARNING -> Icons.Default.School
+    DemoHabits.NO_SUGAR -> Icons.Default.NoFood
+    DemoHabits.EARLY_SLEEP -> Icons.Default.Bedtime
+    "custom" -> Icons.Default.AutoAwesome
+    else -> null
+  }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/HabitSetupScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/HabitSetupScreen.kt
@@ -36,20 +36,14 @@ import space.be1ski.vibits.shared.core.ui.Indent
 import space.be1ski.vibits.shared.core.ui.theme.AppColors
 import space.be1ski.vibits.shared.core.ui.theme.HabitColors
 import space.be1ski.vibits.shared.core.ui.theme.resolve
+import space.be1ski.vibits.shared.feature.habits.view.components.localizedDemoHabitName
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_start_tracking
-import space.be1ski.vibits.shared.generated.demo_habit_early_sleep
-import space.be1ski.vibits.shared.generated.demo_habit_exercise
-import space.be1ski.vibits.shared.generated.demo_habit_learning
-import space.be1ski.vibits.shared.generated.demo_habit_meditation
-import space.be1ski.vibits.shared.generated.demo_habit_no_sugar
-import space.be1ski.vibits.shared.generated.demo_habit_reading
-import space.be1ski.vibits.shared.generated.demo_habit_walking
-import space.be1ski.vibits.shared.generated.demo_habit_water
 import space.be1ski.vibits.shared.generated.hint_habit_name
 import space.be1ski.vibits.shared.generated.label_habit_color
 import space.be1ski.vibits.shared.generated.label_habit_name
+import space.be1ski.vibits.shared.generated.label_habit_preset_custom
 import space.be1ski.vibits.shared.generated.msg_habit_name_required
 import space.be1ski.vibits.shared.generated.msg_habit_setup
 import space.be1ski.vibits.shared.generated.title_habit_setup
@@ -180,15 +174,8 @@ private fun resolveErrorMessage(error: String?): String? =
 @Composable
 private fun getLocalizedPresetName(nameKey: String): String =
   when (nameKey) {
-    "demo_habit_exercise" -> stringResource(Res.string.demo_habit_exercise)
-    "demo_habit_water" -> stringResource(Res.string.demo_habit_water)
-    "demo_habit_reading" -> stringResource(Res.string.demo_habit_reading)
-    "demo_habit_meditation" -> stringResource(Res.string.demo_habit_meditation)
-    "demo_habit_walking" -> stringResource(Res.string.demo_habit_walking)
-    "demo_habit_learning" -> stringResource(Res.string.demo_habit_learning)
-    "demo_habit_no_sugar" -> stringResource(Res.string.demo_habit_no_sugar)
-    "demo_habit_early_sleep" -> stringResource(Res.string.demo_habit_early_sleep)
-    else -> ""
+    "label_habit_preset_custom" -> stringResource(Res.string.label_habit_preset_custom)
+    else -> localizedDemoHabitName(nameKey)
   }
 
 @Composable


### PR DESCRIPTION
## Summary
Replace emoji-based preset icons with Material icons so they render consistently on web/desktop, and eliminate duplication of demo habit string mappings.

## Changes
- Map onboarding habit presets to Material icons
- Remove unused icon field from HabitPreset
- Extract demo habit string keys to DemoHabitStringKeys object
- Create shared localizedDemoHabitName() function
- Eliminate duplicate string key mappings across onboarding and habits features

🤖 Generated with [Claude Code](https://claude.com/claude-code)