### PR TITLE
Refactor TEA core to enforce Command/Notification separation

### DIFF
--- a/TEA_REFACTOR_PLAN.md
+++ b/TEA_REFACTOR_PLAN.md
@@ -1,0 +1,537 @@
+# TEA Refactor Plan (Commands + Notifications)
+
+## Executive Summary
+
+**Goal:** Enforce Command/Notification separation in TEA core to eliminate `emptyFlow()` anti-pattern and empty coordinator branches.
+
+**Current State:**
+- Onboarding & Settings already have Command/Notification structure, but TEA core doesn't enforce it
+- All 6 features need migration: 3 with notifications (Onboarding, Settings, ModeSelection), 3 commands-only (App, Memos, Habits)
+
+**Effort:**
+- Phase 1 (Core TEA): ~4 files, blocking all features
+- Phase 2 (Features): ~18 files, parallelizable after Phase 1
+- Phase 3-5 (Coordinators, Tests, Cleanup): ~8 files
+
+**Status:** ✅ Planning complete, ready for implementation
+
+---
+
+## Context
+
+### Current State
+Some features **already have** Command/Notification separation in their effect types:
+- `OnboardingEffect` has `Command` and `Notification` sealed interfaces
+- `SettingsEffect` has `Command` and `Notification` sealed interfaces
+- `ModeSelectionEffect` is flat but has `NotifyModeSelected` as a notification
+
+However, the TEA core doesn't enforce this separation:
+- EffectHandlers must manually return `emptyFlow()` for notifications (see `OnboardingEffectHandler:24`, `SettingsEffectHandler:29`, `ModeSelectionEffectHandler:35`)
+- Coordinators must explicitly ignore commands with empty branches (see `AppRoot:216`, `FeatureCoordinator:38-41`)
+- All effects are exposed to external observers, even commands that should stay internal
+
+There are also "silent" actions that do nothing in reducers:
+- `OnboardingAction.OnboardingCompleted` (OnboardingReducer:124-126) - empty block with comment "Handled by coordinator"
+
+### Goal
+Make the Command/Notification separation explicit in the TEA core:
+- **Command**: internal side-effects handled by `EffectHandler` only
+- **Notification**: external signals for coordinators/UI, never reach `EffectHandler`
+- Remove all `emptyFlow()` for notifications in effect handlers
+- Remove all empty branches for commands in coordinators
+
+## Target Architecture (Two Handles)
+
+- Reducer emits **commands** and **notifications** separately.
+- `EffectHandler` processes **only commands**.
+- `Feature` exposes **notifications only** to outside observers.
+- Commands never appear in UI coordinators; notifications never reach EffectHandlers.
+
+## Technical Details
+
+### Type Parameter Strategy
+
+**Features with both commands and notifications:**
+```kotlin
+Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification>
+```
+
+**Features with commands only:**
+```kotlin
+Feature<AppAction, AppState, AppEffect, Nothing>
+```
+
+### `Nothing` Type Behavior
+
+`Nothing` is Kotlin's bottom type that has no instances. Using it as Notification type:
+- ✅ **Compile-time safety**: Calling `notify(...)` in reducer results in compile error
+- ✅ **Type inference**: Makes it impossible to emit notifications
+- ✅ **Flow handling**: `notifications: Flow<Nothing>` never emits (but is a valid, never-emitting flow)
+- ✅ **Coordinator code**: No need to collect from `notifications` flow (it will never emit)
+
+Example reducer with `Nothing`:
+```kotlin
+val appReducer: Reducer<AppAction, AppState, AppEffect, Nothing> = reducer { action, state ->
+  when (action) {
+    is AppAction.SaveTab -> {
+      command(AppEffect.SaveHabitsTimeRangeTab(action.tab))  // ✅ OK
+      // notify(...)  // ❌ Compile error: Nothing type
+    }
+  }
+}
+```
+
+### ReducerResult Structure
+
+Before (single Effect type):
+```kotlin
+ReducerResult<State, Effect>(
+  state = newState,
+  effects = setOf(effect1, effect2)
+)
+```
+
+After (separate Command and Notification):
+```kotlin
+ReducerResult<State, Command, Notification>(
+  state = newState,
+  commands = setOf(command1, command2),
+  notifications = setOf(notification1)
+)
+```
+
+### Test Migration Strategy
+
+**EffectHandler tests:**
+- ✅ No changes needed - they already test command handling only
+- Signature change: `EffectHandler<Effect, Action>` → `EffectHandler<Command, Action>`
+- Test logic remains the same (mock commands, verify actions)
+
+**Reducer tests:**
+- ❌ **Require updates** - need new assertion helpers
+- Replace `assertEffects(effect1, effect2)` with:
+  - `assertCommands(command1)` - verify commands emitted
+  - `assertNotifications(notification1)` - verify notifications emitted
+- For commands-only features: use only `assertCommands(...)`
+- Example:
+  ```kotlin
+  @Test
+  fun `when action then emit command and notification`() = runReducerTest {
+    given { initialState }
+    whenever { someAction }
+    then {
+      assertState { expectedState }
+      assertCommands(SomeEffect.Command.DoSomething)
+      assertNotifications(SomeEffect.Notification.SomethingHappened)
+    }
+  }
+  ```
+
+## Plan
+
+### 1) Inventory & Classification
+
+**Status: ✅ Complete**
+
+All effects classified. Silent actions identified.
+
+**Onboarding** (already has Command/Notification structure)
+- Commands: `LoadPresets`, `CreateFirstHabit`, `MarkOnboardingCompleted`, `MarkFirstCheckIn`
+- Notifications: `Completed`, `Skipped`, `FirstCheckInCreated`
+- Status: Structure exists, needs core TEA migration
+
+**Settings** (already has Command/Notification structure)
+- Commands: `ValidateCredentials`, `SwitchMode`, `SaveCredentials`, `ResetApp`, `SaveLanguage`, `SaveTheme`
+- Notifications: `ModeChanged`, `ResetCompleted`, `CredentialsSaved`, `LanguageChanged`, `ThemeChanged`, `DialogClosed`
+- Status: Structure exists, needs core TEA migration
+
+**ModeSelection** (flat structure)
+- Commands: `InitializeFromLocalConfig`, `CheckStoredCredentials`, `UseStoredCredentialsWithValidation`, `ValidateCredentials`, `SaveCredentials`, `SaveMode`
+- Notifications: `NotifyModeSelected`
+- Status: Needs restructuring into Command/Notification
+
+**App** (commands only)
+- Commands: `SaveHabitsTimeRangeTab`, `SavePostsTimeRangeTab`
+- Notifications: None
+- Status: Use `Nothing` as Notification type
+
+**Memos** (commands only)
+- Commands: `LoadCachedMemos`, `LoadRemoteMemos`, `SaveCredentials`, `LoadCredentials`, `CreateMemo`, `UpdateMemo`, `DeleteMemo`
+- Notifications: None
+- Status: Use `Nothing` as Notification type
+
+**Habits** (commands only)
+- Commands: `CreateMemo`, `UpdateMemo`, `DeleteMemo`, `RefreshMemos`, `RunPrewarmAllRanges`, `RecalculateActivityData`
+- Notifications: None
+- Status: Use `Nothing` as Notification type
+
+**Silent Actions** (to be removed or converted to notifications):
+- `OnboardingAction.OnboardingCompleted` (OnboardingReducer:124-126) - empty block, comment says "Handled by coordinator"
+  - Decision: Remove this action. The notification `OnboardingEffect.Notification.Completed` already serves this purpose.
+
+### 2) Core TEA Contract Changes
+
+**Status: 🔲 Pending**
+
+Update the TEA core to enforce Command/Notification separation.
+
+**Elm.kt changes:**
+1. Introduce `ReducerResult<State, Command, Notification>` to replace current `ReducerResult<State, Effect>`
+2. Update `Reducer` type alias:
+   ```kotlin
+   typealias Reducer<Action, State, Command, Notification> =
+     (Action, State) -> ReducerResult<State, Command, Notification>
+   ```
+3. Update `EffectHandler` to accept only commands:
+   ```kotlin
+   typealias EffectHandler<Command, Action> = (Command) -> Flow<Action>
+   ```
+4. Update `Feature` interface to expose notifications separately:
+   ```kotlin
+   interface Feature<Action, State, Command, Notification> {
+     val state: StateFlow<State>
+     val notifications: Flow<Notification>  // New: only notifications exposed
+     fun send(action: Action)
+     fun launchIn(scope: CoroutineScope)
+   }
+   ```
+
+**ReducerDsl.kt changes:**
+- Keep existing `state { ... }` DSL function unchanged
+- Remove `effect(...)` DSL function entirely - no compatibility layer
+- Add new DSL functions (canonical API):
+  - `command(...)`, `commands(...)` - emit commands for EffectHandler
+  - `notify(...)`, `notifications(...)` - emit notifications for coordinators
+- Migration path: Find/replace all `effect(...)` calls with `command(...)` or `notify(...)` during feature migrations
+- Note: `notify(...)` cannot be called if Notification type is `Nothing` (compile error) - this is desired behavior
+
+**FeatureImpl.kt changes:**
+1. Remove old `effects: Flow<Effect>` property - no longer exposed
+2. Add `commandQueue: Channel<Command>` - internal, processed by EffectHandler
+3. Add `notificationBroadcast: MutableSharedFlow<Notification>` - exposed as `notifications: Flow<Notification>`
+4. Split effect processing in reducer loop: commands → commandQueue, notifications → notificationBroadcast
+5. Update constructor to accept `EffectHandler<Command, Action>` instead of `EffectHandler<Effect, Action>`
+6. Commands from commandQueue are processed by EffectHandler, results dispatched as actions
+7. Notifications from notificationBroadcast are exposed to external observers only
+
+### 3) Feature Migrations
+
+**Status: 🔲 Pending (blocked by step 2)**
+
+Migrate each feature to the new contract, removing empty branches.
+
+**Onboarding** (minimal changes needed)
+- ✅ Effect structure already correct (Command/Notification)
+- Update: Reducer to use `command(...)` and `notify(...)` DSL instead of `effect(...)`
+- Update: EffectHandler signature from `EffectHandler<OnboardingEffect, ...>` to `EffectHandler<OnboardingEffect.Command, ...>`
+- Update: Factory function signature from `Feature<..., OnboardingEffect>` to `Feature<..., OnboardingEffect.Command, OnboardingEffect.Notification>`
+- Remove: `emptyFlow()` branch for Notification (OnboardingEffectHandler:24)
+- Remove: `OnboardingAction.OnboardingCompleted` action and its usage (OnboardingAction.kt, OnboardingReducer.kt:124-126, OnboardingEffectHandler.kt:59)
+- Files: OnboardingReducer.kt, OnboardingEffectHandler.kt, OnboardingAction.kt, OnboardingFeatureFactory.kt
+
+**Settings** (minimal changes needed)
+- ✅ Effect structure already correct (Command/Notification)
+- Update: Reducer to use `command(...)` and `notify(...)` DSL instead of `effect(...)`
+- Update: EffectHandler signature from `EffectHandler<SettingsEffect, ...>` to `EffectHandler<SettingsEffect.Command, ...>`
+- Update: Factory function signature from `Feature<..., SettingsEffect>` to `Feature<..., SettingsEffect.Command, SettingsEffect.Notification>`
+- Remove: `emptyFlow()` branch for Notification (SettingsEffectHandler:29)
+- Files: SettingsReducer.kt, SettingsEffectHandler.kt, SettingsFeatureFactory.kt
+
+**ModeSelection** (requires restructuring)
+- Restructure: `ModeSelectionEffect` into Command/Notification sealed interfaces (similar to OnboardingEffect)
+- Update: Reducer to use `command(...)` and `notify(...)` DSL instead of `effect(...)`
+- Move: `NotifyModeSelected` from flat effect to `ModeSelectionEffect.Notification.ModeSelected`
+- Update: EffectHandler signature to `EffectHandler<ModeSelectionEffect.Command, ...>`
+- Update: EffectHandler to handle only Command branch, remove `emptyFlow()` for NotifyModeSelected (line 35)
+- Update: Factory function signature from `Feature<..., ModeSelectionEffect>` to `Feature<..., ModeSelectionEffect.Command, ModeSelectionEffect.Notification>`
+- Update: AppRoot.kt coordinator to collect from `notifications` instead of `effects`
+- Files: ModeSelectionEffect.kt, ModeSelectionReducer.kt, ModeSelectionEffectHandler.kt, ModeSelectionFeatureFactory.kt, AppRoot.kt
+
+**App** (commands only, minimal changes)
+- Keep: Flat `AppEffect` structure (no notifications needed)
+- Update: Use `Nothing` as Notification type parameter in Feature signature
+- Update: Reducer to use `command(...)` DSL instead of `effect(...)` (never call `notify(...)`)
+- Update: Factory function signature from `Feature<..., AppEffect>` to `Feature<..., AppEffect, Nothing>`
+- Update: AppFeatures.kt container to use new signature
+- Files: AppReducer.kt, AppEffectHandler.kt, AppFeatureFactory.kt, AppFeatures.kt
+
+**Memos** (commands only, minimal changes)
+- Keep: Flat `MemosEffect` structure (no notifications needed)
+- Update: Use `Nothing` as Notification type parameter in Feature signature
+- Update: Reducer to use `command(...)` DSL instead of `effect(...)` (never call `notify(...)`)
+- Update: Factory function signature from `Feature<..., MemosEffect>` to `Feature<..., MemosEffect, Nothing>`
+- Update: AppFeatures.kt container to use new signature
+- Files: MemosReducer.kt, MemosEffectHandler.kt, MemosFeatureFactory.kt, AppFeatures.kt
+
+**Habits** (commands only, minimal changes)
+- Keep: Flat `HabitsEffect` structure (no notifications needed)
+- Update: Use `Nothing` as Notification type parameter in Feature signature
+- Update: Reducer to use `command(...)` DSL instead of `effect(...)` (never call `notify(...)`)
+- Update: Factory function signature from `Feature<..., HabitsEffect>` to `Feature<..., HabitsEffect, Nothing>`
+- Update: AppFeatures.kt container to use new signature
+- Files: HabitsReducer.kt, HabitsEffectHandler.kt, HabitsFeatureFactory.kt, AppFeatures.kt
+
+### 4) Coordinator Updates
+
+**Status: 🔲 Pending (blocked by steps 2 and 3)**
+
+**AppRoot** (AppRoot.kt:187-221)
+- Update: Change from `feature.effects.collect` to `feature.notifications.collect`
+- Remove: Empty branch for `OnboardingEffect.Command` (line 216)
+- Before:
+  ```kotlin
+  feature.effects.collect { effect ->
+    when (effect) {
+      is OnboardingEffect.Notification.Completed,
+      is OnboardingEffect.Notification.Skipped -> onOnboardingCompleted()
+      is OnboardingEffect.Notification.FirstCheckInCreated -> { ... }
+      is OnboardingEffect.Command -> {} // Commands handled by EffectHandler
+    }
+  }
+  ```
+- After:
+  ```kotlin
+  feature.notifications.collect { notification ->
+    when (notification) {
+      is OnboardingEffect.Notification.Completed,
+      is OnboardingEffect.Notification.Skipped -> onOnboardingCompleted()
+      is OnboardingEffect.Notification.FirstCheckInCreated -> { ... }
+    }
+  }
+  ```
+
+**FeatureCoordinator** (FeatureCoordinator.kt:35-43)
+- Update: Change from `feature.effects.collect` to `feature.notifications.collect`
+- Remove: Empty branch for `SettingsEffect.Command` (line 40)
+- Before:
+  ```kotlin
+  features.settings.effects.collect { effect ->
+    when (effect) {
+      is SettingsEffect.Notification -> handleNotification(...)
+      is SettingsEffect.Command -> Unit
+    }
+  }
+  ```
+- After:
+  ```kotlin
+  features.settings.notifications.collect { notification ->
+    handleNotification(notification, ...)
+  }
+  ```
+
+### 5) Testing Updates
+
+**Status: 🔲 Pending (blocked by steps 2 and 3)**
+
+**ReducerTestDsl** (update test helpers)
+- Add `assertCommands(...)` to check emitted commands
+- Add `assertNotifications(...)` to check emitted notifications
+- Deprecate or adapt `assertEffects(...)` for backwards compatibility
+- Example:
+  ```kotlin
+  @Test
+  fun `when Skip then emit Skipped notification`() = runReducerTest(onboardingReducer) {
+    given { OnboardingState(...) }
+    whenever { OnboardingAction.Skip }
+    then {
+      assertNotifications(OnboardingEffect.Notification.Skipped)
+      assertCommands() // empty
+    }
+  }
+  ```
+
+**Feature-specific test updates:**
+- **OnboardingReducerTest**: Replace `assertEffects(...)` with `assertCommands(...)` or `assertNotifications(...)`
+- **SettingsReducerTest**: Same as above
+- **ModeSelectionReducerTest**: Same as above, update effect names after restructuring
+- **AppReducerTest, MemosReducerTest, HabitsReducerTest**: Replace with `assertCommands(...)`
+
+**EffectHandler tests:**
+- No changes needed (they already test only command handling)
+
+### 6) Cleanup Checklist
+
+**Status: 🔲 Pending (integrated into Phases 2-5)**
+
+This is a checklist of anti-patterns to eliminate during migration. Each item should be addressed in the relevant phase.
+
+**`emptyFlow()` branches to remove (Phase 2):**
+- `OnboardingEffectHandler.kt:24` - `is OnboardingEffect.Notification -> emptyFlow()`
+- `SettingsEffectHandler.kt:29` - `is SettingsEffect.Notification -> emptyFlow()`
+- `ModeSelectionEffectHandler.kt:35` - `is ModeSelectionEffect.NotifyModeSelected -> emptyFlow()`
+
+**Coordinator comments to remove (Phase 3):**
+- `OnboardingReducer.kt:125` - `// Handled by coordinator`
+- `AppRoot.kt:216` - `// Commands handled by EffectHandler`
+- `FeatureCoordinator.kt:40` - comment about ignoring commands
+
+**Silent actions to remove (Phase 2):**
+- `OnboardingAction.OnboardingCompleted` (OnboardingAction.kt, OnboardingReducer.kt:124-126)
+- `OnboardingEffectHandler.kt:59` - don't emit this action after `MarkOnboardingCompleted`
+
+**Empty coordinator branches to remove (Phase 3):**
+- `AppRoot.kt:216` - `is OnboardingEffect.Command -> {}`
+- `FeatureCoordinator.kt:40` - `is SettingsEffect.Command -> Unit`
+
+**Final verification (Phase 5):**
+- No actions that do nothing in any reducer
+- No empty coordinator branches for commands
+- No `emptyFlow()` in any effect handler
+- All Feature types use 4-type-parameter signature
+
+## Implementation Order
+
+**Phase 1: Core TEA (BLOCKING)**
+1. Update `Elm.kt` - new contracts for Command/Notification separation
+2. Update `FeatureImpl.kt` - split command/notification processing
+3. Update `ReducerDsl.kt` - add `command(...)`/`notify(...)` DSL functions
+4. Update `ReducerTestDsl` - add assertion helpers for commands/notifications
+
+**Phase 2: Feature Migrations (can be done in parallel after Phase 1)**
+5. Migrate Onboarding (smallest surface, already has structure)
+   - Remove `OnboardingAction.OnboardingCompleted` action and its usage
+   - Files: OnboardingReducer.kt, OnboardingEffectHandler.kt, OnboardingAction.kt, OnboardingFeatureFactory.kt
+6. Migrate Settings (already has structure)
+   - Files: SettingsReducer.kt, SettingsEffectHandler.kt, SettingsFeatureFactory.kt
+7. Migrate ModeSelection (needs restructuring + AppRoot coordinator)
+   - Files: ModeSelectionEffect.kt, ModeSelectionReducer.kt, ModeSelectionEffectHandler.kt, ModeSelectionFeatureFactory.kt, AppRoot.kt
+8. Migrate App, Memos, Habits (commands-only features + AppFeatures container)
+   - App: AppReducer.kt, AppEffectHandler.kt, AppFeatureFactory.kt
+   - Memos: MemosReducer.kt, MemosEffectHandler.kt, MemosFeatureFactory.kt
+   - Habits: HabitsReducer.kt, HabitsEffectHandler.kt, HabitsFeatureFactory.kt
+   - Shared: AppFeatures.kt (container with all Feature types), AppFeaturesFactory.kt (factory that creates all features)
+
+**Phase 3: Coordinators (after Phase 2)**
+9. Update AppRoot coordinator - switch to `notifications` flow
+10. Update FeatureCoordinator - switch to `notifications` flow
+
+**Phase 4: Tests (after Phase 2)**
+11. Update all reducer tests - use new assertion helpers
+12. Verify all tests pass
+
+**Phase 5: Cleanup & Verification (final pass)**
+13. Remove coordinator comments (e.g., `// Handled by coordinator`, `// Commands handled by EffectHandler`)
+14. Verify no `emptyFlow()` remains for notifications in any EffectHandler
+15. Verify no silent actions remain in any reducer
+16. Verify all Feature types use new 4-type-parameter signature
+17. Final code review and documentation check
+
+## Risks / Notes
+
+**Breaking Changes:**
+- This is a **breaking change** to TEA core affecting all features
+- All `Feature` type signatures will change from `Feature<Action, State, Effect>` to `Feature<Action, State, Command, Notification>`
+- All `EffectHandler` type signatures will change from `EffectHandler<Effect, Action>` to `EffectHandler<Command, Action>`
+- All reducers will need type updates and DSL changes
+
+**Migration Strategy:**
+- Phase 1 is BLOCKING - all features must wait for core changes
+- After Phase 1, features can migrate in parallel (good for team distribution)
+- Keep migrations focused: no UI, domain, or business logic changes during migration
+- Test each feature after migration before moving to next
+
+**Type Parameter Decisions (RESOLVED):**
+- Features with only commands (App, Memos, Habits): Use `Nothing` as Notification type
+- Example: `Feature<AppAction, AppState, AppEffect, Nothing>`
+- `Nothing` is Kotlin's bottom type - perfect for "this will never happen"
+
+**Testing Strategy:**
+- Run full test suite after Phase 1 (expect failures, that's normal)
+- Fix feature tests incrementally in Phase 4
+- Keep CI green or clearly mark as WIP in PRs
+
+## Open Questions
+
+**Status: ✅ All Resolved**
+
+All open questions have been answered:
+
+1. ✅ **What type to use for Notification in commands-only features?**
+   - Decision: Use `Nothing` (Kotlin's bottom type)
+   - Applies to: App, Memos, Habits features
+   - Benefit: Compile-time prevention of `notify(...)` calls
+   - See: Technical Details section for `Nothing` behavior
+
+2. ✅ **What to do with `OnboardingAction.OnboardingCompleted`?**
+   - Decision: Remove this silent action in Phase 2
+   - Rationale: `OnboardingEffect.Notification.Completed` already serves this purpose
+   - Location: OnboardingAction.kt, OnboardingReducer.kt:124-126, OnboardingEffectHandler.kt:59
+
+3. ✅ **Which features have Command/Notification structure?**
+   - Already structured: Onboarding, Settings
+   - Needs restructuring: ModeSelection
+   - Commands only: App, Memos, Habits
+
+4. ✅ **Are there other silent actions?**
+   - Audit complete: Only `OnboardingAction.OnboardingCompleted` found
+
+5. ✅ **Implementation order and blocking?**
+   - Phase 1 (Core TEA) blocks everything
+   - Phase 2 (Features) can be parallelized
+   - Phase 3 (Coordinators) depends on Phase 2
+   - All files identified including factories and containers
+
+6. ✅ **How to handle `effect(...)` DSL migration?**
+   - Decision: Remove `effect(...)` entirely, no compatibility layer
+   - Find/replace with `command(...)` or `notify(...)` during feature migrations
+   - Compile errors will guide the migration
+
+7. ✅ **What happens to old `effects: Flow<Effect>`?**
+   - Remove from Feature interface
+   - Replace with `notifications: Flow<Notification>`
+   - Commands stay internal, never exposed
+
+8. ✅ **Which factory files need updates?**
+   - All `*FeatureFactory.kt` files (return type changes)
+   - `AppFeatures.kt` container (all Feature properties)
+   - `AppFeaturesFactory.kt` factory (creates all features)
+
+**The plan is now ready for implementation.**
+
+## Optional Follow-ups (Post-Migration)
+
+These are **not required** for the core refactor but may improve clarity:
+
+1. **Naming consistency across features:**
+   - Current: `OnboardingEffect.Command`, `SettingsEffect.Command`
+   - Alternative: Separate top-level types like `OnboardingCommand`, `OnboardingNotification`
+   - Decision: Keep current naming (nested sealed interfaces) for consistency with existing codebase patterns
+
+2. **Action audit for completion events:**
+   - Look for actions that exist only to signal "effect completed" (like `OnboardingCompleted`)
+   - Evaluate if they should be notifications instead
+   - This refactor already addresses the known case (`OnboardingAction.OnboardingCompleted`)
+
+3. **Documentation updates:**
+   - Update CLAUDE.md with new TEA patterns
+   - Add examples of command-only vs notification-emitting features
+   - Document when to use `Nothing` vs actual Notification types
+
+4. **Performance monitoring:**
+   - Measure if separating command/notification flows improves performance
+   - Current implementation processes all effects through single channel
+   - New implementation may have better throughput with separate channels
+
+---
+
+## PR Summary (for description)
+
+**Why**
+- TEA core currently routes all effects through EffectHandler and exposes them to UI, forcing `emptyFlow()` and no‑op branches.
+- This refactor enforces Command/Notification separation, removing anti‑patterns and clarifying intent.
+
+**What changed (high level)**
+- TEA core updated to split commands and notifications in reducer results.
+- EffectHandler now accepts only commands; Feature exposes only notifications.
+- All features migrated to the new contract; ModeSelection restructured.
+- Coordinators now observe notifications only.
+- Reducer test DSL updated to assert commands/notifications separately.
+
+**Key cleanups**
+- Removed `emptyFlow()` branches for notifications in effect handlers.
+- Removed silent actions (e.g., `OnboardingAction.OnboardingCompleted`).
+- Removed coordinator branches that ignore commands.
+
+**Testing**
+- Update reducer tests to use `assertCommands(...)` / `assertNotifications(...)`.
+- Run `./gradlew :shared:desktopTest` (or full `./gradlew checkAll`).

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeatureFactory.kt
@@ -18,7 +18,7 @@ internal fun createAppFeature(
   currentDate: LocalDate,
   initialHabitsTab: TimeRangeTab = TimeRangeTab.WEEKS,
   initialPostsTab: TimeRangeTab = TimeRangeTab.WEEKS,
-): Feature<AppAction, AppState, AppEffect> =
+): Feature<AppAction, AppState, AppEffect, Nothing> =
   FeatureImpl(
     initialState =
       AppState(

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppFeatures.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppFeatures.kt
@@ -17,8 +17,8 @@ import space.be1ski.vibits.shared.feature.settings.presentation.SettingsState
  * Created by AppFeaturesFactory, lives in AppScope.
  */
 class AppFeatures internal constructor(
-  val app: Feature<AppAction, AppState, AppEffect>,
-  val memos: Feature<MemosAction, MemosState, MemosEffect>,
-  val habits: Feature<HabitsAction, HabitsState, HabitsEffect>,
-  val settings: Feature<SettingsAction, SettingsState, SettingsEffect>,
+  val app: Feature<AppAction, AppState, AppEffect, Nothing>,
+  val memos: Feature<MemosAction, MemosState, MemosEffect, Nothing>,
+  val habits: Feature<HabitsAction, HabitsState, HabitsEffect, Nothing>,
+  val settings: Feature<SettingsAction, SettingsState, SettingsEffect.Command, SettingsEffect.Notification>,
 )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducer.kt
@@ -11,7 +11,7 @@ import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
 /**
  * Pure reducer for the App coordinator feature.
  */
-internal val appReducer: Reducer<AppAction, AppState, AppEffect> =
+internal val appReducer: Reducer<AppAction, AppState, AppEffect, Nothing> =
   reducer { action, state ->
     when (action) {
       is AppAction.SelectScreen -> {
@@ -20,12 +20,12 @@ internal val appReducer: Reducer<AppAction, AppState, AppEffect> =
 
       is AppAction.SetHabitsTimeRangeTab -> {
         state { copy(habitsTimeRangeTab = action.tab) }
-        effect(AppEffect.SaveHabitsTimeRangeTab(action.tab))
+        command(AppEffect.SaveHabitsTimeRangeTab(action.tab))
       }
 
       is AppAction.SetPostsTimeRangeTab -> {
         state { copy(postsTimeRangeTab = action.tab) }
-        effect(AppEffect.SavePostsTimeRangeTab(action.tab))
+        command(AppEffect.SavePostsTimeRangeTab(action.tab))
       }
 
       is AppAction.SetPeriodStartDate -> {
@@ -39,13 +39,13 @@ internal val appReducer: Reducer<AppAction, AppState, AppEffect> =
       is AppAction.ChangeHabitsTab -> {
         val adjustedDate = AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
         state { copy(habitsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
-        effect(AppEffect.SaveHabitsTimeRangeTab(action.newTab))
+        command(AppEffect.SaveHabitsTimeRangeTab(action.newTab))
       }
 
       is AppAction.ChangePostsTab -> {
         val adjustedDate = AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
         state { copy(postsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
-        effect(AppEffect.SavePostsTimeRangeTab(action.newTab))
+        command(AppEffect.SavePostsTimeRangeTab(action.newTab))
       }
 
       is AppAction.ResetToHome -> {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
@@ -177,7 +177,7 @@ private fun rememberAppFeatures(version: Int): AppFeatures =
 private fun rememberModeSelectionFeature(
   dependencies: AppDependencies,
   onModeSelected: (AppMode) -> Unit,
-): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect> {
+): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> {
   val feature =
     remember {
       createModeSelectionFeature(dependencies = dependencies.modeSelectionDependencies)
@@ -185,8 +185,10 @@ private fun rememberModeSelectionFeature(
   val scope = rememberCoroutineScope()
   LaunchedEffect(feature) { feature.launchIn(scope) }
   LaunchedEffect(feature) {
-    feature.effects.collect { effect ->
-      if (effect is ModeSelectionEffect.NotifyModeSelected) onModeSelected(effect.mode)
+    feature.notifications.collect { notification ->
+      when (notification) {
+        is ModeSelectionEffect.Notification.ModeSelected -> onModeSelected(notification.mode)
+      }
     }
   }
   return feature
@@ -197,7 +199,7 @@ private fun rememberOnboardingFeature(
   dependencies: AppDependencies,
   features: AppFeatures,
   onOnboardingCompleted: () -> Unit,
-): Feature<OnboardingAction, OnboardingState, OnboardingEffect> {
+): Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification> {
   val feature =
     remember {
       createOnboardingFeature(dependencies = dependencies.onboardingDependencies)
@@ -205,15 +207,14 @@ private fun rememberOnboardingFeature(
   val scope = rememberCoroutineScope()
   LaunchedEffect(feature) { feature.launchIn(scope) }
   LaunchedEffect(feature) {
-    feature.effects.collect { effect ->
-      when (effect) {
+    feature.notifications.collect { notification ->
+      when (notification) {
         is OnboardingEffect.Notification.Completed,
         is OnboardingEffect.Notification.Skipped,
         -> onOnboardingCompleted()
         is OnboardingEffect.Notification.FirstCheckInCreated -> {
           features.memos.send(MemosAction.LoadMemos)
         }
-        is OnboardingEffect.Command -> {} // Commands handled by EffectHandler
       }
     }
   }
@@ -231,8 +232,8 @@ private fun resolveDarkTheme(theme: AppTheme): Boolean {
 }
 
 private data class FeaturesState(
-  val modeSelection: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect>,
-  val onboarding: Feature<OnboardingAction, OnboardingState, OnboardingEffect>,
+  val modeSelection: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification>,
+  val onboarding: Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification>,
   val app: AppFeatures,
 )
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
@@ -33,12 +33,8 @@ internal fun FeatureCoordinator(
 
   // Cross-feature coordination via Settings notifications
   LaunchedEffect(features.settings) {
-    features.settings.effects.collect { effect ->
-      when (effect) {
-        is SettingsEffect.Notification ->
-          handleNotification(effect, dispatchApp, dispatchMemos, dispatchHabits, onResetApp, onThemeChanged, onLanguageChanged)
-        is SettingsEffect.Command -> Unit
-      }
+    features.settings.notifications.collect { notification ->
+      handleNotification(notification, dispatchApp, dispatchMemos, dispatchHabits, onResetApp, onThemeChanged, onLanguageChanged)
     }
   }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/Elm.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/Elm.kt
@@ -12,12 +12,22 @@ import kotlinx.coroutines.flow.StateFlow
  * The Elm Architecture is a unidirectional data flow pattern where:
  * - [State] represents the current state of the feature
  * - [Action] represents events that can modify the state
- * - [Effect] represents side effects (API calls, navigation, etc.)
+ * - [Command] represents internal side effects handled by the EffectHandler
+ * - [Notification] represents external signals for coordinators and UI
  *
  * Data flows in one direction:
  * ```
- * Action -> Reducer -> (State, Effects) -> EffectHandler -> Action -> ...
+ * Action -> Reducer -> (State, Commands, Notifications)
+ *                          |           |
+ *                          v           v
+ *                   EffectHandler  Coordinators/UI
+ *                          |
+ *                          v
+ *                       Action
  * ```
+ *
+ * Commands are processed internally by the EffectHandler and never exposed externally.
+ * Notifications are exposed to coordinators/UI and never reach the EffectHandler.
  *
  * Example usage:
  * ```
@@ -27,21 +37,30 @@ import kotlinx.coroutines.flow.StateFlow
  *   effectHandler = counterEffectHandler,
  * )
  *
- * // Start processing actions and effects
+ * // Start processing actions and commands
  * feature.launchIn(viewModelScope)
  *
  * // Observe state
  * feature.state.collect { state -> updateUI(state) }
  *
+ * // Observe notifications (external events only)
+ * feature.notifications.collect { notification -> handleNotification(notification) }
+ *
  * // Send actions
  * feature.send(CounterAction.Increment)
  * ```
  *
+ * For features with only commands and no notifications, use [Nothing] as the Notification type:
+ * ```
+ * Feature<MyAction, MyState, MyCommand, Nothing>
+ * ```
+ *
  * @param Action The type of actions this feature accepts
  * @param State The type of state this feature manages
- * @param Effect The type of side effects this feature produces
+ * @param Command The type of internal commands processed by EffectHandler
+ * @param Notification The type of external notifications for coordinators/UI
  */
-public interface Feature<Action, State, Effect> {
+public interface Feature<Action, State, Command, Notification> {
   /**
    * The current state of the feature as a [StateFlow].
    *
@@ -51,28 +70,30 @@ public interface Feature<Action, State, Effect> {
   public val state: StateFlow<State>
 
   /**
-   * A [Flow] of effects produced by the feature.
+   * A [Flow] of notifications produced by the feature.
    *
-   * Effects are emitted when the reducer returns them. External observers (e.g., for analytics
-   * or one-time UI events) can collect this flow. Note that effects are also processed internally
-   * by the effect handler.
+   * Notifications are emitted when the reducer returns them. External observers (coordinators,
+   * UI, analytics) can collect this flow. Notifications never reach the EffectHandler.
+   *
+   * For features with no notifications, this flow will never emit (Notification type is [Nothing]).
    */
-  public val effects: Flow<Effect>
+  public val notifications: Flow<Notification>
 
   /**
    * Sends an action to be processed by the feature's reducer.
    *
    * Actions are queued and processed sequentially. Each action causes:
-   * 1. The reducer to compute a new state and optional effects
+   * 1. The reducer to compute a new state, optional commands, and optional notifications
    * 2. The state to be updated
-   * 3. Effects to be sent to the effect handler
+   * 3. Commands to be sent to the effect handler
+   * 4. Notifications to be emitted to external observers
    *
    * @param action The action to process
    */
   public fun send(action: Action)
 
   /**
-   * Starts the feature's action and effect processing loops.
+   * Starts the feature's action and command processing loops.
    *
    * Must be called before the feature can process actions. The feature will continue
    * processing until the provided [scope] is cancelled.
@@ -83,7 +104,7 @@ public interface Feature<Action, State, Effect> {
 }
 
 /**
- * A pure function that computes a new state and effects from an action and current state.
+ * A pure function that computes a new state, commands, and notifications from an action and current state.
  *
  * Reducers must be pure functions with no side effects. They should:
  * - Always return the same result for the same inputs
@@ -92,58 +113,90 @@ public interface Feature<Action, State, Effect> {
  *
  * Use the [reducer] DSL function to create reducers with a convenient syntax:
  * ```
- * val myReducer: Reducer<MyAction, MyState, MyEffect> = reducer { action, state ->
+ * val myReducer: Reducer<MyAction, MyState, MyCommand, MyNotification> = reducer { action, state ->
  *   when (action) {
  *     is MyAction.Increment -> state { copy(count = count + 1) }
- *     is MyAction.LoadData -> effect(MyEffect.FetchData)
+ *     is MyAction.LoadData -> command(MyCommand.FetchData)
+ *     is MyAction.Completed -> notify(MyNotification.Finished)
+ *   }
+ * }
+ * ```
+ *
+ * For features with only commands and no notifications, use [Nothing] as Notification type:
+ * ```
+ * val myReducer: Reducer<MyAction, MyState, MyCommand, Nothing> = reducer { action, state ->
+ *   when (action) {
+ *     is MyAction.LoadData -> command(MyCommand.FetchData)
+ *     // notify(...) cannot be called - compile error
  *   }
  * }
  * ```
  *
  * @param Action The type of actions the reducer handles
  * @param State The type of state the reducer operates on
- * @param Effect The type of effects the reducer can produce
+ * @param Command The type of commands the reducer can produce for EffectHandler
+ * @param Notification The type of notifications the reducer can produce for coordinators/UI
  */
-public typealias Reducer<Action, State, Effect> = (Action, State) -> ReducerResult<State, Effect>
+public typealias Reducer<Action, State, Command, Notification> =
+  (Action, State) -> ReducerResult<State, Command, Notification>
 
 /**
- * A function that handles side effects and produces actions in response.
+ * A function that handles commands (internal side effects) and produces actions in response.
  *
  * Effect handlers are responsible for:
  * - Performing asynchronous operations (API calls, database queries, etc.)
- * - Converting effect results into actions to update the state
+ * - Converting command results into actions to update the state
  *
+ * The handler processes only commands - notifications are handled externally by coordinators.
  * The handler returns a [Flow] of actions, allowing it to emit multiple actions
- * for a single effect (e.g., progress updates, success/failure results).
+ * for a single command (e.g., progress updates, success/failure results).
  *
  * Example:
  * ```
- * val effectHandler: EffectHandler<MyEffect, MyAction> = { effect ->
- *   when (effect) {
- *     is MyEffect.FetchData -> flow {
+ * val effectHandler: EffectHandler<MyCommand, MyAction> = { command ->
+ *   when (command) {
+ *     is MyCommand.FetchData -> flow {
  *       val result = api.fetchData()
  *       emit(MyAction.DataLoaded(result))
  *     }
- *     is MyEffect.LogAnalytics -> {
- *       analytics.log(effect.event)
- *       emptyFlow()
+ *     is MyCommand.SaveToDb -> flow {
+ *       db.save(command.data)
+ *       emit(MyAction.Saved)
  *     }
  *   }
  * }
  * ```
  *
- * @param Effect The type of effects this handler processes
+ * @param Command The type of commands this handler processes
  * @param Action The type of actions this handler produces
  */
-public typealias EffectHandler<Effect, Action> = (Effect) -> Flow<Action>
+public typealias EffectHandler<Command, Action> = (Command) -> Flow<Action>
 
 /**
- * The result of a reducer invocation, containing the new state and any effects to execute.
+ * Container for commands and notifications produced by a reducer.
+ *
+ * @property commands Commands to be processed internally by the EffectHandler
+ * @property notifications Notifications to be emitted to external observers
+ */
+public data class Effects<Command, Notification>(
+  val commands: List<Command>,
+  val notifications: List<Notification>,
+)
+
+/**
+ * The result of a reducer invocation, containing the new state and effects.
+ *
+ * Effects are split into commands (processed internally by EffectHandler) and
+ * notifications (exposed to external observers like coordinators and UI).
  *
  * @property state The new state after processing the action
- * @property effects A list of effects to be processed by the effect handler
+ * @property effects Container with commands and notifications
  */
-public data class ReducerResult<State, Effect>(
+public data class ReducerResult<State, Command, Notification>(
   val state: State,
-  val effects: List<Effect>,
-)
+  val effects: Effects<Command, Notification>,
+) {
+  // Convenience accessors for direct access
+  val commands: List<Command> get() = effects.commands
+  val notifications: List<Notification> get() = effects.notifications
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/FeatureImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/FeatureImpl.kt
@@ -17,11 +17,14 @@ import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.receiveAsFlow
 
 /**
- * Default implementation of [Feature] that processes actions and effects using channels and flows.
+ * Default implementation of [Feature] that processes actions, commands, and notifications using channels and flows.
  *
- * This implementation uses unbounded channels for actions and effects, ensuring that no events
- * are lost even under high load. Actions are processed sequentially, while effects can be
+ * This implementation uses unbounded channels for actions, commands, and notifications, ensuring that no events
+ * are lost even under high load. Actions are processed sequentially, while commands can be
  * processed concurrently (controlled by [concurrency]).
+ *
+ * Commands are processed internally by the EffectHandler. Notifications are exposed to external
+ * observers (coordinators, UI) and never reach the EffectHandler.
  *
  * Example usage:
  * ```
@@ -29,36 +32,37 @@ import kotlinx.coroutines.flow.receiveAsFlow
  *   initialState = MyState(),
  *   reducer = myReducer,
  *   effectHandler = myEffectHandler,
- *   initialEffects = listOf(MyEffect.LoadInitialData),
+ *   initialCommands = listOf(MyCommand.LoadInitialData),
  * )
  *
  * feature.launchIn(viewModelScope)
  * feature.send(MyAction.ButtonClicked)
+ * feature.notifications.collect { notification -> handleNotification(notification) }
  * ```
  *
  * @param initialState The initial state of the feature
- * @param reducer The reducer that processes actions and produces state changes and effects
- * @param effectHandler The handler that processes effects and produces actions
- * @param initialEffects Effects to process immediately when [launchIn] is called
- * @param concurrency The number of concurrent coroutines to process effects.
+ * @param reducer The reducer that processes actions and produces state changes, commands, and notifications
+ * @param effectHandler The handler that processes commands and produces actions
+ * @param initialCommands Commands to process immediately when [launchIn] is called
+ * @param concurrency The number of concurrent coroutines to process commands.
  *   Defaults to [DEFAULT_CONCURRENCY]. Increase this value if your effect handler
  *   performs many parallel operations.
  */
 @OptIn(FlowPreview::class)
-public open class FeatureImpl<Action, State, Effect>(
+public open class FeatureImpl<Action, State, Command, Notification>(
   initialState: State,
-  private val reducer: Reducer<Action, State, Effect>,
-  private val effectHandler: EffectHandler<Effect, Action>,
-  private val initialEffects: List<Effect> = emptyList(),
+  private val reducer: Reducer<Action, State, Command, Notification>,
+  private val effectHandler: EffectHandler<Command, Action>,
+  private val initialCommands: List<Command> = emptyList(),
   private val concurrency: Int = DEFAULT_CONCURRENCY,
-) : Feature<Action, State, Effect> {
+) : Feature<Action, State, Command, Notification> {
   private val _state: MutableStateFlow<State> = MutableStateFlow(initialState)
   override val state: StateFlow<State> = _state.asStateFlow()
 
   private val actionChannel: Channel<Action> = Channel(Channel.UNLIMITED)
-  private val effectQueue: Channel<Effect> = Channel(Channel.UNLIMITED)
-  private val effectBroadcast: Channel<Effect> = Channel(Channel.UNLIMITED)
-  override val effects: Flow<Effect> = effectBroadcast.receiveAsFlow()
+  private val commandQueue: Channel<Command> = Channel(Channel.UNLIMITED)
+  private val notificationBroadcast: Channel<Notification> = Channel(Channel.UNLIMITED)
+  override val notifications: Flow<Notification> = notificationBroadcast.receiveAsFlow()
 
   @OptIn(ExperimentalCoroutinesApi::class)
   override fun launchIn(scope: CoroutineScope) {
@@ -67,13 +71,13 @@ public open class FeatureImpl<Action, State, Effect>(
       .onEach(::dispatch)
       .launchIn(scope)
 
-    effectQueue
+    commandQueue
       .receiveAsFlow()
       .flatMapMerge(concurrency) { effectHandler(it) }
       .onEach(::send)
       .launchIn(scope)
 
-    initialEffects.forEach(::enqueueEffect)
+    initialCommands.forEach(::enqueueCommand)
   }
 
   override fun send(action: Action) {
@@ -81,13 +85,17 @@ public open class FeatureImpl<Action, State, Effect>(
   }
 
   private fun dispatch(action: Action) {
-    val (newState, newEffects) = reducer(action, state.value)
+    val (newState, effects) = reducer(action, state.value)
     _state.value = newState
-    newEffects.forEach(::enqueueEffect)
+    effects.commands.forEach(::enqueueCommand)
+    effects.notifications.forEach(::emitNotification)
   }
 
-  private fun enqueueEffect(effect: Effect) {
-    effectQueue.trySend(effect)
-    effectBroadcast.trySend(effect)
+  private fun enqueueCommand(command: Command) {
+    commandQueue.trySend(command)
+  }
+
+  private fun emitNotification(notification: Notification) {
+    notificationBroadcast.trySend(notification)
   }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/ReducerDsl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/elm/ReducerDsl.kt
@@ -3,60 +3,78 @@
 package space.be1ski.vibits.shared.core.elm
 
 /**
- * Creates a [Reducer] using the DSL syntax.
+ * Creates a [Reducer] using the DSL syntax with Command/Notification separation.
  *
  * Simple example:
  * ```
- * val myReducer = reducer<MyAction, MyState, MyEffect> { action, state ->
+ * val myReducer = reducer<MyAction, MyState, MyCommand, MyNotification> { action, state ->
  *   when (action) {
  *     is MyAction.IncrementCounter -> state { copy(counter = counter++) }
  *     is MyAction.Reset -> {
  *       state { copy(counter = 0) }
- *       effect(MyEffect.ShowResetNotification)
+ *       notify(MyNotification.ResetCompleted)
  *     }
- *     is MyAction.LoadData -> effect(MyEffect.FetchData)
- *     is MyAction.WithEffects -> effects(MyEffect.FetchData, MyEffect.ShowLoading, MyEffect.LogAnalytics)
+ *     is MyAction.LoadData -> command(MyCommand.FetchData)
+ *     is MyAction.Multiple -> {
+ *       commands(MyCommand.FetchData, MyCommand.ShowLoading)
+ *       notify(MyNotification.LoadingStarted)
+ *     }
+ *   }
+ * }
+ * ```
+ *
+ * For features with only commands and no notifications, use [Nothing] as Notification type:
+ * ```
+ * val myReducer = reducer<MyAction, MyState, MyCommand, Nothing> { action, state ->
+ *   when (action) {
+ *     is MyAction.LoadData -> command(MyCommand.FetchData)
+ *     // notify(...) cannot be called - compile error
  *   }
  * }
  * ```
  *
  * Example when reducer is extracted to a different file:
  * ```
- * class MyReducer : Reducer<MyAction, MyState, MyEffect> by reducer({ action, state ->
+ * class MyReducer : Reducer<MyAction, MyState, MyCommand, MyNotification> by reducer({ action, state ->
  *   when (action) {
- *     is MyAction.IncrementCounter -> handleReset(state)
+ *     is MyAction.Reset -> handleReset(state)
  *     ...
  *   }
  * })
  *
- * fun ReducerContext<MyState, MyEffect>.handleReset(state: MyState) {
+ * fun ReducerContext<MyState, MyCommand, MyNotification>.handleReset(state: MyState) {
  *   state { copy(counter = 0) }
- *   effect(MyEffect.ShowResetNotification)
+ *   notify(MyNotification.ResetCompleted)
  * }
  * ```
  */
-public fun <Action, State, Effect> reducer(reduce: ReducerContext<State, Effect>.(Action, State) -> Unit): Reducer<Action, State, Effect> =
+public fun <Action, State, Command, Notification> reducer(
+  reduce: ReducerContext<State, Command, Notification>.(Action, State) -> Unit,
+): Reducer<Action, State, Command, Notification> =
   { action, state ->
-    ReducerContext<State, Effect>().apply { reduce(action, state) }.getResult(state)
+    ReducerContext<State, Command, Notification>().apply { reduce(action, state) }.getResult(state)
   }
 
 /**
- * Builder context for creating [ReducerResult] instances in a DSL-style.
+ * Builder context for creating [ReducerResult] instances in a DSL-style with Command/Notification separation.
  *
  * This class is used within the [reducer] function to provide a convenient way to build
- * state updates and collect effects. It supports multiple patterns:
+ * state updates and collect commands and notifications. It supports multiple patterns:
  *
  * - State update only: `state { copy(count = count + 1) }`
- * - Effect only: `effect(MyEffect.LogAnalytics)`
- * - State and effects: combine both in any order
- * - Multiple effects: `effects(Effect.A, Effect.B)` or `effects(listOf(...))`
+ * - Command only: `command(MyCommand.FetchData)`
+ * - Notification only: `notify(MyNotification.Completed)`
+ * - State and commands/notifications: combine in any order
+ * - Multiple commands: `commands(Command.A, Command.B)` or `commands(listOf(...))`
+ * - Multiple notifications: `notifications(Notification.A, Notification.B)`
  *
  * Note: If [state] is called multiple times, only the last transformation is applied.
- * Effects accumulate with each call to [effect] or [effects].
+ * Commands and notifications accumulate with each call.
  */
-public class ReducerContext<State, Effect> {
+public class ReducerContext<State, Command, Notification> {
   private var stateUpdate: (State.() -> State) = { this }
-  private val effects = mutableListOf<Effect>()
+  private val commands = mutableListOf<Command>()
+  private val notifications = mutableListOf<Notification>()
 
   /**
    * Updates the state using a transformation lambda.
@@ -86,44 +104,95 @@ public class ReducerContext<State, Effect> {
   }
 
   /**
-   * Adds a single effect to be executed.
+   * Adds a single command to be executed by the EffectHandler.
+   *
+   * Commands are internal side effects that are processed by the EffectHandler
+   * and never exposed to external observers.
    *
    * ```
-   * effect(MyEffect.FetchData)
+   * command(MyCommand.FetchData)
    * ```
    *
-   * @param effect The effect to add
+   * @param command The command to add
    */
-  public fun effect(effect: Effect) {
-    effects.add(effect)
+  public fun command(command: Command) {
+    commands.add(command)
   }
 
   /**
-   * Adds multiple effects to be executed.
+   * Adds multiple commands to be executed by the EffectHandler.
    *
    * ```
-   * effects(MyEffect.SaveData, MyEffect.ShowNotification, MyEffect.LogAnalytics)
+   * commands(MyCommand.SaveData, MyCommand.ShowLoading, MyCommand.LogAnalytics)
    * ```
    *
-   * @param effects The effects to add
+   * @param commands The commands to add
    */
-  public fun effects(vararg effects: Effect) {
-    effects(effects.toList())
+  public fun commands(vararg commands: Command) {
+    commands(commands.toList())
   }
 
   /**
-   * Adds a list of effects to be executed.
+   * Adds a list of commands to be executed by the EffectHandler.
    *
    * ```
-   * effects(listOf(MyEffect.SaveData, MyEffect.ShowNotification))
+   * commands(listOf(MyCommand.SaveData, MyCommand.ShowLoading))
    * ```
    *
-   * @param effects The list of effects to add
+   * @param commands The list of commands to add
    */
-  public fun effects(effects: List<Effect>) {
-    this.effects.addAll(effects)
+  public fun commands(commands: List<Command>) {
+    this.commands.addAll(commands)
   }
 
-  internal fun getResult(initialState: State): ReducerResult<State, Effect> =
-    ReducerResult(state = stateUpdate(initialState), effects = effects)
+  /**
+   * Emits a single notification to external observers (coordinators, UI).
+   *
+   * Notifications are external signals that are exposed to coordinators and UI
+   * and never reach the EffectHandler.
+   *
+   * ```
+   * notify(MyNotification.Completed)
+   * ```
+   *
+   * Note: For features with Notification type = [Nothing], calling this method
+   * will result in a compile error, which is the desired behavior.
+   *
+   * @param notification The notification to emit
+   */
+  public fun notify(notification: Notification) {
+    notifications.add(notification)
+  }
+
+  /**
+   * Emits multiple notifications to external observers.
+   *
+   * ```
+   * notifications(MyNotification.Saved, MyNotification.DialogClosed)
+   * ```
+   *
+   * @param notifications The notifications to emit
+   */
+  public fun notifications(vararg notifications: Notification) {
+    notifications(notifications.toList())
+  }
+
+  /**
+   * Emits a list of notifications to external observers.
+   *
+   * ```
+   * notifications(listOf(MyNotification.Saved, MyNotification.DialogClosed))
+   * ```
+   *
+   * @param notifications The list of notifications to emit
+   */
+  public fun notifications(notifications: List<Notification>) {
+    this.notifications.addAll(notifications)
+  }
+
+  internal fun getResult(initialState: State): ReducerResult<State, Command, Notification> =
+    ReducerResult(
+      state = stateUpdate(initialState),
+      effects = Effects(commands = commands, notifications = notifications),
+    )
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/di/HabitsFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/di/HabitsFeatureFactory.kt
@@ -15,7 +15,7 @@ fun createHabitsFeature(
   dependencies: HabitsDependencies,
   onRefresh: () -> Unit,
   initialState: HabitsState = HabitsState(),
-): Feature<HabitsAction, HabitsState, HabitsEffect> =
+): Feature<HabitsAction, HabitsState, HabitsEffect, Nothing> =
   FeatureImpl(
     initialState = initialState,
     reducer = habitsReducer,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsReducer.kt
@@ -19,7 +19,7 @@ import kotlin.random.Random
  * Pure reducer for the Habits feature.
  * All state transitions are deterministic and testable.
  */
-val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
+val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect, Nothing> =
   reducer { action, state ->
     when (action) {
       is HabitsAction.OpenEditor -> {
@@ -96,9 +96,9 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             state { copy(isLoading = true, editorError = null) }
 
             if (existing != null) {
-              effect(HabitsEffect.UpdateMemo(existing.name, content))
+              command(HabitsEffect.UpdateMemo(existing.name, content))
             } else {
-              effect(HabitsEffect.CreateMemo(content))
+              command(HabitsEffect.CreateMemo(content))
             }
           }
         }
@@ -111,7 +111,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
       is HabitsAction.ConfirmDelete -> {
         val existing = state.editorExisting ?: return@reducer
         state { copy(isLoading = true) }
-        effect(HabitsEffect.DeleteMemo(existing.name))
+        command(HabitsEffect.DeleteMemo(existing.name))
       }
 
       is HabitsAction.CancelDelete -> {
@@ -188,7 +188,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
         } else {
           val content = buildHabitsConfigContentFromList(validHabits)
           state { copy(isLoading = true) }
-          effect(HabitsEffect.CreateMemo(content))
+          command(HabitsEffect.CreateMemo(content))
         }
       }
 
@@ -216,7 +216,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             pendingConfigMemo = null,
           )
         }
-        effect(HabitsEffect.UpdateMemo(existingMemo.name, content))
+        command(HabitsEffect.UpdateMemo(existingMemo.name, content))
       }
 
       is HabitsAction.CreateNewConfigInstead -> {
@@ -229,7 +229,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             pendingConfigMemo = null,
           )
         }
-        effect(HabitsEffect.CreateMemo(content))
+        command(HabitsEffect.CreateMemo(content))
       }
 
       is HabitsAction.RequestDeleteConfig -> {
@@ -247,7 +247,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             isLoading = true,
           )
         }
-        effect(HabitsEffect.DeleteMemo(existingMemo.name))
+        command(HabitsEffect.DeleteMemo(existingMemo.name))
       }
 
       is HabitsAction.CancelDeleteConfig -> {
@@ -287,16 +287,16 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
           !hasAnySelection && existing != null -> {
             // All habits unchecked and memo exists - delete it
             state { copy(isLoading = true) }
-            effect(HabitsEffect.DeleteMemo(existing.name))
+            command(HabitsEffect.DeleteMemo(existing.name))
           }
           hasAnySelection -> {
             // Build and save the memo
             val content = buildDailyContent(day.date, config, selections)
             state { copy(isLoading = true) }
             if (existing != null) {
-              effect(HabitsEffect.UpdateMemo(existing.name, content))
+              command(HabitsEffect.UpdateMemo(existing.name, content))
             } else {
-              effect(HabitsEffect.CreateMemo(content))
+              command(HabitsEffect.CreateMemo(content))
             }
           }
           else -> {
@@ -364,7 +364,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             singleToggleConfig = emptyList(),
           )
         }
-        effect(HabitsEffect.RefreshMemos)
+        command(HabitsEffect.RefreshMemos)
       }
 
       is HabitsAction.MemoDeleted -> {
@@ -383,7 +383,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             singleToggleConfig = emptyList(),
           )
         }
-        effect(HabitsEffect.RefreshMemos)
+        command(HabitsEffect.RefreshMemos)
       }
 
       is HabitsAction.MemoOperationFailed -> {
@@ -407,7 +407,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             isInitialLoading = true,
           )
         }
-        effect(HabitsEffect.RunPrewarmAllRanges(action.memos, action.appMode))
+        command(HabitsEffect.RunPrewarmAllRanges(action.memos, action.appMode))
       }
 
       is HabitsAction.UpdateActivityData -> {
@@ -447,7 +447,7 @@ val habitsReducer: Reducer<HabitsAction, HabitsState, HabitsEffect> =
             needsCacheRefresh = false,
           )
         }
-        effect(HabitsEffect.RecalculateActivityData(action.range, action.mode, action.appMode, action.memos))
+        command(HabitsEffect.RecalculateActivityData(action.range, action.mode, action.appMode, action.memos))
       }
     }
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/di/MemosFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/di/MemosFeatureFactory.kt
@@ -12,7 +12,7 @@ fun createMemosFeature(
   dependencies: MemosDependencies,
   isOfflineMode: Boolean = false,
   initialState: MemosState = MemosState(),
-): Feature<MemosAction, MemosState, MemosEffect> {
+): Feature<MemosAction, MemosState, MemosEffect, Nothing> {
   val creds = dependencies.loadCredentials()
   val needsCredentials = !isOfflineMode && (creds.baseUrl.isBlank() || creds.token.isBlank())
 
@@ -35,6 +35,6 @@ fun createMemosFeature(
         updateMemo = dependencies.updateMemo,
         deleteMemo = dependencies.deleteMemo,
       ),
-    initialEffects = if (!needsCredentials) listOf(MemosEffect.LoadCachedMemos) else emptyList(),
+    initialCommands = if (!needsCredentials) listOf(MemosEffect.LoadCachedMemos) else emptyList(),
   )
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducer.kt
@@ -10,7 +10,7 @@ private const val MILLIS_PER_DAY = 86400000L
 /**
  * Pure reducer for the Memos feature.
  */
-val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
+val memosReducer: Reducer<MemosAction, MemosState, MemosEffect, Nothing> =
   reducer { action, state ->
     when (action) {
       // Credentials input
@@ -24,7 +24,7 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
 
       is MemosAction.EditCredentials -> {
         state { copy(credentialsMode = true, errorMessage = null) }
-        effect(MemosEffect.LoadCredentials)
+        command(MemosEffect.LoadCredentials)
       }
 
       is MemosAction.CredentialsLoaded -> {
@@ -38,14 +38,14 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
         } else {
           state { copy(isLoading = true, errorMessage = null, credentialsMode = false) }
           if (!state.isOfflineMode) {
-            effect(MemosEffect.SaveCredentials(state.baseUrl, state.token))
+            command(MemosEffect.SaveCredentials(state.baseUrl, state.token))
           }
-          effect(MemosEffect.LoadRemoteMemos)
+          command(MemosEffect.LoadRemoteMemos)
         }
       }
 
       is MemosAction.LoadCachedMemos -> {
-        effect(MemosEffect.LoadCachedMemos)
+        command(MemosEffect.LoadCachedMemos)
       }
 
       is MemosAction.ResetForModeChange -> {
@@ -82,7 +82,7 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
         } else if (!state.isOfflineMode) {
           // Cache is empty and we're online - load from server immediately
           state { copy(isLoading = true) }
-          effect(MemosEffect.LoadRemoteMemos)
+          command(MemosEffect.LoadRemoteMemos)
         } else {
           // Offline mode with no cache - mark as loaded
           state { copy(initialDataLoaded = true) }
@@ -104,17 +104,17 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
       // CRUD
       is MemosAction.CreateMemo -> {
         state { copy(isLoading = true) }
-        effect(MemosEffect.CreateMemo(action.content))
+        command(MemosEffect.CreateMemo(action.content))
       }
 
       is MemosAction.UpdateMemo -> {
         state { copy(isLoading = true) }
-        effect(MemosEffect.UpdateMemo(action.name, action.content))
+        command(MemosEffect.UpdateMemo(action.name, action.content))
       }
 
       is MemosAction.DeleteMemo -> {
         state { copy(isLoading = true) }
-        effect(MemosEffect.DeleteMemo(action.name))
+        command(MemosEffect.DeleteMemo(action.name))
       }
 
       is MemosAction.MemoCreated -> {
@@ -158,7 +158,7 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
         val content = state.createDialogContent.trim()
         if (content.isNotBlank()) {
           state { copy(showCreateDialog = false, createDialogContent = "", isLoading = true) }
-          effect(MemosEffect.CreateMemo(content))
+          command(MemosEffect.CreateMemo(content))
         }
       }
 
@@ -186,7 +186,7 @@ val memosReducer: Reducer<MemosAction, MemosState, MemosEffect> =
         val content = state.editDialogContent.trim()
         if (memo != null && content.isNotBlank()) {
           state { copy(showEditDialog = false, editDialogContent = "", editDialogMemo = null, isLoading = true) }
-          effect(MemosEffect.UpdateMemo(memo.name, content))
+          command(MemosEffect.UpdateMemo(memo.name, content))
         }
       }
     }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/di/ModeSelectionFeatureFactory.kt
@@ -11,7 +11,7 @@ import space.be1ski.vibits.shared.feature.mode.presentation.modeSelectionReducer
 fun createModeSelectionFeature(
   dependencies: ModeSelectionDependencies,
   initialState: ModeSelectionState = ModeSelectionState(),
-): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect> =
+): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> =
   FeatureImpl(
     initialState = initialState,
     reducer = modeSelectionReducer,
@@ -23,5 +23,5 @@ fun createModeSelectionFeature(
         saveCredentials = dependencies.saveCredentials,
         saveAppMode = dependencies.saveAppMode,
       ),
-    initialEffects = listOf(ModeSelectionEffect.InitializeFromLocalConfig),
+    initialCommands = listOf(ModeSelectionEffect.Command.InitializeFromLocalConfig),
   )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffect.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffect.kt
@@ -3,29 +3,37 @@ package space.be1ski.vibits.shared.feature.mode.presentation
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
 sealed interface ModeSelectionEffect {
-  // Async operations (handled by EffectHandler)
-  data object InitializeFromLocalConfig : ModeSelectionEffect
+  /**
+   * Commands handled by ModeSelectionEffectHandler (async operations).
+   */
+  sealed interface Command : ModeSelectionEffect {
+    data object InitializeFromLocalConfig : Command
 
-  data object CheckStoredCredentials : ModeSelectionEffect
+    data object CheckStoredCredentials : Command
 
-  data object UseStoredCredentialsWithValidation : ModeSelectionEffect
+    data object UseStoredCredentialsWithValidation : Command
 
-  data class ValidateCredentials(
-    val baseUrl: String,
-    val token: String,
-  ) : ModeSelectionEffect
+    data class ValidateCredentials(
+      val baseUrl: String,
+      val token: String,
+    ) : Command
 
-  data class SaveCredentials(
-    val baseUrl: String,
-    val token: String,
-  ) : ModeSelectionEffect
+    data class SaveCredentials(
+      val baseUrl: String,
+      val token: String,
+    ) : Command
 
-  data class SaveMode(
-    val mode: AppMode,
-  ) : ModeSelectionEffect
+    data class SaveMode(
+      val mode: AppMode,
+    ) : Command
+  }
 
-  // Parent notifications (observed by AppRoot)
-  data class NotifyModeSelected(
-    val mode: AppMode,
-  ) : ModeSelectionEffect
+  /**
+   * Notifications observed by AppRoot for cross-feature coordination.
+   */
+  sealed interface Notification : ModeSelectionEffect {
+    data class ModeSelected(
+      val mode: AppMode,
+    ) : Notification
+  }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandler.kt
@@ -22,17 +22,15 @@ class ModeSelectionEffectHandler(
   private val loadCredentials: LoadCredentialsUseCase,
   private val saveCredentials: SaveCredentialsUseCase,
   private val saveAppMode: SaveAppModeUseCase,
-) : EffectHandler<ModeSelectionEffect, ModeSelectionAction> {
-  override fun invoke(effect: ModeSelectionEffect): Flow<ModeSelectionAction> =
-    when (effect) {
-      is ModeSelectionEffect.InitializeFromLocalConfig -> handleInitializeFromLocalConfig()
-      is ModeSelectionEffect.CheckStoredCredentials -> handleCheckStoredCredentials()
-      is ModeSelectionEffect.UseStoredCredentialsWithValidation -> handleUseStoredCredentials()
-      is ModeSelectionEffect.ValidateCredentials -> handleValidateCredentials(effect)
-      is ModeSelectionEffect.SaveCredentials -> handleSaveCredentials(effect)
-      is ModeSelectionEffect.SaveMode -> handleSaveMode(effect)
-      // Parent notification effects are not handled here - they flow through to AppRoot
-      is ModeSelectionEffect.NotifyModeSelected -> emptyFlow()
+) : EffectHandler<ModeSelectionEffect.Command, ModeSelectionAction> {
+  override fun invoke(command: ModeSelectionEffect.Command): Flow<ModeSelectionAction> =
+    when (command) {
+      is ModeSelectionEffect.Command.InitializeFromLocalConfig -> handleInitializeFromLocalConfig()
+      is ModeSelectionEffect.Command.CheckStoredCredentials -> handleCheckStoredCredentials()
+      is ModeSelectionEffect.Command.UseStoredCredentialsWithValidation -> handleUseStoredCredentials()
+      is ModeSelectionEffect.Command.ValidateCredentials -> handleValidateCredentials(command)
+      is ModeSelectionEffect.Command.SaveCredentials -> handleSaveCredentials(command)
+      is ModeSelectionEffect.Command.SaveMode -> handleSaveMode(command)
     }
 
   private fun handleInitializeFromLocalConfig(): Flow<ModeSelectionAction> =
@@ -72,23 +70,23 @@ class ModeSelectionEffectHandler(
         .onFailure { emit(ModeSelectionAction.ValidationFailed) }
     }
 
-  private fun handleValidateCredentials(effect: ModeSelectionEffect.ValidateCredentials): Flow<ModeSelectionAction> =
+  private fun handleValidateCredentials(command: ModeSelectionEffect.Command.ValidateCredentials): Flow<ModeSelectionAction> =
     flow {
       Log.d(TAG, "Testing connection")
-      connectionTester(effect.baseUrl, effect.token)
+      connectionTester(command.baseUrl, command.token)
         .onSuccess { emit(ModeSelectionAction.ValidationSucceeded) }
         .onFailure { emit(ModeSelectionAction.ValidationFailed) }
     }
 
-  private fun handleSaveCredentials(effect: ModeSelectionEffect.SaveCredentials): Flow<ModeSelectionAction> =
+  private fun handleSaveCredentials(command: ModeSelectionEffect.Command.SaveCredentials): Flow<ModeSelectionAction> =
     flow {
       Log.d(TAG, "Saving credentials")
-      saveCredentials(Credentials(effect.baseUrl, effect.token))
+      saveCredentials(Credentials(command.baseUrl, command.token))
     }
 
-  private fun handleSaveMode(effect: ModeSelectionEffect.SaveMode): Flow<ModeSelectionAction> =
+  private fun handleSaveMode(command: ModeSelectionEffect.Command.SaveMode): Flow<ModeSelectionAction> =
     flow {
-      Log.i(TAG, "Saving mode: ${effect.mode}")
-      saveAppMode(effect.mode)
+      Log.i(TAG, "Saving mode: ${command.mode}")
+      saveAppMode(command.mode)
     }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducer.kt
@@ -4,7 +4,7 @@ import space.be1ski.vibits.shared.core.elm.Reducer
 import space.be1ski.vibits.shared.core.elm.reducer
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
-val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect> =
+val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> =
   reducer { action, state ->
     when (action) {
       is ModeSelectionAction.StoredCredentialsFound -> {
@@ -21,7 +21,7 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
 
       is ModeSelectionAction.UseStoredCredentials -> {
         state { copy(showQuickOnlineDialog = false, isValidating = true) }
-        effect(ModeSelectionEffect.UseStoredCredentialsWithValidation)
+        command(ModeSelectionEffect.Command.UseStoredCredentialsWithValidation)
       }
 
       is ModeSelectionAction.ShowCredentialsDialog -> {
@@ -55,7 +55,7 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
           state { copy(error = ModeSelectionError.FILL_ALL_FIELDS) }
         } else {
           state { copy(isValidating = true, error = null) }
-          effect(ModeSelectionEffect.ValidateCredentials(baseUrl, token))
+          command(ModeSelectionEffect.Command.ValidateCredentials(baseUrl, token))
         }
       }
 
@@ -76,10 +76,10 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
         }
         // Only save credentials if they were manually entered
         if (wasManuallyEntered) {
-          effect(ModeSelectionEffect.SaveCredentials(capturedBaseUrl, capturedToken))
+          command(ModeSelectionEffect.Command.SaveCredentials(capturedBaseUrl, capturedToken))
         }
-        effect(ModeSelectionEffect.SaveMode(AppMode.ONLINE))
-        effect(ModeSelectionEffect.NotifyModeSelected(AppMode.ONLINE))
+        command(ModeSelectionEffect.Command.SaveMode(AppMode.ONLINE))
+        notify(ModeSelectionEffect.Notification.ModeSelected(AppMode.ONLINE))
       }
 
       is ModeSelectionAction.ValidationFailed -> {
@@ -88,8 +88,8 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
 
       is ModeSelectionAction.SelectMode -> {
         state { copy(showQuickOnlineDialog = false) }
-        effect(ModeSelectionEffect.SaveMode(action.mode))
-        effect(ModeSelectionEffect.NotifyModeSelected(action.mode))
+        command(ModeSelectionEffect.Command.SaveMode(action.mode))
+        notify(ModeSelectionEffect.Notification.ModeSelected(action.mode))
       }
     }
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
@@ -54,7 +54,9 @@ import space.be1ski.vibits.shared.generated.msg_connection_failed
 import space.be1ski.vibits.shared.generated.msg_fill_all_fields
 
 @Composable
-fun ModeSelectionScreen(feature: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect>) {
+fun ModeSelectionScreen(
+  feature: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification>,
+) {
   val state by feature.state.collectAsState()
   val dispatch: (ModeSelectionAction) -> Unit = feature::send
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/di/OnboardingFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/di/OnboardingFeatureFactory.kt
@@ -11,7 +11,7 @@ import space.be1ski.vibits.shared.feature.onboarding.presentation.onboardingRedu
 fun createOnboardingFeature(
   dependencies: OnboardingDependencies,
   initialState: OnboardingState = OnboardingState(),
-): Feature<OnboardingAction, OnboardingState, OnboardingEffect> =
+): Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification> =
   FeatureImpl(
     initialState = initialState,
     reducer = onboardingReducer,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingAction.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingAction.kt
@@ -45,6 +45,4 @@ sealed interface OnboardingAction {
   data object FirstCheckInCreated : OnboardingAction
 
   data object GoToDashboard : OnboardingAction
-
-  data object OnboardingCompleted : OnboardingAction
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingEffectHandler.kt
@@ -17,17 +17,11 @@ class OnboardingEffectHandler(
   private val createFirstHabit: CreateFirstHabitUseCase,
   private val createFirstCheckIn: CreateFirstCheckInUseCase,
   private val markOnboardingCompleted: MarkOnboardingCompletedUseCase,
-) : EffectHandler<OnboardingEffect, OnboardingAction> {
-  override fun invoke(effect: OnboardingEffect): Flow<OnboardingAction> =
-    when (effect) {
-      is OnboardingEffect.Command -> handleCommand(effect)
-      is OnboardingEffect.Notification -> emptyFlow()
-    }
-
-  private fun handleCommand(effect: OnboardingEffect.Command): Flow<OnboardingAction> =
-    when (effect) {
+) : EffectHandler<OnboardingEffect.Command, OnboardingAction> {
+  override fun invoke(command: OnboardingEffect.Command): Flow<OnboardingAction> =
+    when (command) {
       is OnboardingEffect.Command.LoadPresets -> handleLoadPresets()
-      is OnboardingEffect.Command.CreateFirstHabit -> handleCreateFirstHabit(effect)
+      is OnboardingEffect.Command.CreateFirstHabit -> handleCreateFirstHabit(command)
       is OnboardingEffect.Command.MarkOnboardingCompleted -> handleMarkOnboardingCompleted()
       is OnboardingEffect.Command.MarkFirstCheckIn -> handleMarkFirstCheckIn()
     }
@@ -39,10 +33,10 @@ class OnboardingEffectHandler(
       emit(OnboardingAction.PresetsLoaded(presets))
     }
 
-  private fun handleCreateFirstHabit(effect: OnboardingEffect.Command.CreateFirstHabit): Flow<OnboardingAction> =
+  private fun handleCreateFirstHabit(command: OnboardingEffect.Command.CreateFirstHabit): Flow<OnboardingAction> =
     flow {
-      Log.d(TAG, "Creating first habit: ${effect.name}")
-      createFirstHabit(effect.name, effect.presetId, effect.color)
+      Log.d(TAG, "Creating first habit: ${command.name}")
+      createFirstHabit(command.name, command.presetId, command.color)
         .onSuccess {
           Log.d(TAG, "Habit created successfully")
           emit(OnboardingAction.HabitCreated)
@@ -56,7 +50,6 @@ class OnboardingEffectHandler(
     flow {
       Log.i(TAG, "Marking onboarding as completed")
       markOnboardingCompleted()
-      emit(OnboardingAction.OnboardingCompleted)
     }
 
   private fun handleMarkFirstCheckIn(): Flow<OnboardingAction> =

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducer.kt
@@ -3,13 +3,13 @@ package space.be1ski.vibits.shared.feature.onboarding.presentation
 import space.be1ski.vibits.shared.core.elm.Reducer
 import space.be1ski.vibits.shared.core.elm.reducer
 
-val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffect> =
+val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification> =
   reducer { action, state ->
     when (action) {
       // Navigation
       is OnboardingAction.StartOnboarding -> {
         state { copy(currentStep = OnboardingStep.Welcome) }
-        effect(OnboardingEffect.Command.LoadPresets)
+        command(OnboardingEffect.Command.LoadPresets)
       }
 
       is OnboardingAction.Continue -> {
@@ -23,7 +23,7 @@ val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffe
           OnboardingStep.HabitSetup -> {
             if (state.habitName.isNotBlank()) {
               state { copy(isCreatingHabit = true, creationError = null) }
-              effect(
+              command(
                 OnboardingEffect.Command.CreateFirstHabit(
                   state.habitName,
                   state.selectedPresetId,
@@ -49,7 +49,7 @@ val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffe
       }
 
       is OnboardingAction.Skip -> {
-        effect(OnboardingEffect.Notification.Skipped)
+        notify(OnboardingEffect.Notification.Skipped)
       }
 
       // Preset selection
@@ -73,7 +73,7 @@ val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffe
       is OnboardingAction.CreateHabit -> {
         if (state.habitName.isNotBlank()) {
           state { copy(isCreatingHabit = true, creationError = null) }
-          effect(
+          command(
             OnboardingEffect.Command.CreateFirstHabit(
               state.habitName,
               state.selectedPresetId,
@@ -107,22 +107,18 @@ val onboardingReducer: Reducer<OnboardingAction, OnboardingState, OnboardingEffe
 
       // Completion
       is OnboardingAction.MarkFirstCheckIn -> {
-        effect(OnboardingEffect.Command.MarkFirstCheckIn)
-        effect(OnboardingEffect.Command.MarkOnboardingCompleted)
+        command(OnboardingEffect.Command.MarkFirstCheckIn)
+        command(OnboardingEffect.Command.MarkOnboardingCompleted)
       }
 
       is OnboardingAction.FirstCheckInCreated -> {
-        effect(OnboardingEffect.Notification.FirstCheckInCreated)
-        effect(OnboardingEffect.Notification.Completed)
+        notify(OnboardingEffect.Notification.FirstCheckInCreated)
+        notify(OnboardingEffect.Notification.Completed)
       }
 
       is OnboardingAction.GoToDashboard -> {
-        effect(OnboardingEffect.Command.MarkOnboardingCompleted)
-        effect(OnboardingEffect.Notification.Completed)
-      }
-
-      is OnboardingAction.OnboardingCompleted -> {
-        // Handled by coordinator
+        command(OnboardingEffect.Command.MarkOnboardingCompleted)
+        notify(OnboardingEffect.Notification.Completed)
       }
     }
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
@@ -15,7 +15,7 @@ fun createSettingsFeature(
   initialMode: AppMode,
   appDetails: AppDetails,
   initialState: SettingsState = SettingsState(),
-): Feature<SettingsAction, SettingsState, SettingsEffect> =
+): Feature<SettingsAction, SettingsState, SettingsEffect.Command, SettingsEffect.Notification> =
   FeatureImpl(
     initialState =
       initialState.copy(

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
@@ -22,42 +22,36 @@ class SettingsEffectHandler(
   private val resetApp: ResetAppUseCase,
   private val saveLanguage: SaveLanguageUseCase,
   private val saveTheme: SaveThemeUseCase,
-) : EffectHandler<SettingsEffect, SettingsAction> {
-  override fun invoke(effect: SettingsEffect): Flow<SettingsAction> =
-    when (effect) {
-      is SettingsEffect.Command -> handleCommand(effect)
-      is SettingsEffect.Notification -> emptyFlow()
-    }
-
-  private fun handleCommand(effect: SettingsEffect.Command): Flow<SettingsAction> =
-    when (effect) {
-      is SettingsEffect.Command.ValidateCredentials -> handleValidateCredentials(effect)
-      is SettingsEffect.Command.SwitchMode -> handleSwitchMode(effect)
-      is SettingsEffect.Command.SaveCredentials -> handleSaveCredentials(effect)
+) : EffectHandler<SettingsEffect.Command, SettingsAction> {
+  override fun invoke(command: SettingsEffect.Command): Flow<SettingsAction> =
+    when (command) {
+      is SettingsEffect.Command.ValidateCredentials -> handleValidateCredentials(command)
+      is SettingsEffect.Command.SwitchMode -> handleSwitchMode(command)
+      is SettingsEffect.Command.SaveCredentials -> handleSaveCredentials(command)
       is SettingsEffect.Command.ResetApp -> handleResetApp()
-      is SettingsEffect.Command.SaveLanguage -> handleSaveLanguage(effect)
-      is SettingsEffect.Command.SaveTheme -> handleSaveTheme(effect)
+      is SettingsEffect.Command.SaveLanguage -> handleSaveLanguage(command)
+      is SettingsEffect.Command.SaveTheme -> handleSaveTheme(command)
     }
 
-  private fun handleValidateCredentials(effect: SettingsEffect.Command.ValidateCredentials): Flow<SettingsAction> =
+  private fun handleValidateCredentials(command: SettingsEffect.Command.ValidateCredentials): Flow<SettingsAction> =
     flow {
       Log.d(TAG, "Testing connection")
-      connectionTester(effect.baseUrl, effect.token)
+      connectionTester(command.baseUrl, command.token)
         .onSuccess { emit(SettingsAction.ValidationSucceeded) }
         .onFailure { emit(SettingsAction.ValidationFailed("connection_failed")) }
     }
 
-  private fun handleSwitchMode(effect: SettingsEffect.Command.SwitchMode): Flow<SettingsAction> =
+  private fun handleSwitchMode(command: SettingsEffect.Command.SwitchMode): Flow<SettingsAction> =
     flow {
-      Log.i(TAG, "Switching mode to ${effect.mode}")
-      switchAppMode(effect.mode)
+      Log.i(TAG, "Switching mode to ${command.mode}")
+      switchAppMode(command.mode)
       emit(SettingsAction.ModeSwitched)
     }
 
-  private fun handleSaveCredentials(effect: SettingsEffect.Command.SaveCredentials): Flow<SettingsAction> =
+  private fun handleSaveCredentials(command: SettingsEffect.Command.SaveCredentials): Flow<SettingsAction> =
     flow {
       Log.d(TAG, "Saving credentials")
-      saveCredentials(Credentials(effect.baseUrl, effect.token))
+      saveCredentials(Credentials(command.baseUrl, command.token))
     }
 
   private fun handleResetApp(): Flow<SettingsAction> =
@@ -67,15 +61,15 @@ class SettingsEffectHandler(
       emit(SettingsAction.ResetCompleted)
     }
 
-  private fun handleSaveLanguage(effect: SettingsEffect.Command.SaveLanguage): Flow<SettingsAction> =
+  private fun handleSaveLanguage(command: SettingsEffect.Command.SaveLanguage): Flow<SettingsAction> =
     emptyFlow<SettingsAction>().also {
-      Log.i(TAG, "Language changed to ${effect.language}")
-      saveLanguage(effect.language)
+      Log.i(TAG, "Language changed to ${command.language}")
+      saveLanguage(command.language)
     }
 
-  private fun handleSaveTheme(effect: SettingsEffect.Command.SaveTheme): Flow<SettingsAction> =
+  private fun handleSaveTheme(command: SettingsEffect.Command.SaveTheme): Flow<SettingsAction> =
     emptyFlow<SettingsAction>().also {
-      Log.i(TAG, "Theme changed to ${effect.theme}")
-      saveTheme(effect.theme)
+      Log.i(TAG, "Theme changed to ${command.theme}")
+      saveTheme(command.theme)
     }
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducer.kt
@@ -6,7 +6,7 @@ import space.be1ski.vibits.shared.core.elm.Reducer
 import space.be1ski.vibits.shared.core.elm.reducer
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 
-val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
+val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect.Command, SettingsEffect.Notification> =
   reducer { action, state ->
     when (action) {
       // Dialog lifecycle
@@ -39,7 +39,7 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
             showLogsDialog = false,
           )
         }
-        effect(SettingsEffect.Notification.DialogClosed)
+        notify(SettingsEffect.Notification.DialogClosed)
       }
 
       is SettingsAction.Dismiss -> {
@@ -52,7 +52,7 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
             showLogsDialog = false,
           )
         }
-        effect(SettingsEffect.Notification.DialogClosed)
+        notify(SettingsEffect.Notification.DialogClosed)
       }
 
       // Credentials - just update local state, save on Save action
@@ -83,13 +83,13 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
       is SettingsAction.ValidationSucceeded -> {
         // Validation succeeded - save all settings and close dialog
         state { copy(isValidating = false, isOpen = false, pendingSave = false, appMode = AppMode.ONLINE) }
-        effect(SettingsEffect.Command.SaveCredentials(state.editBaseUrl, state.editToken))
-        effect(SettingsEffect.Command.SwitchMode(AppMode.ONLINE))
-        effect(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
-        effect(SettingsEffect.Command.SaveTheme(state.selectedTheme))
-        effect(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
-        effect(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
-        effect(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))
+        command(SettingsEffect.Command.SaveCredentials(state.editBaseUrl, state.editToken))
+        command(SettingsEffect.Command.SwitchMode(AppMode.ONLINE))
+        command(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
+        command(SettingsEffect.Command.SaveTheme(state.selectedTheme))
+        notify(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
+        notify(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
+        notify(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))
       }
 
       is SettingsAction.ValidationFailed -> {
@@ -97,7 +97,7 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
       }
 
       is SettingsAction.ModeSwitched -> {
-        effect(SettingsEffect.Notification.ModeChanged(state.appMode))
+        notify(SettingsEffect.Notification.ModeChanged(state.appMode))
       }
 
       // Reset flow
@@ -107,7 +107,7 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
 
       is SettingsAction.ConfirmReset -> {
         state { copy(showResetConfirmation = false, isResetting = true) }
-        effect(SettingsEffect.Command.ResetApp)
+        command(SettingsEffect.Command.ResetApp)
       }
 
       is SettingsAction.CancelReset -> {
@@ -116,7 +116,7 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
 
       is SettingsAction.ResetCompleted -> {
         state { copy(isOpen = false, isResetting = false) }
-        effect(SettingsEffect.Notification.ResetCompleted)
+        notify(SettingsEffect.Notification.ResetCompleted)
       }
 
       // Logs
@@ -138,18 +138,18 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect> =
           } else {
             // Validate before saving in Online mode
             state { copy(isValidating = true, validationError = null, pendingSave = true) }
-            effect(SettingsEffect.Command.ValidateCredentials(baseUrl, token, AppMode.ONLINE))
+            command(SettingsEffect.Command.ValidateCredentials(baseUrl, token, AppMode.ONLINE))
           }
         } else {
           // Save all settings and close dialog
           state { copy(isOpen = false) }
-          effect(SettingsEffect.Command.SaveCredentials(state.editBaseUrl, state.editToken))
-          effect(SettingsEffect.Command.SwitchMode(state.appMode))
-          effect(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
-          effect(SettingsEffect.Command.SaveTheme(state.selectedTheme))
-          effect(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
-          effect(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
-          effect(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))
+          command(SettingsEffect.Command.SaveCredentials(state.editBaseUrl, state.editToken))
+          command(SettingsEffect.Command.SwitchMode(state.appMode))
+          command(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
+          command(SettingsEffect.Command.SaveTheme(state.selectedTheme))
+          notify(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
+          notify(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
+          notify(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))
         }
       }
     }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/app/presentation/AppReducerTest.kt
@@ -29,7 +29,7 @@ class AppReducerTest {
       send(AppAction.SetHabitsTimeRangeTab(TimeRangeTab.MONTHS))
 
       assertState { habitsTimeRangeTab == TimeRangeTab.MONTHS }
-      val effect = assertHasEffect<AppEffect.SaveHabitsTimeRangeTab>()
+      val effect = assertHasCommand<AppEffect.SaveHabitsTimeRangeTab>()
       assertEquals(TimeRangeTab.MONTHS, effect.tab)
     }
 
@@ -39,7 +39,7 @@ class AppReducerTest {
       send(AppAction.SetPostsTimeRangeTab(TimeRangeTab.QUARTERS))
 
       assertState { postsTimeRangeTab == TimeRangeTab.QUARTERS }
-      val effect = assertHasEffect<AppEffect.SavePostsTimeRangeTab>()
+      val effect = assertHasCommand<AppEffect.SavePostsTimeRangeTab>()
       assertEquals(TimeRangeTab.QUARTERS, effect.tab)
     }
 
@@ -71,7 +71,7 @@ class AppReducerTest {
       send(AppAction.ChangeHabitsTab(oldTab = TimeRangeTab.MONTHS, newTab = TimeRangeTab.WEEKS))
 
       assertState { habitsTimeRangeTab == TimeRangeTab.WEEKS && periodStartDate == LocalDate(2024, Month.MARCH, 31) }
-      assertHasEffect<AppEffect.SaveHabitsTimeRangeTab>()
+      assertHasCommand<AppEffect.SaveHabitsTimeRangeTab>()
     }
 
   @Test
@@ -80,7 +80,7 @@ class AppReducerTest {
       send(AppAction.ChangePostsTab(oldTab = TimeRangeTab.YEARS, newTab = TimeRangeTab.QUARTERS))
 
       assertState { postsTimeRangeTab == TimeRangeTab.QUARTERS && periodStartDate == LocalDate(2024, Month.DECEMBER, 31) }
-      assertHasEffect<AppEffect.SavePostsTimeRangeTab>()
+      assertHasCommand<AppEffect.SavePostsTimeRangeTab>()
     }
 
   @Test

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/FeatureImplTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/FeatureImplTest.kt
@@ -36,14 +36,14 @@ class FeatureImplTest {
     data object NoOp : Effect
   }
 
-  private val testReducer: Reducer<Action, State, Effect> =
+  private val testReducer: Reducer<Action, State, Effect, Nothing> =
     reducer { action, _ ->
       when (action) {
         Action.Increment -> state { copy(count = count + 1) }
         Action.Decrement -> state { copy(count = count - 1) }
         Action.StartLoading -> {
           state { copy(loading = true) }
-          effect(Effect.Load)
+          command(Effect.Load)
         }
         Action.LoadingComplete -> state { copy(loading = false) }
         is Action.SetCount -> state { copy(count = action.value) }
@@ -137,7 +137,7 @@ class FeatureImplTest {
           initialState = State(),
           reducer = testReducer,
           effectHandler = createEffectHandler(loadResult = 50),
-          initialEffects = listOf(Effect.Load),
+          initialCommands = listOf(Effect.Load),
         )
       val featureScope = featureTestScope()
       feature.launchIn(featureScope)
@@ -150,21 +150,21 @@ class FeatureImplTest {
   fun `when effect handler returns multiple actions then all are processed`() =
     runTest(UnconfinedTestDispatcher()) {
       var actionCount = 0
-      val countingReducer: Reducer<Action, State, Effect> =
+      val countingReducer: Reducer<Action, State, Effect, Nothing> =
         reducer { action, _ ->
           actionCount++
           when (action) {
             Action.Increment -> state { copy(count = count + 1) }
             Action.StartLoading -> {
               state { copy(loading = true) }
-              effect(Effect.Load)
+              command(Effect.Load)
             }
             else -> {}
           }
         }
 
       val feature =
-        FeatureImpl<Action, State, Effect>(
+        FeatureImpl<Action, State, Effect, Nothing>(
           initialState = State(),
           reducer = countingReducer,
           effectHandler = { effect ->

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerContextTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerContextTest.kt
@@ -21,18 +21,18 @@ class ReducerContextTest {
 
   @Test
   fun `when no changes then getResult returns initial state with empty effects`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     val initialState = TestState(value = 42)
 
     val result = context.getResult(initialState)
 
     assertEquals(initialState, result.state)
-    assertEquals(emptyList(), result.effects)
+    assertEquals(emptyList(), result.commands)
   }
 
   @Test
   fun `when state called with lambda then transformation is applied`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     context.state { copy(value = value + 10) }
 
     val result = context.getResult(TestState(value = 5))
@@ -42,7 +42,7 @@ class ReducerContextTest {
 
   @Test
   fun `when state called with direct value then state is replaced`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     val newState = TestState(value = 100, name = "new")
     context.state(newState)
 
@@ -53,7 +53,7 @@ class ReducerContextTest {
 
   @Test
   fun `when state called multiple times then last call wins`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     context.state { copy(value = 10) }
     context.state { copy(value = 20) }
     context.state { copy(value = 30) }
@@ -65,75 +65,75 @@ class ReducerContextTest {
 
   @Test
   fun `when effect called then effect is added`() {
-    val context = ReducerContext<TestState, TestEffect>()
-    context.effect(TestEffect.EffectA)
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
+    context.command(TestEffect.EffectA)
 
     val result = context.getResult(TestState())
 
-    assertEquals(listOf(TestEffect.EffectA), result.effects)
+    assertEquals(listOf(TestEffect.EffectA), result.commands)
   }
 
   @Test
   fun `when effect called multiple times then effects accumulate`() {
-    val context = ReducerContext<TestState, TestEffect>()
-    context.effect(TestEffect.EffectA)
-    context.effect(TestEffect.EffectB)
-    context.effect(TestEffect.EffectC("data"))
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
+    context.command(TestEffect.EffectA)
+    context.command(TestEffect.EffectB)
+    context.command(TestEffect.EffectC("data"))
 
     val result = context.getResult(TestState())
 
     assertEquals(
       listOf(TestEffect.EffectA, TestEffect.EffectB, TestEffect.EffectC("data")),
-      result.effects,
+      result.commands,
     )
   }
 
   @Test
   fun `when effects called with vararg then all effects are added`() {
-    val context = ReducerContext<TestState, TestEffect>()
-    context.effects(TestEffect.EffectA, TestEffect.EffectB)
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
+    context.commands(TestEffect.EffectA, TestEffect.EffectB)
 
     val result = context.getResult(TestState())
 
-    assertEquals(listOf(TestEffect.EffectA, TestEffect.EffectB), result.effects)
+    assertEquals(listOf(TestEffect.EffectA, TestEffect.EffectB), result.commands)
   }
 
   @Test
   fun `when effects called with list then all effects are added`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     val effectList = listOf(TestEffect.EffectA, TestEffect.EffectC("test"))
-    context.effects(effectList)
+    context.commands(effectList)
 
     val result = context.getResult(TestState())
 
-    assertEquals(effectList, result.effects)
+    assertEquals(effectList, result.commands)
   }
 
   @Test
   fun `when state and effects combined then both are captured`() {
-    val context = ReducerContext<TestState, TestEffect>()
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
     context.state { copy(value = 42, name = "updated") }
-    context.effect(TestEffect.EffectA)
-    context.effects(TestEffect.EffectB, TestEffect.EffectC("combo"))
+    context.command(TestEffect.EffectA)
+    context.commands(TestEffect.EffectB, TestEffect.EffectC("combo"))
 
     val result = context.getResult(TestState())
 
     assertEquals(TestState(value = 42, name = "updated"), result.state)
     assertEquals(
       listOf(TestEffect.EffectA, TestEffect.EffectB, TestEffect.EffectC("combo")),
-      result.effects,
+      result.commands,
     )
   }
 
   @Test
   fun `when only effect without state change then initial state is preserved`() {
-    val context = ReducerContext<TestState, TestEffect>()
-    context.effect(TestEffect.EffectA)
+    val context = ReducerContext<TestState, TestEffect, Nothing>()
+    context.command(TestEffect.EffectA)
 
     val initialState = TestState(value = 99, name = "preserved")
     val result = context.getResult(initialState)
 
     assertEquals(initialState, result.state)
-    assertEquals(listOf(TestEffect.EffectA), result.effects)
+    assertEquals(listOf(TestEffect.EffectA), result.commands)
   }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTest.kt
@@ -33,20 +33,20 @@ class ReducerTest {
     data object NotifyReset : CounterEffect
   }
 
-  private val counterReducer: Reducer<CounterAction, CounterState, CounterEffect> =
+  private val counterReducer: Reducer<CounterAction, CounterState, CounterEffect, Nothing> =
     reducer { action, state ->
       when (action) {
         CounterAction.Increment -> state { copy(count = count + 1, lastAction = "increment") }
         CounterAction.Decrement -> state { copy(count = count - 1, lastAction = "decrement") }
         is CounterAction.Add -> {
           state { copy(count = count + action.amount, lastAction = "add") }
-          effect(CounterEffect.Log("Added ${action.amount}"))
+          command(CounterEffect.Log("Added ${action.amount}"))
         }
         CounterAction.Reset -> {
           state { copy(count = 0, lastAction = "reset") }
-          effects(CounterEffect.Persist, CounterEffect.NotifyReset)
+          commands(CounterEffect.Persist, CounterEffect.NotifyReset)
         }
-        CounterAction.Save -> effect(CounterEffect.Persist)
+        CounterAction.Save -> command(CounterEffect.Persist)
       }
     }
 
@@ -56,7 +56,7 @@ class ReducerTest {
 
     assertEquals(6, result.state.count)
     assertEquals("increment", result.state.lastAction)
-    assertEquals(emptyList(), result.effects)
+    assertEquals(emptyList(), result.commands)
   }
 
   @Test
@@ -65,7 +65,7 @@ class ReducerTest {
 
     assertEquals(15, result.state.count)
     assertEquals("add", result.state.lastAction)
-    assertEquals(listOf(CounterEffect.Log("Added 10")), result.effects)
+    assertEquals(listOf(CounterEffect.Log("Added 10")), result.commands)
   }
 
   @Test
@@ -74,7 +74,7 @@ class ReducerTest {
 
     assertEquals(0, result.state.count)
     assertEquals("reset", result.state.lastAction)
-    assertEquals(listOf(CounterEffect.Persist, CounterEffect.NotifyReset), result.effects)
+    assertEquals(listOf(CounterEffect.Persist, CounterEffect.NotifyReset), result.commands)
   }
 
   @Test
@@ -84,7 +84,7 @@ class ReducerTest {
     val result = counterReducer(CounterAction.Save, initialState)
 
     assertEquals(initialState, result.state)
-    assertEquals(listOf(CounterEffect.Persist), result.effects)
+    assertEquals(listOf(CounterEffect.Persist), result.commands)
   }
 
   @Test

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTestDsl.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTestDsl.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertTrue
 import kotlin.test.fail
 
 /**
- * DSL for testing reducers in a readable and concise way.
+ * DSL for testing reducers with Command/Notification separation.
  *
  * Example:
  * ```
@@ -14,32 +14,35 @@ import kotlin.test.fail
  *   send(CounterAction.Increment)
  *
  *   assertState { count == 6 }
- *   assertNoEffects()
+ *   assertNoCommands()
+ *   assertNoNotifications()
  * }
  *
  * @Test
- * fun `reset clears counter and emits effects`() = counterReducer.test(CounterState(count = 100)) {
+ * fun `reset clears counter and emits command and notification`() = counterReducer.test(CounterState(count = 100)) {
  *   send(CounterAction.Reset)
  *
  *   assertState(CounterState(count = 0))
- *   assertEffects(CounterEffect.Persist, CounterEffect.NotifyReset)
+ *   assertCommands(CounterCommand.Persist)
+ *   assertNotifications(CounterNotification.ResetCompleted)
  * }
  * ```
  */
-fun <Action, State, Effect> Reducer<Action, State, Effect>.test(
+fun <Action, State, Command, Notification> Reducer<Action, State, Command, Notification>.test(
   initialState: State,
-  block: ReducerTestScope<Action, State, Effect>.() -> Unit,
+  block: ReducerTestScope<Action, State, Command, Notification>.() -> Unit,
 ) {
   ReducerTestScope(this, initialState).apply(block)
 }
 
-class ReducerTestScope<Action, State, Effect>(
-  private val reducer: Reducer<Action, State, Effect>,
+class ReducerTestScope<Action, State, Command, Notification>(
+  private val reducer: Reducer<Action, State, Command, Notification>,
   initialState: State,
 ) {
   private var currentState: State = initialState
-  private var lastResult: ReducerResult<State, Effect>? = null
-  private val allEffects = mutableListOf<Effect>()
+  private var lastResult: ReducerResult<State, Command, Notification>? = null
+  private val allCommands = mutableListOf<Command>()
+  private val allNotifications = mutableListOf<Notification>()
 
   /**
    * Sends an action to the reducer and captures the result.
@@ -47,7 +50,8 @@ class ReducerTestScope<Action, State, Effect>(
   fun send(action: Action) {
     lastResult = reducer(action, currentState)
     currentState = lastResult!!.state
-    allEffects.addAll(lastResult!!.effects)
+    allCommands.addAll(lastResult!!.commands)
+    allNotifications.addAll(lastResult!!.notifications)
   }
 
   /**
@@ -56,14 +60,24 @@ class ReducerTestScope<Action, State, Effect>(
   val state: State get() = currentState
 
   /**
-   * Returns effects from the last action only.
+   * Returns commands from the last action only.
    */
-  val effects: List<Effect> get() = lastResult?.effects ?: emptyList()
+  val commands: List<Command> get() = lastResult?.commands ?: emptyList()
 
   /**
-   * Returns all effects accumulated from all sent actions.
+   * Returns notifications from the last action only.
    */
-  val allEmittedEffects: List<Effect> get() = allEffects.toList()
+  val notifications: List<Notification> get() = lastResult?.notifications ?: emptyList()
+
+  /**
+   * Returns all commands accumulated from all sent actions.
+   */
+  val allEmittedCommands: List<Command> get() = allCommands.toList()
+
+  /**
+   * Returns all notifications accumulated from all sent actions.
+   */
+  val allEmittedNotifications: List<Notification> get() = allNotifications.toList()
 
   /**
    * Asserts that the current state equals the expected state.
@@ -86,50 +100,106 @@ class ReducerTestScope<Action, State, Effect>(
   }
 
   /**
-   * Asserts that no effects were emitted from the last action.
+   * Asserts that no commands or notifications were emitted from the last action.
    */
   fun assertNoEffects() {
-    assertTrue(effects.isEmpty(), "Expected no effects but got: $effects")
+    assertNoCommands()
+    assertNoNotifications()
   }
 
   /**
-   * Asserts that the last action emitted exactly these effects in order.
+   * Asserts that no commands were emitted from the last action.
    */
-  fun assertEffects(vararg expected: Effect) {
-    assertEquals(expected.toList(), effects, "Effects mismatch")
+  fun assertNoCommands() {
+    assertTrue(commands.isEmpty(), "Expected no commands but got: $commands")
   }
 
   /**
-   * Asserts that the last action emitted exactly these effects in order.
+   * Asserts that no notifications were emitted from the last action.
    */
-  fun assertEffects(expected: List<Effect>) {
-    assertEquals(expected, effects, "Effects mismatch")
+  fun assertNoNotifications() {
+    assertTrue(notifications.isEmpty(), "Expected no notifications but got: $notifications")
   }
 
   /**
-   * Asserts that the last action emitted an effect of the given type.
+   * Asserts that the last action emitted exactly these commands in order.
    */
-  inline fun <reified E : Effect> assertHasEffect(): E {
-    val effect =
-      effects.filterIsInstance<E>().firstOrNull()
-        ?: fail("Expected effect of type ${E::class.simpleName} but got: $effects")
-    return effect
+  fun assertCommands(vararg expected: Command) {
+    assertEquals(expected.toList(), commands, "Commands mismatch")
   }
 
   /**
-   * Asserts that the last action emitted an effect matching the predicate.
+   * Asserts that the last action emitted exactly these commands in order.
    */
-  inline fun <reified E : Effect> assertHasEffect(predicate: (E) -> Boolean): E {
-    val effect =
-      effects.filterIsInstance<E>().firstOrNull(predicate)
-        ?: fail("Expected effect of type ${E::class.simpleName} matching predicate but got: $effects")
-    return effect
+  fun assertCommands(expected: List<Command>) {
+    assertEquals(expected, commands, "Commands mismatch")
   }
 
   /**
-   * Asserts the number of effects emitted from the last action.
+   * Asserts that the last action emitted exactly these notifications in order.
    */
-  fun assertEffectCount(expected: Int) {
-    assertEquals(expected, effects.size, "Effect count mismatch")
+  fun assertNotifications(vararg expected: Notification) {
+    assertEquals(expected.toList(), notifications, "Notifications mismatch")
+  }
+
+  /**
+   * Asserts that the last action emitted exactly these notifications in order.
+   */
+  fun assertNotifications(expected: List<Notification>) {
+    assertEquals(expected, notifications, "Notifications mismatch")
+  }
+
+  /**
+   * Asserts that the last action emitted a command of the given type.
+   */
+  inline fun <reified C : Command> assertHasCommand(): C {
+    val command =
+      commands.filterIsInstance<C>().firstOrNull()
+        ?: fail("Expected command of type ${C::class.simpleName} but got: $commands")
+    return command
+  }
+
+  /**
+   * Asserts that the last action emitted a command matching the predicate.
+   */
+  inline fun <reified C : Command> assertHasCommand(predicate: (C) -> Boolean): C {
+    val command =
+      commands.filterIsInstance<C>().firstOrNull(predicate)
+        ?: fail("Expected command of type ${C::class.simpleName} matching predicate but got: $commands")
+    return command
+  }
+
+  /**
+   * Asserts that the last action emitted a notification of the given type.
+   */
+  inline fun <reified N : Notification> assertHasNotification(): N {
+    val notification =
+      notifications.filterIsInstance<N>().firstOrNull()
+        ?: fail("Expected notification of type ${N::class.simpleName} but got: $notifications")
+    return notification
+  }
+
+  /**
+   * Asserts that the last action emitted a notification matching the predicate.
+   */
+  inline fun <reified N : Notification> assertHasNotification(predicate: (N) -> Boolean): N {
+    val notification =
+      notifications.filterIsInstance<N>().firstOrNull(predicate)
+        ?: fail("Expected notification of type ${N::class.simpleName} matching predicate but got: $notifications")
+    return notification
+  }
+
+  /**
+   * Asserts the number of commands emitted from the last action.
+   */
+  fun assertCommandCount(expected: Int) {
+    assertEquals(expected, commands.size, "Command count mismatch")
+  }
+
+  /**
+   * Asserts the number of notifications emitted from the last action.
+   */
+  fun assertNotificationCount(expected: Int) {
+    assertEquals(expected, notifications.size, "Notification count mismatch")
   }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTestDslTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/elm/ReducerTestDslTest.kt
@@ -32,15 +32,15 @@ class ReducerTestDslTest {
     data object Notify : Effect
   }
 
-  private val testReducer: Reducer<Action, State, Effect> =
+  private val testReducer: Reducer<Action, State, Effect, Nothing> =
     reducer { action, _ ->
       when (action) {
         Action.Increment -> state { copy(count = count + 1) }
         is Action.SetText -> state { copy(text = action.value) }
-        Action.Save -> effect(Effect.Persist)
+        Action.Save -> command(Effect.Persist)
         Action.Complex -> {
           state { copy(count = count + 10, text = "complex") }
-          effects(Effect.Persist, Effect.Log("complex action"), Effect.Notify)
+          commands(Effect.Persist, Effect.Log("complex action"), Effect.Notify)
         }
       }
     }
@@ -65,40 +65,40 @@ class ReducerTestDslTest {
     }
 
   @Test
-  fun `when effect-only action then state is preserved`() =
+  fun `when command-only action then state is preserved`() =
     testReducer.test(State(count = 42, text = "preserved")) {
       send(Action.Save)
 
       assertState(State(count = 42, text = "preserved"))
-      assertEffects(Effect.Persist)
+      assertCommands(Effect.Persist)
     }
 
   @Test
-  fun `when action with multiple effects then all effects are captured`() =
+  fun `when action with multiple commands then all commands are captured`() =
     testReducer.test(State()) {
       send(Action.Complex)
 
-      assertEffects(Effect.Persist, Effect.Log("complex action"), Effect.Notify)
-      assertEffectCount(3)
+      assertCommands(Effect.Persist, Effect.Log("complex action"), Effect.Notify)
+      assertCommandCount(3)
     }
 
   @Test
-  fun `when assertHasEffect then effect is found by type`() =
+  fun `when assertHasCommand then command is found by type`() =
     testReducer.test(State()) {
       send(Action.Complex)
 
-      assertHasEffect<Effect.Persist>()
-      assertHasEffect<Effect.Notify>()
-      val log = assertHasEffect<Effect.Log>()
+      assertHasCommand<Effect.Persist>()
+      assertHasCommand<Effect.Notify>()
+      val log = assertHasCommand<Effect.Log>()
       assertEquals("complex action", log.msg)
     }
 
   @Test
-  fun `when assertHasEffect with predicate then matching effect is found`() =
+  fun `when assertHasCommand with predicate then matching command is found`() =
     testReducer.test(State()) {
       send(Action.Complex)
 
-      assertHasEffect<Effect.Log> { it.msg.contains("complex") }
+      assertHasCommand<Effect.Log> { it.msg.contains("complex") }
     }
 
   @Test
@@ -116,13 +116,13 @@ class ReducerTestDslTest {
     }
 
   @Test
-  fun `when multiple actions then allEmittedEffects accumulates`() =
+  fun `when multiple actions then allEmittedCommands accumulates`() =
     testReducer.test(State()) {
       send(Action.Save)
       send(Action.Complex)
 
-      assertEffectCount(3) // Last action only
-      assertEquals(4, allEmittedEffects.size) // All effects
+      assertCommandCount(3) // Last action only
+      assertEquals(4, allEmittedCommands.size) // All commands
     }
 
   @Test
@@ -145,7 +145,7 @@ class ReducerTestDslTest {
   }
 
   @Test
-  fun `when assertNoEffects with effects then AssertionError is thrown`() {
+  fun `when assertNoEffects with commands then AssertionError is thrown`() {
     assertFailsWith<AssertionError> {
       testReducer.test(State()) {
         send(Action.Save)

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsCacheTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsCacheTest.kt
@@ -101,7 +101,7 @@ class HabitsCacheTest {
     actions.forEach { action ->
       val (newState, effects) = reducer.invoke(action, initialState)
       assertEquals(false, newState.isLoading, "Action $action should stop loading")
-      assertTrue(effects.any { it is HabitsEffect.RefreshMemos }, "Action $action should trigger RefreshMemos")
+      assertTrue(effects.commands.any { it is HabitsEffect.RefreshMemos }, "Action $action should trigger RefreshMemos")
     }
   }
 
@@ -136,6 +136,6 @@ class HabitsCacheTest {
     assertEquals(2, newState.activityDataCache.size, "Cache size should remain unchanged")
     assertNotNull(newState.activityDataCache[week1Key], "Week 1 cache should exist")
     assertNotNull(newState.activityDataCache[week2Key], "Week 2 cache should exist")
-    assertTrue(effects.any { it is HabitsEffect.RefreshMemos }, "Should trigger memos refresh")
+    assertTrue(effects.commands.any { it is HabitsEffect.RefreshMemos }, "Should trigger memos refresh")
   }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsReducerTest.kt
@@ -145,7 +145,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmEditor)
 
       assertState { isLoading }
-      assertHasEffect<HabitsEffect.CreateMemo>()
+      assertHasCommand<HabitsEffect.CreateMemo>()
     }
 
   @Test
@@ -161,7 +161,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmEditor)
 
       assertState { isLoading }
-      val effect = assertHasEffect<HabitsEffect.UpdateMemo>()
+      val effect = assertHasCommand<HabitsEffect.UpdateMemo>()
       assertEquals("memos/1", effect.name)
     }
 
@@ -194,7 +194,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmDelete)
 
       assertState { isLoading }
-      val effect = assertHasEffect<HabitsEffect.DeleteMemo>()
+      val effect = assertHasCommand<HabitsEffect.DeleteMemo>()
       assertEquals("memos/1", effect.name)
     }
 
@@ -260,7 +260,7 @@ class HabitsReducerTest {
       send(HabitsAction.MemoCreated(Memo(name = "memos/1")))
 
       assertState { !isLoading && editorDay == null && editorConfig.isEmpty() }
-      assertEffects(HabitsEffect.RefreshMemos)
+      assertCommands(HabitsEffect.RefreshMemos)
     }
 
   @Test
@@ -269,7 +269,7 @@ class HabitsReducerTest {
       send(HabitsAction.MemoUpdated(Memo(name = "memos/1")))
 
       assertState { !isLoading && editorDay == null }
-      assertEffects(HabitsEffect.RefreshMemos)
+      assertCommands(HabitsEffect.RefreshMemos)
     }
 
   @Test
@@ -284,7 +284,7 @@ class HabitsReducerTest {
       send(HabitsAction.MemoDeleted("memos/1"))
 
       assertState { !isLoading && editorDay == null && !showDeleteConfirm }
-      assertEffects(HabitsEffect.RefreshMemos)
+      assertCommands(HabitsEffect.RefreshMemos)
     }
 
   @Test
@@ -446,7 +446,7 @@ class HabitsReducerTest {
       send(HabitsAction.SaveConfigDialog)
 
       assertState { isLoading }
-      assertHasEffect<HabitsEffect.CreateMemo>()
+      assertHasCommand<HabitsEffect.CreateMemo>()
     }
 
   @Test
@@ -463,7 +463,7 @@ class HabitsReducerTest {
     ) {
       send(HabitsAction.SaveConfigDialog)
 
-      val effect = assertHasEffect<HabitsEffect.CreateMemo>()
+      val effect = assertHasCommand<HabitsEffect.CreateMemo>()
       assertEquals(true, effect.content.contains("Exercise"))
       assertEquals(true, effect.content.contains("Reading"))
       assertEquals(false, effect.content.contains("habit_2"))
@@ -495,7 +495,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmSingleHabitToggle)
 
       assertState { isLoading }
-      val effect = assertHasEffect<HabitsEffect.DeleteMemo>()
+      val effect = assertHasCommand<HabitsEffect.DeleteMemo>()
       assertEquals("memos/1", effect.name)
     }
 
@@ -511,7 +511,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmSingleHabitToggle)
 
       assertState { isLoading }
-      assertHasEffect<HabitsEffect.CreateMemo>()
+      assertHasCommand<HabitsEffect.CreateMemo>()
     }
 
   @Test
@@ -526,7 +526,7 @@ class HabitsReducerTest {
       send(HabitsAction.ConfirmSingleHabitToggle)
 
       assertState { isLoading }
-      val effect = assertHasEffect<HabitsEffect.UpdateMemo>()
+      val effect = assertHasCommand<HabitsEffect.UpdateMemo>()
       assertEquals("memos/1", effect.name)
     }
 
@@ -664,7 +664,7 @@ class HabitsReducerTest {
       send(HabitsAction.SaveConfigDialog)
 
       assertState { isLoading }
-      assertHasEffect<HabitsEffect.CreateMemo>()
+      assertHasCommand<HabitsEffect.CreateMemo>()
     }
 
   @Test
@@ -704,7 +704,7 @@ class HabitsReducerTest {
           isLoading &&
           pendingConfigEdit.isEmpty()
       }
-      assertHasEffect<HabitsEffect.UpdateMemo>()
+      assertHasCommand<HabitsEffect.UpdateMemo>()
     }
 
   @Test
@@ -723,7 +723,7 @@ class HabitsReducerTest {
           isLoading &&
           pendingConfigEdit.isEmpty()
       }
-      assertHasEffect<HabitsEffect.CreateMemo>()
+      assertHasCommand<HabitsEffect.CreateMemo>()
     }
 
   @Test
@@ -752,7 +752,7 @@ class HabitsReducerTest {
           editingConfigMemo == null &&
           isLoading
       }
-      val effect = assertHasEffect<HabitsEffect.DeleteMemo>()
+      val effect = assertHasCommand<HabitsEffect.DeleteMemo>()
       assertEquals("memos/config_old", effect.name)
     }
 
@@ -791,7 +791,7 @@ class HabitsReducerTest {
       send(HabitsAction.RequestPrewarmAllRanges(memos = memos, appMode = AppMode.ONLINE))
 
       assertState { !needsCacheRefresh && isInitialLoading }
-      val effect = assertHasEffect<HabitsEffect.RunPrewarmAllRanges>()
+      val effect = assertHasCommand<HabitsEffect.RunPrewarmAllRanges>()
       assertEquals(memos, effect.memos)
       assertEquals(AppMode.ONLINE, effect.appMode)
     }
@@ -877,7 +877,7 @@ class HabitsReducerTest {
           isRecalculating.contains(ActivityCacheKey(ActivityRange.Week(LocalDate(2024, 1, 1)), ActivityMode.HABITS, AppMode.ONLINE)) &&
           !needsCacheRefresh
       }
-      val effect = assertHasEffect<HabitsEffect.RecalculateActivityData>()
+      val effect = assertHasCommand<HabitsEffect.RecalculateActivityData>()
       assertEquals(ActivityRange.Week(LocalDate(2024, 1, 1)), effect.range)
       assertEquals(ActivityMode.HABITS, effect.mode)
       assertEquals(AppMode.ONLINE, effect.appMode)

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosReducerTest.kt
@@ -39,7 +39,7 @@ class MemosReducerTest {
       send(MemosAction.EditCredentials)
 
       assertState { credentialsMode && errorMessage == null }
-      assertEffects(MemosEffect.LoadCredentials)
+      assertCommands(MemosEffect.LoadCredentials)
     }
 
   @Test
@@ -66,9 +66,9 @@ class MemosReducerTest {
       send(MemosAction.LoadMemos)
 
       assertState { isLoading && !credentialsMode && errorMessage == null }
-      assertEffectCount(2)
-      assertHasEffect<MemosEffect.SaveCredentials>()
-      assertHasEffect<MemosEffect.LoadRemoteMemos>()
+      assertCommandCount(2)
+      assertHasCommand<MemosEffect.SaveCredentials>()
+      assertHasCommand<MemosEffect.LoadRemoteMemos>()
     }
 
   @Test
@@ -76,7 +76,7 @@ class MemosReducerTest {
     memosReducer.test(MemosState()) {
       send(MemosAction.LoadCachedMemos)
 
-      assertEffects(MemosEffect.LoadCachedMemos)
+      assertCommands(MemosEffect.LoadCachedMemos)
     }
 
   @Test
@@ -112,7 +112,7 @@ class MemosReducerTest {
       send(MemosAction.CachedMemosLoaded(emptyList()))
 
       assertState { memos.isEmpty() && !initialDataLoaded && isLoading }
-      assertEffects(MemosEffect.LoadRemoteMemos)
+      assertCommands(MemosEffect.LoadRemoteMemos)
     }
 
   @Test
@@ -139,7 +139,7 @@ class MemosReducerTest {
       send(MemosAction.CreateMemo("New memo content"))
 
       assertState { isLoading }
-      val effect = assertHasEffect<MemosEffect.CreateMemo>()
+      val effect = assertHasCommand<MemosEffect.CreateMemo>()
       assertEquals("New memo content", effect.content)
     }
 
@@ -149,7 +149,7 @@ class MemosReducerTest {
       send(MemosAction.UpdateMemo("memos/1", "Updated content"))
 
       assertState { isLoading }
-      val effect = assertHasEffect<MemosEffect.UpdateMemo>()
+      val effect = assertHasCommand<MemosEffect.UpdateMemo>()
       assertEquals("memos/1", effect.name)
       assertEquals("Updated content", effect.content)
     }
@@ -160,7 +160,7 @@ class MemosReducerTest {
       send(MemosAction.DeleteMemo("memos/1"))
 
       assertState { isLoading }
-      val effect = assertHasEffect<MemosEffect.DeleteMemo>()
+      val effect = assertHasCommand<MemosEffect.DeleteMemo>()
       assertEquals("memos/1", effect.name)
     }
 
@@ -249,8 +249,8 @@ class MemosReducerTest {
       send(MemosAction.LoadMemos)
 
       assertState { isLoading }
-      assertEffectCount(1)
-      assertHasEffect<MemosEffect.LoadRemoteMemos>()
+      assertCommandCount(1)
+      assertHasCommand<MemosEffect.LoadRemoteMemos>()
     }
 
   @Test
@@ -286,7 +286,7 @@ class MemosReducerTest {
       send(MemosAction.ConfirmCreateDialog)
 
       assertState { !showCreateDialog && createDialogContent == "" && isLoading }
-      val effect = assertHasEffect<MemosEffect.CreateMemo>()
+      val effect = assertHasCommand<MemosEffect.CreateMemo>()
       assertEquals("New memo", effect.content)
     }
 
@@ -332,7 +332,7 @@ class MemosReducerTest {
       send(MemosAction.ConfirmEditDialog)
 
       assertState { !showEditDialog && editDialogContent == "" && editDialogMemo == null && isLoading }
-      val effect = assertHasEffect<MemosEffect.UpdateMemo>()
+      val effect = assertHasCommand<MemosEffect.UpdateMemo>()
       assertEquals(testMemo.name, effect.name)
       assertEquals("Updated", effect.content)
     }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -6,6 +6,7 @@ import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUse
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SaveAppModeUseCase
+import space.be1ski.vibits.shared.feature.mode.presentation.ModeSelectionEffect.Command
 import space.be1ski.vibits.shared.test.FakeAppModeRepository
 import space.be1ski.vibits.shared.test.FakeCredentialsRepository
 import kotlin.test.Test
@@ -20,7 +21,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions =
         handler(
-          ModeSelectionEffect.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
+          Command.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
         ).toList()
 
       assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
@@ -33,7 +34,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions =
         handler(
-          ModeSelectionEffect.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
+          Command.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
         ).toList()
 
       assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
@@ -46,7 +47,7 @@ class ModeSelectionEffectHandlerTest {
       val handler = createHandler(credentialsRepository = credentialsRepo)
 
       handler(
-        ModeSelectionEffect.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
+        Command.SaveCredentials(baseUrl = "https://saved.com", token = "saved-token"),
       ).toList()
 
       assertEquals("https://saved.com", credentialsRepo.stored.baseUrl)
@@ -59,22 +60,9 @@ class ModeSelectionEffectHandlerTest {
       val appModeRepo = FakeAppModeRepository()
       val handler = createHandler(appModeRepository = appModeRepo)
 
-      handler(ModeSelectionEffect.SaveMode(mode = AppMode.OFFLINE)).toList()
+      handler(Command.SaveMode(mode = AppMode.OFFLINE)).toList()
 
       assertEquals(AppMode.OFFLINE, appModeRepo.storedMode)
-    }
-
-  @Test
-  fun `when NotifyModeSelected effect then returns empty flow`() =
-    runTest {
-      val handler = createHandler()
-
-      val actions =
-        handler(
-          ModeSelectionEffect.NotifyModeSelected(mode = AppMode.ONLINE),
-        ).toList()
-
-      assertTrue(actions.isEmpty())
     }
 
   @Test
@@ -91,7 +79,7 @@ class ModeSelectionEffectHandlerTest {
         )
       val handler = createHandler(credentialsRepository = credentialsRepo, localConfigProvider = configProvider)
 
-      val actions = handler(ModeSelectionEffect.InitializeFromLocalConfig).toList()
+      val actions = handler(Command.InitializeFromLocalConfig).toList()
 
       assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
     }
@@ -105,7 +93,7 @@ class ModeSelectionEffectHandlerTest {
           .createFakeLocalConfigProvider(config = emptyMap())
       val handler = createHandler(credentialsRepository = credentialsRepo, localConfigProvider = configProvider)
 
-      val actions = handler(ModeSelectionEffect.InitializeFromLocalConfig).toList()
+      val actions = handler(Command.InitializeFromLocalConfig).toList()
 
       assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
     }
@@ -123,7 +111,7 @@ class ModeSelectionEffectHandlerTest {
         )
       val handler = createHandler(credentialsRepository = credentialsRepo)
 
-      val actions = handler(ModeSelectionEffect.CheckStoredCredentials).toList()
+      val actions = handler(Command.CheckStoredCredentials).toList()
 
       assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
     }
@@ -134,7 +122,7 @@ class ModeSelectionEffectHandlerTest {
       val credentialsRepo = FakeCredentialsRepository()
       val handler = createHandler(credentialsRepository = credentialsRepo)
 
-      val actions = handler(ModeSelectionEffect.CheckStoredCredentials).toList()
+      val actions = handler(Command.CheckStoredCredentials).toList()
 
       assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
     }
@@ -152,7 +140,7 @@ class ModeSelectionEffectHandlerTest {
         )
       val handler = createHandler(credentialsRepository = credentialsRepo)
 
-      val actions = handler(ModeSelectionEffect.UseStoredCredentialsWithValidation).toList()
+      val actions = handler(Command.UseStoredCredentialsWithValidation).toList()
 
       assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
     }
@@ -170,7 +158,7 @@ class ModeSelectionEffectHandlerTest {
         )
       val handler = createHandler(connectionResult = Result.failure(Exception("Failed")), credentialsRepository = credentialsRepo)
 
-      val actions = handler(ModeSelectionEffect.UseStoredCredentialsWithValidation).toList()
+      val actions = handler(Command.UseStoredCredentialsWithValidation).toList()
 
       assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
     }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -2,6 +2,8 @@ package space.be1ski.vibits.shared.feature.mode.presentation
 
 import space.be1ski.vibits.shared.core.elm.test
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
+import space.be1ski.vibits.shared.feature.mode.presentation.ModeSelectionEffect.Command
+import space.be1ski.vibits.shared.feature.mode.presentation.ModeSelectionEffect.Notification
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -89,7 +91,7 @@ class ModeSelectionReducerTest {
       send(ModeSelectionAction.Submit)
 
       assertState { isValidating && error == null }
-      val effect = assertHasEffect<ModeSelectionEffect.ValidateCredentials>()
+      val effect = assertHasCommand<Command.ValidateCredentials>()
       assertEquals("https://api.com", effect.baseUrl)
       assertEquals("token123", effect.token)
     }
@@ -104,7 +106,7 @@ class ModeSelectionReducerTest {
     ) {
       send(ModeSelectionAction.Submit)
 
-      val effect = assertHasEffect<ModeSelectionEffect.ValidateCredentials>()
+      val effect = assertHasCommand<Command.ValidateCredentials>()
       assertEquals("https://api.com", effect.baseUrl)
       assertEquals("token123", effect.token)
     }
@@ -128,10 +130,10 @@ class ModeSelectionReducerTest {
           token == "" &&
           error == null
       }
-      assertEffectCount(3)
-      assertHasEffect<ModeSelectionEffect.SaveCredentials>()
-      assertHasEffect<ModeSelectionEffect.SaveMode>()
-      assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
+      assertCommandCount(2)
+      assertHasCommand<Command.SaveCredentials>()
+      assertHasCommand<Command.SaveMode>()
+      assertHasNotification<Notification.ModeSelected>()
     }
 
   @Test
@@ -146,9 +148,9 @@ class ModeSelectionReducerTest {
     ) {
       send(ModeSelectionAction.ValidationSucceeded)
 
-      val saveEffect = assertHasEffect<ModeSelectionEffect.SaveCredentials>()
-      assertEquals("https://api.com", saveEffect.baseUrl)
-      assertEquals("token123", saveEffect.token)
+      val effect = assertHasCommand<Command.SaveCredentials>()
+      assertEquals("https://api.com", effect.baseUrl)
+      assertEquals("token123", effect.token)
     }
 
   @Test
@@ -156,11 +158,11 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
       send(ModeSelectionAction.ValidationSucceeded)
 
-      val saveModeEffect = assertHasEffect<ModeSelectionEffect.SaveMode>()
-      assertEquals(AppMode.ONLINE, saveModeEffect.mode)
+      val effect = assertHasCommand<Command.SaveMode>()
+      assertEquals(AppMode.ONLINE, effect.mode)
 
-      val notifyEffect = assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
-      assertEquals(AppMode.ONLINE, notifyEffect.mode)
+      val notification = assertHasNotification<Notification.ModeSelected>()
+      assertEquals(AppMode.ONLINE, notification.mode)
     }
 
   @Test
@@ -177,12 +179,12 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState()) {
       send(ModeSelectionAction.SelectMode(AppMode.OFFLINE))
 
-      assertEffectCount(2)
-      val saveModeEffect = assertHasEffect<ModeSelectionEffect.SaveMode>()
-      assertEquals(AppMode.OFFLINE, saveModeEffect.mode)
+      assertCommandCount(1)
+      val effect = assertHasCommand<Command.SaveMode>()
+      assertEquals(AppMode.OFFLINE, effect.mode)
 
-      val notifyEffect = assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
-      assertEquals(AppMode.OFFLINE, notifyEffect.mode)
+      val notification = assertHasNotification<Notification.ModeSelected>()
+      assertEquals(AppMode.OFFLINE, notification.mode)
     }
 
   @Test
@@ -190,12 +192,12 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState()) {
       send(ModeSelectionAction.SelectMode(AppMode.DEMO))
 
-      assertEffectCount(2)
-      val saveModeEffect = assertHasEffect<ModeSelectionEffect.SaveMode>()
-      assertEquals(AppMode.DEMO, saveModeEffect.mode)
+      assertCommandCount(1)
+      val effect = assertHasCommand<Command.SaveMode>()
+      assertEquals(AppMode.DEMO, effect.mode)
 
-      val notifyEffect = assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
-      assertEquals(AppMode.DEMO, notifyEffect.mode)
+      val notification = assertHasNotification<Notification.ModeSelected>()
+      assertEquals(AppMode.DEMO, notification.mode)
     }
 
   @Test
@@ -231,7 +233,7 @@ class ModeSelectionReducerTest {
       send(ModeSelectionAction.UseStoredCredentials)
 
       assertState { !showQuickOnlineDialog && isValidating }
-      assertEffects(ModeSelectionEffect.UseStoredCredentialsWithValidation)
+      assertCommands(Command.UseStoredCredentialsWithValidation)
     }
 
   @Test
@@ -240,9 +242,9 @@ class ModeSelectionReducerTest {
       send(ModeSelectionAction.ValidationSucceeded)
 
       assertState { !isValidating && baseUrl == "" && token == "" }
-      assertEffectCount(2)
-      assertHasEffect<ModeSelectionEffect.SaveMode>()
-      assertHasEffect<ModeSelectionEffect.NotifyModeSelected>()
+      assertCommandCount(1)
+      assertHasCommand<Command.SaveMode>()
+      assertHasNotification<Notification.ModeSelected>()
     }
 
   @Test
@@ -251,6 +253,6 @@ class ModeSelectionReducerTest {
       send(ModeSelectionAction.SelectMode(AppMode.DEMO))
 
       assertState { !showQuickOnlineDialog }
-      assertEffectCount(2)
+      assertCommandCount(1)
     }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingEffectHandlerTest.kt
@@ -104,13 +104,13 @@ class OnboardingEffectHandlerTest {
     }
 
   @Test
-  fun `when MarkOnboardingCompleted then emits OnboardingCompleted`() =
+  fun `when MarkOnboardingCompleted then emits no actions`() =
     runTest {
       val handler = createHandler()
 
       val actions = handler(OnboardingEffect.Command.MarkOnboardingCompleted).toList()
 
-      assertEquals(listOf(OnboardingAction.OnboardingCompleted), actions)
+      assertTrue(actions.isEmpty())
     }
 
   @Test
@@ -144,20 +144,6 @@ class OnboardingEffectHandlerTest {
       val actions = handler(OnboardingEffect.Command.MarkFirstCheckIn).toList()
 
       assertTrue(actions.isEmpty())
-    }
-
-  @Test
-  fun `when Notification effect then returns empty flow`() =
-    runTest {
-      val handler = createHandler()
-
-      val completedActions = handler(OnboardingEffect.Notification.Completed).toList()
-      val skippedActions = handler(OnboardingEffect.Notification.Skipped).toList()
-      val firstCheckInActions = handler(OnboardingEffect.Notification.FirstCheckInCreated).toList()
-
-      assertTrue(completedActions.isEmpty())
-      assertTrue(skippedActions.isEmpty())
-      assertTrue(firstCheckInActions.isEmpty())
     }
 
   private fun createHandler(memosRepository: FakeMemosRepository = FakeMemosRepository()): OnboardingEffectHandler {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducerTest.kt
@@ -2,6 +2,8 @@ package space.be1ski.vibits.shared.feature.onboarding.presentation
 
 import space.be1ski.vibits.shared.core.elm.test
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
+import space.be1ski.vibits.shared.feature.onboarding.presentation.OnboardingEffect.Command
+import space.be1ski.vibits.shared.feature.onboarding.presentation.OnboardingEffect.Notification
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -12,7 +14,7 @@ class OnboardingReducerTest {
       send(OnboardingAction.StartOnboarding)
 
       assertState { currentStep == OnboardingStep.Welcome }
-      assertHasEffect<OnboardingEffect.Command.LoadPresets>()
+      assertHasCommand<Command.LoadPresets>()
     }
 
   @Test
@@ -128,7 +130,7 @@ class OnboardingReducerTest {
       send(OnboardingAction.CreateHabit)
 
       assertState { isCreatingHabit }
-      val effect = assertHasEffect<OnboardingEffect.Command.CreateFirstHabit>()
+      val effect = assertHasCommand<Command.CreateFirstHabit>()
       assertEquals("Exercise", effect.name)
       assertEquals("custom", effect.presetId)
       assertEquals(0xFF4CAF50L, effect.color)
@@ -190,7 +192,7 @@ class OnboardingReducerTest {
     onboardingReducer.test(OnboardingState()) {
       send(OnboardingAction.Skip)
 
-      assertHasEffect<OnboardingEffect.Notification.Skipped>()
+      assertHasNotification<Notification.Skipped>()
     }
 
   @Test
@@ -198,8 +200,8 @@ class OnboardingReducerTest {
     onboardingReducer.test(OnboardingState(currentStep = OnboardingStep.Success)) {
       send(OnboardingAction.GoToDashboard)
 
-      assertHasEffect<OnboardingEffect.Command.MarkOnboardingCompleted>()
-      assertHasEffect<OnboardingEffect.Notification.Completed>()
+      assertHasCommand<Command.MarkOnboardingCompleted>()
+      assertHasNotification<Notification.Completed>()
     }
 
   @Test
@@ -207,8 +209,8 @@ class OnboardingReducerTest {
     onboardingReducer.test(OnboardingState(currentStep = OnboardingStep.Success)) {
       send(OnboardingAction.MarkFirstCheckIn)
 
-      assertHasEffect<OnboardingEffect.Command.MarkFirstCheckIn>()
-      assertHasEffect<OnboardingEffect.Command.MarkOnboardingCompleted>()
+      assertHasCommand<Command.MarkFirstCheckIn>()
+      assertHasCommand<Command.MarkOnboardingCompleted>()
     }
 
   @Test
@@ -216,8 +218,8 @@ class OnboardingReducerTest {
     onboardingReducer.test(OnboardingState(currentStep = OnboardingStep.Success)) {
       send(OnboardingAction.FirstCheckInCreated)
 
-      assertHasEffect<OnboardingEffect.Notification.FirstCheckInCreated>()
-      assertHasEffect<OnboardingEffect.Notification.Completed>()
+      assertHasNotification<Notification.FirstCheckInCreated>()
+      assertHasNotification<Notification.Completed>()
     }
 
   @Test
@@ -269,7 +271,7 @@ class OnboardingReducerTest {
       send(OnboardingAction.Continue)
 
       assertState { isCreatingHabit && creationError == null }
-      val effect = assertHasEffect<OnboardingEffect.Command.CreateFirstHabit>()
+      val effect = assertHasCommand<Command.CreateFirstHabit>()
       assertEquals("Exercise", effect.name)
       assertEquals("custom", effect.presetId)
       assertEquals(0xFF4CAF50L, effect.color)
@@ -298,14 +300,6 @@ class OnboardingReducerTest {
       send(OnboardingAction.Continue)
 
       assertState { currentStep == OnboardingStep.Success }
-      assertNoEffects()
-    }
-
-  @Test
-  fun `when OnboardingCompleted then does nothing`() =
-    onboardingReducer.test(OnboardingState()) {
-      send(OnboardingAction.OnboardingCompleted)
-
       assertNoEffects()
     }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -115,38 +115,6 @@ class SettingsEffectHandlerTest {
       assertEquals(AppTheme.DARK, prefsRepo.stored.theme)
     }
 
-  @Test
-  fun `when Notification effect then returns empty flow`() =
-    runTest {
-      val handler = createHandler()
-
-      val notifyModeActions =
-        handler(
-          SettingsEffect.Notification.ModeChanged(newMode = AppMode.OFFLINE),
-        ).toList()
-      val notifyResetActions = handler(SettingsEffect.Notification.ResetCompleted).toList()
-      val notifyCredentialsActions =
-        handler(
-          SettingsEffect.Notification.CredentialsSaved(baseUrl = "url", token = "token"),
-        ).toList()
-      val notifyLanguageActions =
-        handler(
-          SettingsEffect.Notification.LanguageChanged(language = AppLanguage.ENGLISH),
-        ).toList()
-      val notifyThemeActions =
-        handler(
-          SettingsEffect.Notification.ThemeChanged(theme = AppTheme.DARK),
-        ).toList()
-      val notifyDialogActions = handler(SettingsEffect.Notification.DialogClosed).toList()
-
-      assertTrue(notifyModeActions.isEmpty())
-      assertTrue(notifyResetActions.isEmpty())
-      assertTrue(notifyCredentialsActions.isEmpty())
-      assertTrue(notifyLanguageActions.isEmpty())
-      assertTrue(notifyThemeActions.isEmpty())
-      assertTrue(notifyDialogActions.isEmpty())
-    }
-
   private fun createHandler(
     connectionResult: Result<Unit> = Result.success(Unit),
     appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducerTest.kt
@@ -46,7 +46,7 @@ class SettingsReducerTest {
       send(SettingsAction.Close)
 
       assertState { !isOpen && !showLogsDialog && validationError == null }
-      assertEffects(SettingsEffect.Notification.DialogClosed)
+      assertNotifications(SettingsEffect.Notification.DialogClosed)
     }
 
   @Test
@@ -55,7 +55,7 @@ class SettingsReducerTest {
       send(SettingsAction.Dismiss)
 
       assertState { !isOpen }
-      assertEffects(SettingsEffect.Notification.DialogClosed)
+      assertNotifications(SettingsEffect.Notification.DialogClosed)
     }
 
   @Test
@@ -134,14 +134,14 @@ class SettingsReducerTest {
       send(SettingsAction.ValidationSucceeded)
 
       assertState { !isValidating && !isOpen && !pendingSave && appMode == AppMode.ONLINE }
-      assertEffectCount(7)
-      assertHasEffect<SettingsEffect.Command.SaveCredentials>()
-      assertHasEffect<SettingsEffect.Command.SwitchMode>()
-      assertHasEffect<SettingsEffect.Command.SaveLanguage>()
-      assertHasEffect<SettingsEffect.Command.SaveTheme>()
-      assertHasEffect<SettingsEffect.Notification.LanguageChanged>()
-      assertHasEffect<SettingsEffect.Notification.ThemeChanged>()
-      assertHasEffect<SettingsEffect.Notification.CredentialsSaved>()
+      assertCommandCount(4)
+      assertHasCommand<SettingsEffect.Command.SaveCredentials>()
+      assertHasCommand<SettingsEffect.Command.SwitchMode>()
+      assertHasCommand<SettingsEffect.Command.SaveLanguage>()
+      assertHasCommand<SettingsEffect.Command.SaveTheme>()
+      assertHasNotification<SettingsEffect.Notification.LanguageChanged>()
+      assertHasNotification<SettingsEffect.Notification.ThemeChanged>()
+      assertHasNotification<SettingsEffect.Notification.CredentialsSaved>()
     }
 
   @Test
@@ -163,7 +163,7 @@ class SettingsReducerTest {
     settingsReducer.test(SettingsState(appMode = AppMode.OFFLINE)) {
       send(SettingsAction.ModeSwitched)
 
-      val effect = assertHasEffect<SettingsEffect.Notification.ModeChanged>()
+      val effect = assertHasNotification<SettingsEffect.Notification.ModeChanged>()
       assertEquals(AppMode.OFFLINE, effect.newMode)
     }
 
@@ -182,7 +182,7 @@ class SettingsReducerTest {
       send(SettingsAction.ConfirmReset)
 
       assertState { !showResetConfirmation && isResetting }
-      assertEffects(SettingsEffect.Command.ResetApp)
+      assertCommands(SettingsEffect.Command.ResetApp)
     }
 
   @Test
@@ -205,7 +205,7 @@ class SettingsReducerTest {
       send(SettingsAction.ResetCompleted)
 
       assertState { !isOpen && !isResetting }
-      assertEffects(SettingsEffect.Notification.ResetCompleted)
+      assertNotifications(SettingsEffect.Notification.ResetCompleted)
     }
 
   @Test
@@ -239,11 +239,11 @@ class SettingsReducerTest {
       send(SettingsAction.Save)
 
       assertState { !isOpen }
-      assertEffectCount(7)
-      assertHasEffect<SettingsEffect.Command.SaveCredentials>()
-      assertHasEffect<SettingsEffect.Command.SwitchMode>()
-      assertHasEffect<SettingsEffect.Command.SaveLanguage>()
-      assertHasEffect<SettingsEffect.Command.SaveTheme>()
+      assertCommandCount(4)
+      assertHasCommand<SettingsEffect.Command.SaveCredentials>()
+      assertHasCommand<SettingsEffect.Command.SwitchMode>()
+      assertHasCommand<SettingsEffect.Command.SaveLanguage>()
+      assertHasCommand<SettingsEffect.Command.SaveTheme>()
     }
 
   @Test
@@ -276,7 +276,7 @@ class SettingsReducerTest {
 
       assertState { isOpen && isValidating && pendingSave && validationError == null }
 
-      val effect = assertHasEffect<SettingsEffect.Command.ValidateCredentials>()
+      val effect = assertHasCommand<SettingsEffect.Command.ValidateCredentials>()
       assertEquals("https://api.com", effect.baseUrl)
       assertEquals("token123", effect.token)
     }


### PR DESCRIPTION
## Summary

Enforce Command/Notification separation in TEA architecture to eliminate `emptyFlow()` anti-pattern and empty coordinator branches.

## Key Changes

### TEA Core
- **Feature signature:** `Feature<A, S, E>` → `Feature<A, S, Cmd, Not>`
- **EffectHandler signature:** `EffectHandler<E, A>` → `EffectHandler<Cmd, A>`
- **Concise destructuring:** `val (state, effects) = reducer(...)` with `Effects<Command, Notification>` wrapper
- **DSL:** Added `command()`/`notify()`, removed `effect()`

### Features Migrated
- ✅ Onboarding (removed silent `OnboardingCompleted` action)
- ✅ Settings (minimal changes)
- ✅ ModeSelection (restructured to Command/Notification)
- ✅ App/Memos/Habits (commands-only with `Nothing` type)

### Architecture Improvements
- **Commands:** Processed internally by EffectHandler only
- **Notifications:** Exposed externally to coordinators only
- **No more:** `emptyFlow()` in EffectHandlers
- **No more:** Empty `is Command -> {}` branches in coordinators

### Test DSL
- Added `assertCommands()` / `assertNotifications()`
- Added `assertNoEffects()` convenience helper

## Before/After

**EffectHandler (Before):**
```kotlin
when (effect) {
  is Effect.Command -> handleCommand(effect)
  is Effect.Notification -> emptyFlow()  // ❌
}
```

**EffectHandler (After):**
```kotlin
when (command) {
  is Command.DoSomething -> handleCommand(command)  // ✅ Only commands!
}
```

**Coordinator (Before):**
```kotlin
feature.effects.collect { effect ->
  when (effect) {
    is Notification.Something -> handle()
    is Command -> {}  // ❌
  }
}
```

**Coordinator (After):**
```kotlin
feature.notifications.collect { notification ->
  when (notification) {
    is Notification.Something -> handle()  // ✅ Only notifications!
  }
}
```

## Breaking Changes

- All `Feature` type signatures require 4 type parameters
- All `EffectHandler` signatures now accept `Command` instead of `Effect`
- `effect()` DSL removed, use `command()` or `notify()`
- `initialEffects` parameter renamed to `initialCommands`
- Test assertions updated (old methods removed)

## Testing

- ✅ Compilation successful
- ⏳ Tests need completion (some still WIP)

## Next Steps

- [ ] Complete remaining test migrations
- [ ] Run full `./gradlew checkAll`
- [ ] Update CLAUDE.md with new patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)