### PR TITLE
Fix onboarding preset list layout

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/ChoosePresetScreen.kt
@@ -89,7 +89,6 @@ fun ChoosePresetScreen(
     Spacer(modifier = Modifier.height(Indent.m))
 
     LazyColumn(
-      modifier = Modifier.weight(1f),
       verticalArrangement = Arrangement.spacedBy(Indent.s),
     ) {
       items(presets, key = { it.id }) { preset ->
@@ -100,6 +99,8 @@ fun ChoosePresetScreen(
         )
       }
     }
+
+    Spacer(modifier = Modifier.weight(1f))
 
     Spacer(modifier = Modifier.height(Indent.m))
 


### PR DESCRIPTION
## Summary
Fixes the onboarding "Choose a starter habit" screen layout on Android where the Continue button was not properly positioned at the bottom of the screen.

## Changes
- Removed `weight(1f)` from LazyColumn in ChoosePresetScreen
- Added weighted Spacer before Continue button to push it to the bottom

## Before
The LazyColumn with `weight(1f)` was expanding to fill all available space, but its items weren't expanding. This created an awkward visual gap between the list items and the Continue button, which became especially noticeable after replacing larger emoji icons (40dp) with smaller Material icons (24dp) in #124.

## After
The list is now compact, and the Continue button is properly anchored to the bottom of the screen with a flexible spacer between them.

## Test plan
- [x] Run `./gradlew checkAll` - all checks pass
- [ ] Test on Android (Pixel 9 Pro XL)
- [ ] Test on Desktop
- [ ] Test on Web

🤖 Generated with [Claude Code](https://claude.com/claude-code)