### PR TITLE
Add reset app with memos option

### DIFF
--- a/shared/src/commonMain/composeResources/values-ar/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ar/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">تحديث</string>
     <string name="action_reset">إعادة تعيين</string>
     <string name="action_reset_app">إعادة تعيين التطبيق</string>
+    <string name="action_reset_settings_only">إعادة تعيين الإعدادات فقط</string>
+    <string name="action_reset_with_memos">إعادة تعيين كل شيء (بما في ذلك الذكريات)</string>
     <string name="action_save">حفظ</string>
     <string name="action_show_details">عرض التفاصيل</string>
     <string name="action_start_tracking">بدء التتبع</string>
@@ -137,6 +139,7 @@
     <string name="msg_no_logs">لا توجد سجلات بعد</string>
     <string name="msg_no_memos_yet">لا توجد مذكرات في هذه الفترة.</string>
     <string name="msg_reset_confirm">هل أنت متأكد من إعادة تعيين التطبيق؟ سيتم مسح جميع البيانات.</string>
+    <string name="msg_reset_choose_option">اختر خيار إعادة التعيين:</string>
     <string name="msg_select_habit">اختر عادة واحدة على الأقل.</string>
     <string name="msg_mark_done_confirm">وضع علامة "%1$s" كمكتمل لـ %2$s؟</string>
     <string name="msg_mark_not_done_confirm">إزالة إكمال "%1$s" في %2$s؟</string>

--- a/shared/src/commonMain/composeResources/values-az/strings.xml
+++ b/shared/src/commonMain/composeResources/values-az/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Yenilə</string>
     <string name="action_reset">Sıfırla</string>
     <string name="action_reset_app">Tətbiqi sıfırla</string>
+    <string name="action_reset_settings_only">Yalnız tənzimləmələri sıfırla</string>
+    <string name="action_reset_with_memos">Hər şeyi sıfırla (xatirələr daxil)</string>
     <string name="action_save">Saxla</string>
     <string name="action_show_details">Detalları göstər</string>
     <string name="action_start_tracking">İzləməyə başla</string>
@@ -137,6 +139,7 @@ Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlk
     <string name="msg_no_logs">Loglar hələ yoxdur</string>
     <string name="msg_no_memos_yet">Bu dövrdə qeyd yoxdur.</string>
     <string name="msg_reset_confirm">Tətbiqi sıfırlamaq istədiyinizə əminsiniz? Bütün məlumatlar silinəcək.</string>
+    <string name="msg_reset_choose_option">Sıfırlama variantını seçin:</string>
     <string name="msg_select_habit">Ən azı bir vərdiş seçin.</string>
     <string name="msg_mark_done_confirm">«%1$s» %2$s üçün tamamlanmış kimi qeyd edilsin?</string>
     <string name="msg_mark_not_done_confirm">%2$s tarixində «%1$s» qeydini silmək istəyirsiniz?</string>

--- a/shared/src/commonMain/composeResources/values-be/strings.xml
+++ b/shared/src/commonMain/composeResources/values-be/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Абнавіць</string>
     <string name="action_reset">Скінуць</string>
     <string name="action_reset_app">Скінуць праграму</string>
+    <string name="action_reset_settings_only">Скінуць толькі налады</string>
+    <string name="action_reset_with_memos">Скінуць усё (уключна з успамінамі)</string>
     <string name="action_save">Захаваць</string>
     <string name="action_show_details">Паказаць дэталі</string>
     <string name="action_start_tracking">Пачаць адсочванне</string>
@@ -136,6 +138,7 @@
     <string name="msg_no_logs">Логаў пакуль няма</string>
     <string name="msg_no_memos_yet">Няма нататак за гэты перыяд.</string>
     <string name="msg_reset_confirm">Вы ўпэўнены, што хочаце скінуць праграму? Усе даныя будуць выдалены.</string>
+    <string name="msg_reset_choose_option">Абярыце варыянт скіду:</string>
     <string name="msg_select_habit">Абярыце хаця б адну звычку.</string>
     <string name="msg_mark_done_confirm">Пазначыць «%1$s» як выкананую за %2$s?</string>
     <string name="msg_mark_not_done_confirm">Зняць пазнаку з «%1$s» за %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-de/strings.xml
+++ b/shared/src/commonMain/composeResources/values-de/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Aktualisieren</string>
     <string name="action_reset">Zurücksetzen</string>
     <string name="action_reset_app">App zurücksetzen</string>
+    <string name="action_reset_settings_only">Nur Einstellungen zurücksetzen</string>
+    <string name="action_reset_with_memos">Alles zurücksetzen (einschließlich Erinnerungen)</string>
     <string name="action_save">Speichern</string>
     <string name="action_show_details">Details anzeigen</string>
     <string name="action_start_tracking">Tracking starten</string>
@@ -137,6 +139,7 @@ Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Dat
     <string name="msg_no_logs">Noch keine Protokolle</string>
     <string name="msg_no_memos_yet">Keine Notizen in diesem Zeitraum.</string>
     <string name="msg_reset_confirm">Sind Sie sicher, dass Sie die App zurücksetzen möchten? Alle Daten werden gelöscht.</string>
+    <string name="msg_reset_choose_option">Zurücksetzungsoption wählen:</string>
     <string name="msg_select_habit">Wählen Sie mindestens eine Gewohnheit aus.</string>
     <string name="msg_mark_done_confirm">"%1$s" als erledigt für %2$s markieren?</string>
     <string name="msg_mark_not_done_confirm">Erledigung von "%1$s" am %2$s entfernen?</string>

--- a/shared/src/commonMain/composeResources/values-es/strings.xml
+++ b/shared/src/commonMain/composeResources/values-es/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Actualizar</string>
     <string name="action_reset">Restablecer</string>
     <string name="action_reset_app">Restablecer app</string>
+    <string name="action_reset_settings_only">Restablecer solo la configuración</string>
+    <string name="action_reset_with_memos">Restablecer todo (incluidos los recuerdos)</string>
     <string name="action_save">Guardar</string>
     <string name="action_show_details">Mostrar detalles</string>
     <string name="action_start_tracking">Comenzar seguimiento</string>
@@ -133,6 +135,7 @@
     <string name="msg_no_logs">Aún no hay registros</string>
     <string name="msg_no_memos_yet">No hay notas en este período.</string>
     <string name="msg_reset_confirm">¿Está seguro de que desea restablecer la app? Se eliminarán todos los datos.</string>
+    <string name="msg_reset_choose_option">Elige la opción de restablecimiento:</string>
     <string name="msg_select_habit">Seleccione al menos un hábito.</string>
     <string name="msg_mark_done_confirm">¿Marcar "%1$s" como completado para %2$s?</string>
     <string name="msg_mark_not_done_confirm">¿Quitar la marca de "%1$s" para %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-fr/strings.xml
+++ b/shared/src/commonMain/composeResources/values-fr/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Actualiser</string>
     <string name="action_reset">Réinitialiser</string>
     <string name="action_reset_app">Réinitialiser l\'app</string>
+    <string name="action_reset_settings_only">Réinitialiser uniquement les paramètres</string>
+    <string name="action_reset_with_memos">Tout réinitialiser (y compris les souvenirs)</string>
     <string name="action_save">Enregistrer</string>
     <string name="action_show_details">Afficher les détails</string>
     <string name="action_start_tracking">Commencer le suivi</string>
@@ -137,6 +139,7 @@ Bonne pratique : créez une nouvelle configuration. Vos données historiques con
     <string name="msg_no_logs">Aucun journal pour l\'instant</string>
     <string name="msg_no_memos_yet">Aucune note pour cette période.</string>
     <string name="msg_reset_confirm">Êtes-vous sûr de vouloir réinitialiser l\'app ? Toutes les données seront supprimées.</string>
+    <string name="msg_reset_choose_option">Choisissez l option de réinitialisation :</string>
     <string name="msg_select_habit">Sélectionnez au moins une habitude.</string>
     <string name="msg_mark_done_confirm">Marquer « %1$s » comme accompli pour %2$s ?</string>
     <string name="msg_mark_not_done_confirm">Retirer l\'accomplissement de « %1$s » le %2$s ?</string>

--- a/shared/src/commonMain/composeResources/values-hi/strings.xml
+++ b/shared/src/commonMain/composeResources/values-hi/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">रिफ्रेश</string>
     <string name="action_reset">रीसेट</string>
     <string name="action_reset_app">ऐप रीसेट करें</string>
+    <string name="action_reset_settings_only">केवल सेटिंग्स रीसेट करें</string>
+    <string name="action_reset_with_memos">सब कुछ रीसेट करें (यादों सहित)</string>
     <string name="action_save">सेव करें</string>
     <string name="action_show_details">विवरण दिखाएं</string>
     <string name="action_start_tracking">ट्रैकिंग शुरू करें</string>
@@ -137,6 +139,7 @@
     <string name="msg_no_logs">अभी कोई लॉग नहीं</string>
     <string name="msg_no_memos_yet">इस अवधि में कोई मेमो नहीं।</string>
     <string name="msg_reset_confirm">क्या आप वाकई ऐप रीसेट करना चाहते हैं? सभी डेटा हटा दिया जाएगा।</string>
+    <string name="msg_reset_choose_option">रीसेट विकल्प चुनें:</string>
     <string name="msg_select_habit">कम से कम एक आदत चुनें।</string>
     <string name="msg_mark_done_confirm">"%1$s" को %2$s के लिए पूर्ण के रूप में चिह्नित करें?</string>
     <string name="msg_mark_not_done_confirm">%2$s पर "%1$s" की पूर्णता हटाएं?</string>

--- a/shared/src/commonMain/composeResources/values-ja/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ja/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">更新</string>
     <string name="action_reset">リセット</string>
     <string name="action_reset_app">アプリをリセット</string>
+    <string name="action_reset_settings_only">設定のみをリセット</string>
+    <string name="action_reset_with_memos">すべてをリセット（思い出を含む）</string>
     <string name="action_save">保存</string>
     <string name="action_show_details">詳細を表示</string>
     <string name="action_start_tracking">記録を開始</string>
@@ -137,6 +139,7 @@
     <string name="msg_no_logs">ログがありません</string>
     <string name="msg_no_memos_yet">この期間にメモがありません。</string>
     <string name="msg_reset_confirm">アプリをリセットしますか？すべてのデータが削除されます。</string>
+    <string name="msg_reset_choose_option">リセットオプションを選択：</string>
     <string name="msg_select_habit">少なくとも1つの習慣を選択してください。</string>
     <string name="msg_mark_done_confirm">「%1$s」を%2$sに完了としてマークしますか？</string>
     <string name="msg_mark_not_done_confirm">%2$sの「%1$s」の完了を取り消しますか？</string>

--- a/shared/src/commonMain/composeResources/values-ka/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ka/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">განახლება</string>
     <string name="action_reset">გადატვირთვა</string>
     <string name="action_reset_app">აპის გადატვირთვა</string>
+    <string name="action_reset_settings_only">მხოლოდ პარამეტრების გადაყენება</string>
+    <string name="action_reset_with_memos">ყველაფრის გადაყენება (მოგონებების ჩათვლით)</string>
     <string name="action_save">შენახვა</string>
     <string name="action_show_details">დეტალების ჩვენება</string>
     <string name="action_start_tracking">თვალთვალის დაწყება</string>
@@ -137,6 +139,7 @@
     <string name="msg_no_logs">ლოგები ჯერ არ არის</string>
     <string name="msg_no_memos_yet">ამ პერიოდში ჩანაწერები არ არის.</string>
     <string name="msg_reset_confirm">დარწმუნებული ხართ, რომ გსურთ აპის გადატვირთვა? ყველა მონაცემი წაიშლება.</string>
+    <string name="msg_reset_choose_option">აირჩიეთ გადაყენების ვარიანტი:</string>
     <string name="msg_select_habit">აირჩიეთ მინიმუმ ერთი ჩვევა.</string>
     <string name="msg_mark_done_confirm">მონიშნოთ «%1$s» როგორც შესრულებული %2$s-ისთვის?</string>
     <string name="msg_mark_not_done_confirm">მოხსნათ მონიშვნა «%1$s»-ს %2$s-ისთვის?</string>

--- a/shared/src/commonMain/composeResources/values-kk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-kk/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Жаңарту</string>
     <string name="action_reset">Қалпына келтіру</string>
     <string name="action_reset_app">Қолданбаны қалпына келтіру</string>
+    <string name="action_reset_settings_only">Тек баптауларды қалпына келтіру</string>
+    <string name="action_reset_with_memos">Бәрін қалпына келтіру (естеліктерді қоса)</string>
     <string name="action_save">Сақтау</string>
     <string name="action_show_details">Мәліметтерді көрсету</string>
     <string name="action_start_tracking">Бақылауды бастау</string>
@@ -136,6 +138,7 @@
     <string name="msg_no_logs">Логтар әлі жоқ</string>
     <string name="msg_no_memos_yet">Бұл кезеңде жазбалар жоқ.</string>
     <string name="msg_reset_confirm">Қолданбаны қалпына келтіргіңіз келе ме? Барлық деректер жойылады.</string>
+    <string name="msg_reset_choose_option">Қалпына келтіру нұсқасын таңдаңыз:</string>
     <string name="msg_select_habit">Кем дегенде бір әдетті таңдаңыз.</string>
     <string name="msg_mark_done_confirm">«%1$s» %2$s үшін орындалды деп белгілеу керек пе?</string>
     <string name="msg_mark_not_done_confirm">%2$s күні «%1$s» белгісін алып тастау керек пе?</string>

--- a/shared/src/commonMain/composeResources/values-ky/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ky/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_refresh">Жаңылоо</string>
     <string name="action_reset">Баштапкыга кайтаруу</string>
     <string name="action_reset_app">Колдонмону баштапкыга кайтаруу</string>
+    <string name="action_reset_settings_only">Жөн гана жөндөөлөрдү калыбына келтирүү</string>
+    <string name="action_reset_with_memos">Баарын калыбына келтирүү (эстеликтерди коштоп)</string>
     <string name="action_save">Сактоо</string>
     <string name="action_show_details">Деталдарды көрсөтүү</string>
     <string name="action_start_tracking">Көзөмөлдөөнү баштоо</string>
@@ -139,6 +141,7 @@
     <string name="msg_offline_onboarding_success">Баары даяр. Бүгүн биринчи белгини коюңуз.</string>
     <string name="msg_offline_onboarding_welcome">Адаттарды түзмөгүңүздө жергиликтүү көзөмөлдөңүз. Эсеп керек эмес.</string>
     <string name="msg_reset_confirm">Колдонмону баштапкыга кайтаргыңыз келеби? Бардык маалыматтар өчүрүлөт.</string>
+    <string name="msg_reset_choose_option">Калыбына келтирүү вариантын тандаңыз:</string>
     <string name="msg_select_habit">Жок дегенде бир адатты тандаңыз.</string>
     <string name="msg_mark_done_confirm">«%1$s» %2$s үчүн аткарылды деп белгилөө керекпи?</string>
     <string name="msg_mark_not_done_confirm">%2$s күнү «%1$s» белгисин алып салуу керекпи?</string>

--- a/shared/src/commonMain/composeResources/values-pt/strings.xml
+++ b/shared/src/commonMain/composeResources/values-pt/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Atualizar</string>
     <string name="action_reset">Redefinir</string>
     <string name="action_reset_app">Redefinir app</string>
+    <string name="action_reset_settings_only">Redefinir apenas as configurações</string>
+    <string name="action_reset_with_memos">Redefinir tudo (incluindo memórias)</string>
     <string name="action_save">Salvar</string>
     <string name="action_show_details">Mostrar detalhes</string>
     <string name="action_start_tracking">Iniciar rastreamento</string>
@@ -137,6 +139,7 @@ Melhor prática: crie uma nova configuração. Seus dados históricos manterão 
     <string name="msg_no_logs">Sem logs ainda</string>
     <string name="msg_no_memos_yet">Sem notas neste período.</string>
     <string name="msg_reset_confirm">Tem certeza de que deseja redefinir o app? Todos os dados serão apagados.</string>
+    <string name="msg_reset_choose_option">Escolha a opção de redefinição:</string>
     <string name="msg_select_habit">Selecione pelo menos um hábito.</string>
     <string name="msg_mark_done_confirm">Marcar "%1$s" como concluído para %2$s?</string>
     <string name="msg_mark_not_done_confirm">Remover conclusão de "%1$s" em %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-ro/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ro/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_refresh">Reîmprospătare</string>
     <string name="action_reset">Resetare</string>
     <string name="action_reset_app">Resetare aplicație</string>
+    <string name="action_reset_settings_only">Resetează doar setările</string>
+    <string name="action_reset_with_memos">Resetează totul (inclusiv memoriile)</string>
     <string name="action_save">Salvează</string>
     <string name="action_show_details">Arată detalii</string>
     <string name="action_start_tracking">Începe urmărirea</string>
@@ -139,6 +141,7 @@ Cea mai bună practică: creează o configurație nouă. Datele tale istorice vo
     <string name="msg_offline_onboarding_success">Totul este gata. Marchează prima verificare astăzi.</string>
     <string name="msg_offline_onboarding_welcome">Urmărește obiceiurile local pe dispozitivul tău. Nu este nevoie de cont.</string>
     <string name="msg_reset_confirm">Sunteți sigur că doriți să resetați aplicația? Toate datele vor fi șterse.</string>
+    <string name="msg_reset_choose_option">Alege opțiunea de resetare:</string>
     <string name="msg_select_habit">Selectați cel puțin un obicei.</string>
     <string name="msg_mark_done_confirm">Marcați «%1$s» ca finalizat pentru %2$s?</string>
     <string name="msg_mark_not_done_confirm">Eliminați marcajul pentru «%1$s» pe %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-ru/strings.xml
+++ b/shared/src/commonMain/composeResources/values-ru/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Обновить</string>
     <string name="action_reset">Сбросить</string>
     <string name="action_reset_app">Сбросить приложение</string>
+    <string name="action_reset_settings_only">Сбросить только настройки</string>
+    <string name="action_reset_with_memos">Сбросить всё (включая воспоминания)</string>
     <string name="action_save">Сохранить</string>
     <string name="action_show_details">Показать детали привычки</string>
     <string name="action_start_tracking">Начать отслеживание</string>
@@ -132,6 +134,7 @@
     <string name="msg_no_logs">Логов пока нет</string>
     <string name="msg_no_memos_yet">Нет воспоминаний за этот период.</string>
     <string name="msg_reset_confirm">Вы уверены, что хотите сбросить приложение? Все данные будут удалены.</string>
+    <string name="msg_reset_choose_option">Выберите вариант сброса:</string>
     <string name="msg_select_habit">Выберите хотя бы одну привычку.</string>
     <string name="msg_mark_done_confirm">Отметить «%1$s» как выполненную за %2$s?</string>
     <string name="msg_mark_not_done_confirm">Снять отметку с «%1$s» за %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-tg/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tg/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_refresh">Навсозӣ</string>
     <string name="action_reset">Барқарор кардан</string>
     <string name="action_reset_app">Барқарор кардани барнома</string>
+    <string name="action_reset_settings_only">Танҳо танзимотро барқарор кардан</string>
+    <string name="action_reset_with_memos">Ҳамаро барқарор кардан (хотираҳоро низ)</string>
     <string name="action_save">Захира кардан</string>
     <string name="action_show_details">Нишон додани тафсилот</string>
     <string name="action_start_tracking">Назоратро оғоз кардан</string>
@@ -139,6 +141,7 @@
     <string name="msg_offline_onboarding_success">Ҳама чиз тайёр аст. Имрӯз қайди аввалинро гузоред.</string>
     <string name="msg_offline_onboarding_welcome">Одатҳоро дар дастгоҳи худ маҳаллӣ назорат кунед. Ҳисоб зарур нест.</string>
     <string name="msg_reset_confirm">Шумо мутмаин ҳастед, ки мехоҳед барномаро барқарор кунед? Ҳамаи маълумот нест мешавад.</string>
+    <string name="msg_reset_choose_option">Вариантҳои барқарорсозиро интихоб кунед:</string>
     <string name="msg_select_habit">Ҳадди ақал як одатро интихоб кунед.</string>
     <string name="msg_mark_done_confirm">«%1$s»-ро барои %2$s ҳамчун иҷрошуда қайд кунем?</string>
     <string name="msg_mark_not_done_confirm">Қайдро аз «%1$s» барои %2$s бардорем?</string>

--- a/shared/src/commonMain/composeResources/values-tk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-tk/strings.xml
@@ -21,6 +21,8 @@
     <string name="action_refresh">Täzele</string>
     <string name="action_reset">Täzeden başla</string>
     <string name="action_reset_app">Programany täzele</string>
+    <string name="action_reset_settings_only">Diňe sazlamalary täzeden düzmek</string>
+    <string name="action_reset_with_memos">Ählisini täzeden düzmek (ýatlamalar bilen)</string>
     <string name="action_save">Sakla</string>
     <string name="action_show_details">Jikme-jiklikleri görkez</string>
     <string name="action_start_tracking">Yzarlamagy başla</string>
@@ -139,6 +141,7 @@ Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigur
     <string name="msg_offline_onboarding_success">Hemme zat taýýar. Şu gün ilkinji belligi goýuň.</string>
     <string name="msg_offline_onboarding_welcome">Endikleri enjamyňyzda ýerli yzarlaň. Hasap gerek däl.</string>
     <string name="msg_reset_confirm">Programmany täzeden başlamak isleýärsiňizmi? Ähli maglumatlar öçüriler.</string>
+    <string name="msg_reset_choose_option">Täzeden düzmek wariantyny saýlaň:</string>
     <string name="msg_select_habit">Azyndan bir endik saýlaň.</string>
     <string name="msg_mark_done_confirm">«%1$s» %2$s üçin ýerine ýetirilen diýip bellesinmi?</string>
     <string name="msg_mark_not_done_confirm">%2$s güni «%1$s» belligini aýyrmak isleýärsiňizmi?</string>

--- a/shared/src/commonMain/composeResources/values-uk/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uk/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Оновити</string>
     <string name="action_reset">Скинути</string>
     <string name="action_reset_app">Скинути додаток</string>
+    <string name="action_reset_settings_only">Скинути лише налаштування</string>
+    <string name="action_reset_with_memos">Скинути все (включно зі спогадами)</string>
     <string name="action_save">Зберегти</string>
     <string name="action_show_details">Показати деталі</string>
     <string name="action_start_tracking">Почати відстеження</string>
@@ -136,6 +138,7 @@
     <string name="msg_no_logs">Логів поки немає</string>
     <string name="msg_no_memos_yet">Немає нотаток за цей період.</string>
     <string name="msg_reset_confirm">Ви впевнені, що хочете скинути додаток? Усі дані буде видалено.</string>
+    <string name="msg_reset_choose_option">Оберіть варіант скидання:</string>
     <string name="msg_select_habit">Оберіть хоча б одну звичку.</string>
     <string name="msg_mark_done_confirm">Позначити «%1$s» як виконану за %2$s?</string>
     <string name="msg_mark_not_done_confirm">Зняти позначку з «%1$s» за %2$s?</string>

--- a/shared/src/commonMain/composeResources/values-uz/strings.xml
+++ b/shared/src/commonMain/composeResources/values-uz/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Yangilash</string>
     <string name="action_reset">Tiklash</string>
     <string name="action_reset_app">Ilovani tiklash</string>
+    <string name="action_reset_settings_only">Faqat sozlamalarni tiklash</string>
+    <string name="action_reset_with_memos">Hammasini tiklash (xotiralarni ham)</string>
     <string name="action_save">Saqlash</string>
     <string name="action_show_details">Tafsilotlarni ko'rsatish</string>
     <string name="action_start_tracking">Kuzatuvni boshlash</string>
@@ -137,6 +139,7 @@ Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfi
     <string name="msg_no_logs">Loglar hali yo\'q</string>
     <string name="msg_no_memos_yet">Bu davrda eslatmalar yo\'q.</string>
     <string name="msg_reset_confirm">Ilovani tiklamoqchimisiz? Barcha ma\'lumotlar o\'chiriladi.</string>
+    <string name="msg_reset_choose_option">Tiklash variantini tanlang:</string>
     <string name="msg_select_habit">Kamida bitta odatni tanlang.</string>
     <string name="msg_mark_done_confirm">«%1$s» ni %2$s uchun bajarilgan deb belgilash kerakmi?</string>
     <string name="msg_mark_not_done_confirm">%2$s sanasida «%1$s» belgisini olib tashlash kerakmi?</string>

--- a/shared/src/commonMain/composeResources/values-zh/strings.xml
+++ b/shared/src/commonMain/composeResources/values-zh/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">刷新</string>
     <string name="action_reset">重置</string>
     <string name="action_reset_app">重置应用</string>
+    <string name="action_reset_settings_only">仅重置设置</string>
+    <string name="action_reset_with_memos">重置所有内容（包括回忆）</string>
     <string name="action_save">保存</string>
     <string name="action_show_details">显示详情</string>
     <string name="action_start_tracking">开始记录</string>
@@ -133,6 +135,7 @@
     <string name="msg_no_logs">暂无日志</string>
     <string name="msg_no_memos_yet">该时期暂无备忘。</string>
     <string name="msg_reset_confirm">确定要重置应用吗？所有数据将被清除。</string>
+    <string name="msg_reset_choose_option">选择重置选项：</string>
     <string name="msg_select_habit">请至少选择一个习惯。</string>
     <string name="msg_mark_done_confirm">将"%1$s"标记为 %2$s 完成？</string>
     <string name="msg_mark_not_done_confirm">取消"%1$s"在 %2$s 的完成标记？</string>

--- a/shared/src/commonMain/composeResources/values/strings.xml
+++ b/shared/src/commonMain/composeResources/values/strings.xml
@@ -22,6 +22,8 @@
     <string name="action_refresh">Refresh</string>
     <string name="action_reset">Reset</string>
     <string name="action_reset_app">Reset app</string>
+    <string name="action_reset_settings_only">Reset settings only</string>
+    <string name="action_reset_with_memos">Reset everything (including memos)</string>
     <string name="action_save">Save</string>
     <string name="action_show_details">Show habit details</string>
     <string name="action_start_tracking">Start tracking</string>
@@ -134,6 +136,7 @@
     <string name="msg_offline_onboarding_success">You're all set. Track your first check-in today.</string>
     <string name="msg_offline_onboarding_welcome">Track habits locally on your device. No account needed.</string>
     <string name="msg_reset_confirm">Are you sure you want to reset the app? This will clear all data.</string>
+    <string name="msg_reset_choose_option">Choose reset option:</string>
     <string name="msg_select_habit">Select at least one habit.</string>
     <string name="msg_mark_done_confirm">Mark "%1$s" as completed for %2$s?</string>
     <string name="msg_mark_not_done_confirm">Remove completion for "%1$s" on %2$s?</string>

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppWithMemosUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/domain/usecase/ResetAppWithMemosUseCase.kt
@@ -1,0 +1,18 @@
+package space.be1ski.vibits.shared.feature.mode.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemosFileDto
+import space.be1ski.vibits.shared.feature.memos.data.platform.OfflineMemoStorage
+
+@Inject
+class ResetAppWithMemosUseCase(
+  private val resetApp: ResetAppUseCase,
+  private val offlineMemoStorage: OfflineMemoStorage,
+) {
+  operator fun invoke() {
+    // First reset app (credentials, preferences, mode, onboarding)
+    resetApp()
+    // Then clear all memos from offline storage
+    offlineMemoStorage.save(OfflineMemosFileDto(memos = emptyList()))
+  }
+}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsDependencies.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsDependencies.kt
@@ -4,16 +4,19 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppWithMemosUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
 
 @Inject
+@Suppress("LongParameterList")
 class SettingsDependencies(
   val connectionTester: ConnectionTester,
   val switchAppMode: SwitchAppModeUseCase,
   val saveCredentials: SaveCredentialsUseCase,
   val resetApp: ResetAppUseCase,
+  val resetAppWithMemos: ResetAppWithMemosUseCase,
   val saveLanguage: SaveLanguageUseCase,
   val saveTheme: SaveThemeUseCase,
 )

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/di/SettingsFeatureFactory.kt
@@ -29,6 +29,7 @@ fun createSettingsFeature(
         switchAppMode = dependencies.switchAppMode,
         saveCredentials = dependencies.saveCredentials,
         resetApp = dependencies.resetApp,
+        resetAppWithMemos = dependencies.resetAppWithMemos,
         saveLanguage = dependencies.saveLanguage,
         saveTheme = dependencies.saveTheme,
       ),

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsAction.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsAction.kt
@@ -56,6 +56,8 @@ sealed interface SettingsAction {
 
   data object ConfirmReset : SettingsAction
 
+  data object ConfirmResetWithMemos : SettingsAction
+
   data object CancelReset : SettingsAction
 
   data object ResetCompleted : SettingsAction

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffect.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffect.kt
@@ -26,6 +26,8 @@ sealed interface SettingsEffect {
 
     data object ResetApp : Command
 
+    data object ResetAppWithMemos : Command
+
     data class SaveLanguage(
       val language: AppLanguage,
     ) : Command

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandler.kt
@@ -9,17 +9,20 @@ import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppWithMemosUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
 
 private const val TAG = "SettingsEffect"
 
+@Suppress("LongParameterList")
 class SettingsEffectHandler(
   private val connectionTester: ConnectionTester,
   private val switchAppMode: SwitchAppModeUseCase,
   private val saveCredentials: SaveCredentialsUseCase,
   private val resetApp: ResetAppUseCase,
+  private val resetAppWithMemos: ResetAppWithMemosUseCase,
   private val saveLanguage: SaveLanguageUseCase,
   private val saveTheme: SaveThemeUseCase,
 ) : EffectHandler<SettingsEffect.Command, SettingsAction> {
@@ -29,6 +32,7 @@ class SettingsEffectHandler(
       is SettingsEffect.Command.SwitchMode -> handleSwitchMode(command)
       is SettingsEffect.Command.SaveCredentials -> handleSaveCredentials(command)
       is SettingsEffect.Command.ResetApp -> handleResetApp()
+      is SettingsEffect.Command.ResetAppWithMemos -> handleResetAppWithMemos()
       is SettingsEffect.Command.SaveLanguage -> handleSaveLanguage(command)
       is SettingsEffect.Command.SaveTheme -> handleSaveTheme(command)
     }
@@ -58,6 +62,13 @@ class SettingsEffectHandler(
     flow {
       Log.i(TAG, "Resetting app")
       resetApp()
+      emit(SettingsAction.ResetCompleted)
+    }
+
+  private fun handleResetAppWithMemos(): Flow<SettingsAction> =
+    flow {
+      Log.i(TAG, "Resetting app with memos")
+      resetAppWithMemos()
       emit(SettingsAction.ResetCompleted)
     }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducer.kt
@@ -110,6 +110,11 @@ val settingsReducer: Reducer<SettingsAction, SettingsState, SettingsEffect.Comma
         command(SettingsEffect.Command.ResetApp)
       }
 
+      is SettingsAction.ConfirmResetWithMemos -> {
+        state { copy(showResetConfirmation = false, isResetting = true) }
+        command(SettingsEffect.Command.ResetAppWithMemos)
+      }
+
       is SettingsAction.CancelReset -> {
         state { copy(showResetConfirmation = false) }
       }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
@@ -74,6 +74,8 @@ import space.be1ski.vibits.shared.generated.action_export_logs
 import space.be1ski.vibits.shared.generated.action_export_memos
 import space.be1ski.vibits.shared.generated.action_reset
 import space.be1ski.vibits.shared.generated.action_reset_app
+import space.be1ski.vibits.shared.generated.action_reset_settings_only
+import space.be1ski.vibits.shared.generated.action_reset_with_memos
 import space.be1ski.vibits.shared.generated.action_save
 import space.be1ski.vibits.shared.generated.action_view_logs
 import space.be1ski.vibits.shared.generated.hint_base_url
@@ -116,6 +118,7 @@ import space.be1ski.vibits.shared.generated.msg_export_failed
 import space.be1ski.vibits.shared.generated.msg_export_success
 import space.be1ski.vibits.shared.generated.msg_fill_all_fields
 import space.be1ski.vibits.shared.generated.msg_no_logs
+import space.be1ski.vibits.shared.generated.msg_reset_choose_option
 import space.be1ski.vibits.shared.generated.msg_reset_confirm
 import space.be1ski.vibits.shared.generated.msg_restart_required
 import space.be1ski.vibits.shared.generated.nav_settings
@@ -149,6 +152,7 @@ fun SettingsDialog(
   if (state.showResetConfirmation) {
     ResetConfirmationDialog(
       onConfirm = { dispatch(SettingsAction.ConfirmReset) },
+      onConfirmWithMemos = { dispatch(SettingsAction.ConfirmResetWithMemos) },
       onDismiss = { dispatch(SettingsAction.CancelReset) },
     )
   }
@@ -475,22 +479,13 @@ private fun SettingsDialogDismissButton(dispatch: (SettingsAction) -> Unit) {
 @Composable
 private fun ResetConfirmationDialog(
   onConfirm: () -> Unit,
+  onConfirmWithMemos: () -> Unit,
   onDismiss: () -> Unit,
 ) {
-  AlertDialog(
-    onDismissRequest = onDismiss,
-    title = { Text(stringResource(Res.string.action_reset_app)) },
-    text = { Text(stringResource(Res.string.msg_reset_confirm)) },
-    confirmButton = {
-      Button(onClick = onConfirm) {
-        Text(stringResource(Res.string.action_reset))
-      }
-    },
-    dismissButton = {
-      TextButton(onClick = onDismiss) {
-        Text(stringResource(Res.string.action_cancel))
-      }
-    },
+  ResetOptionsDialog(
+    onResetSettings = onConfirm,
+    onResetAll = onConfirmWithMemos,
+    onDismiss = onDismiss,
   )
 }
 
@@ -575,6 +570,45 @@ private fun ActionsRow(
 }
 
 private const val LOG_TIMESTAMP_LENGTH = 8
+
+@Suppress("LongMethod")
+@Composable
+private fun ResetOptionsDialog(
+  onResetSettings: () -> Unit,
+  onResetAll: () -> Unit,
+  onDismiss: () -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(stringResource(Res.string.action_reset_app)) },
+    text = {
+      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(
+          text = stringResource(Res.string.msg_reset_choose_option),
+          style = MaterialTheme.typography.bodyMedium,
+        )
+        Button(
+          onClick = onResetSettings,
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Text(stringResource(Res.string.action_reset_settings_only))
+        }
+        Button(
+          onClick = onResetAll,
+          modifier = Modifier.fillMaxWidth(),
+        ) {
+          Text(stringResource(Res.string.action_reset_with_memos))
+        }
+      }
+    },
+    confirmButton = {},
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(Res.string.action_cancel))
+      }
+    },
+  )
+}
 
 @Suppress("LongMethod")
 @Composable

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
@@ -15,14 +15,18 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.DeleteForever
 import androidx.compose.material.icons.filled.KeyboardArrowDown
+import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -582,22 +586,50 @@ private fun ResetOptionsDialog(
     onDismissRequest = onDismiss,
     title = { Text(stringResource(Res.string.action_reset_app)) },
     text = {
-      Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+      Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
         Text(
           text = stringResource(Res.string.msg_reset_choose_option),
           style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
         )
-        Button(
-          onClick = onResetSettings,
+        OutlinedButton(
+          onClick = {
+            onResetSettings()
+            onDismiss()
+          },
           modifier = Modifier.fillMaxWidth(),
         ) {
-          Text(stringResource(Res.string.action_reset_settings_only))
+          Icon(
+            imageVector = Icons.Default.Settings,
+            contentDescription = null,
+            modifier = Modifier.size(Indent.m),
+          )
+          Text(
+            text = stringResource(Res.string.action_reset_settings_only),
+            modifier = Modifier.padding(start = Indent.xs),
+          )
         }
         Button(
-          onClick = onResetAll,
+          onClick = {
+            onResetAll()
+            onDismiss()
+          },
           modifier = Modifier.fillMaxWidth(),
+          colors =
+            ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.error,
+              contentColor = MaterialTheme.colorScheme.onError,
+            ),
         ) {
-          Text(stringResource(Res.string.action_reset_with_memos))
+          Icon(
+            imageVector = Icons.Default.DeleteForever,
+            contentDescription = null,
+            modifier = Modifier.size(Indent.m),
+          )
+          Text(
+            text = stringResource(Res.string.action_reset_with_memos),
+            modifier = Modifier.padding(start = Indent.xs),
+          )
         }
       }
     },

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -7,6 +7,7 @@ import space.be1ski.vibits.shared.feature.auth.domain.usecase.SaveCredentialsUse
 import space.be1ski.vibits.shared.feature.memos.data.ConnectionTester
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppUseCase
+import space.be1ski.vibits.shared.feature.mode.domain.usecase.ResetAppWithMemosUseCase
 import space.be1ski.vibits.shared.feature.mode.domain.usecase.SwitchAppModeUseCase
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppLanguage
 import space.be1ski.vibits.shared.feature.settings.domain.model.AppTheme
@@ -14,6 +15,7 @@ import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveLanguageUs
 import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveThemeUseCase
 import space.be1ski.vibits.shared.test.FakeAppModeRepository
 import space.be1ski.vibits.shared.test.FakeCredentialsRepository
+import space.be1ski.vibits.shared.test.FakeOfflineMemoStorage
 import space.be1ski.vibits.shared.test.FakePreferencesRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -94,6 +96,20 @@ class SettingsEffectHandlerTest {
     }
 
   @Test
+  fun `when ResetAppWithMemos then resets and clears memos and emits ResetCompleted`() =
+    runTest {
+      val appModeRepo = FakeAppModeRepository(initial = AppMode.ONLINE)
+      val offlineMemoStorage = FakeOfflineMemoStorage()
+      val handler = createHandler(appModeRepository = appModeRepo, offlineMemoStorage = offlineMemoStorage)
+
+      val actions = handler(SettingsEffect.Command.ResetAppWithMemos).toList()
+
+      assertEquals(listOf(SettingsAction.ResetCompleted), actions)
+      assertEquals(AppMode.NOT_SELECTED, appModeRepo.storedMode)
+      assertEquals(emptyList(), offlineMemoStorage.stored.memos)
+    }
+
+  @Test
   fun `when SaveLanguage then saves language to repository`() =
     runTest {
       val prefsRepo = FakePreferencesRepository()
@@ -120,20 +136,24 @@ class SettingsEffectHandlerTest {
     appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),
     credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
     preferencesRepository: FakePreferencesRepository = FakePreferencesRepository(),
-  ): SettingsEffectHandler =
-    SettingsEffectHandler(
+    offlineMemoStorage: FakeOfflineMemoStorage = FakeOfflineMemoStorage(),
+  ): SettingsEffectHandler {
+    val resetApp =
+      ResetAppUseCase(
+        appModeRepository,
+        credentialsRepository,
+        preferencesRepository,
+        space.be1ski.vibits.shared.feature.onboarding.data
+          .FakeOnboardingStore(),
+      )
+    return SettingsEffectHandler(
       connectionTester = ConnectionTester { _, _ -> connectionResult },
       switchAppMode = SwitchAppModeUseCase(appModeRepository),
       saveCredentials = SaveCredentialsUseCase(credentialsRepository),
-      resetApp =
-        ResetAppUseCase(
-          appModeRepository,
-          credentialsRepository,
-          preferencesRepository,
-          space.be1ski.vibits.shared.feature.onboarding.data
-            .FakeOnboardingStore(),
-        ),
+      resetApp = resetApp,
+      resetAppWithMemos = ResetAppWithMemosUseCase(resetApp, offlineMemoStorage),
       saveLanguage = SaveLanguageUseCase(preferencesRepository, LocaleProvider()),
       saveTheme = SaveThemeUseCase(preferencesRepository),
     )
+  }
 }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/settings/presentation/SettingsReducerTest.kt
@@ -186,6 +186,15 @@ class SettingsReducerTest {
     }
 
   @Test
+  fun `when ConfirmResetWithMemos then hides confirmation and emits ResetAppWithMemos`() =
+    settingsReducer.test(SettingsState(showResetConfirmation = true)) {
+      send(SettingsAction.ConfirmResetWithMemos)
+
+      assertState { !showResetConfirmation && isResetting }
+      assertCommands(SettingsEffect.Command.ResetAppWithMemos)
+    }
+
+  @Test
   fun `when CancelReset then hides reset confirmation`() =
     settingsReducer.test(SettingsState(showResetConfirmation = true)) {
       send(SettingsAction.CancelReset)

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
@@ -3,7 +3,9 @@ package space.be1ski.vibits.shared.test
 import space.be1ski.vibits.shared.core.platform.env.LocalConfigProvider
 import space.be1ski.vibits.shared.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.shared.feature.auth.domain.repository.CredentialsRepository
+import space.be1ski.vibits.shared.feature.memos.data.offline.OfflineMemosFileDto
 import space.be1ski.vibits.shared.feature.memos.data.platform.MemoCache
+import space.be1ski.vibits.shared.feature.memos.data.platform.OfflineMemoStorage
 import space.be1ski.vibits.shared.feature.memos.domain.model.Memo
 import space.be1ski.vibits.shared.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.shared.feature.mode.domain.model.AppMode
@@ -140,6 +142,22 @@ class FakePreferencesRepository(
 
   override fun save(preferences: UserPreferences) {
     stored = preferences
+    saveCalls += 1
+  }
+}
+
+class FakeOfflineMemoStorage(
+  initial: OfflineMemosFileDto = OfflineMemosFileDto(memos = emptyList()),
+) : OfflineMemoStorage {
+  var stored: OfflineMemosFileDto = initial
+    private set
+  var saveCalls: Int = 0
+    private set
+
+  override fun load(): OfflineMemosFileDto = stored
+
+  override fun save(data: OfflineMemosFileDto) {
+    stored = data
     saveCalls += 1
   }
 }


### PR DESCRIPTION
## Summary

Added third option to reset app dialog that allows users to reset everything including memos.json. The reset dialog now provides three clear choices with improved UI.

## Changes

**Core implementation:**
- Added `ResetAppWithMemosUseCase` that composes `resetApp` with memos clearing
- Added `ConfirmResetWithMemos` action and `ResetAppWithMemos` command
- Updated `SettingsReducer` and `SettingsEffectHandler` with new handlers
- Updated `SettingsDialogContent` to show three-option dialog

**UI improvements:**
- Added Settings icon to "Reset settings only" button (OutlinedButton style)
- Added DeleteForever icon to "Reset everything" button (error-colored Button)
- Improved visual hierarchy with different button styles
- Used design system spacing values (Indent)
- Added subtle color to description text

**Testing:**
- Created `FakeOfflineMemoStorage` for testing
- Added test case for `ResetAppWithMemos` command
- All tests pass ✅

**Localization:**
- Added translations for all 20+ supported languages

## Test plan

- [x] All checks pass
- [x] UI looks professional with proper visual hierarchy
- [x] Reset settings only works correctly
- [x] Reset everything including memos works correctly
- [x] Cancel button works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)