### PR TITLE
Replace success screen emoji with Material icon

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/SuccessScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/SuccessScreen.kt
@@ -7,7 +7,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.CheckCircle
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -40,9 +43,10 @@ fun SuccessScreen(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
   ) {
-    Text(
-      text = "🎉",
-      style = MaterialTheme.typography.displayLarge,
+    Icon(
+      imageVector = Icons.Default.CheckCircle,
+      contentDescription = null,
+      tint = AppColors.habitGreen.resolve(),
       modifier = Modifier.size(80.dp),
     )
 


### PR DESCRIPTION
## Summary
Replace celebration emoji with CheckCircle icon on success screen for consistent rendering across platforms.

## Changes
- Replace 🎉 emoji with Material CheckCircle icon in SuccessScreen
- Use green color for success indication

🤖 Generated with [Claude Code](https://claude.com/claude-code)