### PR TITLE
Configure detekt rules and remove suppression annotations

### DIFF
--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -5,18 +5,72 @@ complexity:
   LongParameterList:
     ignoreAnnotated:
       - Composable
+      - Inject
+    excludes:
+      - '**/di/**'
+      - '**/*EffectHandler.kt'
+
+  LongMethod:
+    ignoreAnnotated:
+      - Composable
+    excludes:
+      - '**/view/**'
+
+  CyclomaticComplexMethod:
+    ignoreAnnotated:
+      - Composable
+    excludes:
+      - '**/view/**'
+
+  TooManyFunctions:
+    excludes:
+      - '**/di/**'
+      - '**/view/**'
+
+exceptions:
+  TooGenericExceptionCaught:
+    excludes:
+      - '**/data/remote/**'
 
 naming:
   FunctionNaming:
     ignoreAnnotated:
       - Composable
       - Preview
+    excludes:
+      - '**/iosMain/**/*ViewController.kt'
 
 style:
   MaxLineLength:
     active: true
     maxLineLength: 140
+
   UnusedPrivateMember:
     active: true
     ignoreAnnotated:
       - Preview
+
+  UnusedParameter:
+    excludes:
+      - '**/wasmJsMain/**'
+      - '**/jsMain/**'
+
+  MagicNumber:
+    ignorePropertyDeclaration: true
+    ignoreCompanionObjectPropertyDeclaration: true
+    ignoreEnums: true
+    ignoreNumbers:
+      - '-1'
+      - '0'
+      - '1'
+      - '2'
+      - '3'
+      - '4'
+      - '7'
+      - '12'
+      - '24'
+      - '60'
+
+  ReturnCount:
+    ignoreAnnotated:
+      - Composable

--- a/iosApp/vibits/vibits/ContentView.swift
+++ b/iosApp/vibits/vibits/ContentView.swift
@@ -10,7 +10,7 @@ import shared
 
 struct ContentView: UIViewControllerRepresentable {
     func makeUIViewController(context: Context) -> UIViewController {
-        MainViewControllerKt.MainViewController()
+        MainViewControllerKt.createMainViewController()
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {}

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppDependencies.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppDependencies.kt
@@ -17,7 +17,6 @@ import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveTimeRangeT
 /**
  * Single entry point for all app dependencies.
  */
-@Suppress("LongParameterList")
 @Inject
 class AppDependencies(
   val localeProvider: LocaleProvider,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeaturesFactory.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppFeaturesFactory.kt
@@ -21,7 +21,6 @@ import space.be1ski.vibits.shared.feature.settings.domain.usecase.SaveTimeRangeT
  * Factory for creating and launching all application TEA features.
  * Extracted from DI graph to keep graph clean of business logic.
  */
-@Suppress("LongParameterList")
 @Inject
 class AppFeaturesFactory(
   private val loadPreferences: LoadPreferencesUseCase,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/di/AppGraph.kt
@@ -28,7 +28,6 @@ import space.be1ski.vibits.shared.feature.onboarding.data.OnboardingStoreImpl
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStore
 import space.be1ski.vibits.shared.feature.settings.data.PreferencesStoreImpl
 
-@Suppress("TooManyFunctions")
 @SingleIn(AppScope::class)
 @DependencyGraph(AppScope::class)
 abstract class AppGraph {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/AppRoot.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package space.be1ski.vibits.shared.app.view
 
 import androidx.compose.foundation.layout.Box
@@ -257,7 +255,6 @@ private fun rememberFeaturesState(
   return FeaturesState(modeSelectionFeature, onboardingFeature, appFeatures)
 }
 
-@Suppress("LongParameterList")
 @Composable
 private fun AppContent(
   appMode: AppMode,
@@ -291,7 +288,6 @@ private fun AppContent(
   }
 }
 
-@Suppress("LongParameterList")
 private fun createResetAppCallback(
   dependencies: AppDependencies,
   onThemeReset: () -> Unit,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/FeatureCoordinator.kt
@@ -69,7 +69,6 @@ internal fun FeatureCoordinator(
   }
 }
 
-@Suppress("LongParameterList")
 private fun handleNotification(
   effect: SettingsEffect.Notification,
   dispatchApp: (AppAction) -> Unit,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/ScaffoldCallbacks.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/ScaffoldCallbacks.kt
@@ -14,7 +14,6 @@ import space.be1ski.vibits.shared.feature.habits.presentation.HabitsAction
 import space.be1ski.vibits.shared.feature.memos.presentation.MemosAction
 import space.be1ski.vibits.shared.feature.settings.domain.model.TimeRangeTab
 
-@Suppress("LongParameterList")
 internal class ScaffoldCallbacks(
   val onClearSelection: () -> Unit,
   val onFeedScrollToTop: () -> Unit,
@@ -25,7 +24,6 @@ internal class ScaffoldCallbacks(
   val onNavigateForward: () -> Unit,
 )
 
-@Suppress("LongMethod")
 @Composable
 internal fun rememberScaffoldCallbacks(
   appState: AppState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/SwipeableContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -106,7 +105,6 @@ internal fun SwipeableTabContent(
   }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun SwipeablePagerContent(
   memosState: MemosState,
@@ -138,9 +136,6 @@ private fun SwipeablePagerContent(
       initialPage = initialPage,
       pageCount = { pageCount },
     )
-
-  @Suppress("UNUSED_VARIABLE")
-  val scope = rememberCoroutineScope()
 
   LaunchedEffect(currentDelta, minDelta) {
     val targetPage = (currentDelta - minDelta).coerceIn(0, pageCount - 1)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/app/view/VibitsAppScaffold.kt
@@ -52,7 +52,6 @@ import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_create_memo
 import space.be1ski.vibits.shared.generated.action_track_today
 
-@Suppress("LongMethod")
 @Composable
 internal fun VibitsAppScaffold(
   features: AppFeatures,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/HabitParser.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/HabitParser.kt
@@ -50,7 +50,6 @@ fun parseHabitConfigLine(line: String): HabitConfig? {
  * Parses a hex color string to ARGB Long.
  * Supports formats: #RRGGBB or #AARRGGBB
  */
-@Suppress("MagicNumber")
 fun parseHexColor(hex: String): Long? {
   val clean = hex.trim().removePrefix("#")
   return when (clean.length) {
@@ -63,7 +62,6 @@ fun parseHexColor(hex: String): Long? {
 /**
  * Formats an ARGB Long color to hex string (#RRGGBB).
  */
-@Suppress("MagicNumber")
 fun formatHexColor(color: Long): String {
   val rgb = color and 0xFFFFFFL
   return "#${rgb.toString(16).uppercase().padStart(6, '0')}"

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -26,7 +26,6 @@ class BuildActivityDataUseCase(
   /**
    * Builds ActivityWeekData for a given range.
    */
-  @Suppress("LongParameterList")
   fun buildWeekData(
     configTimeline: List<HabitsConfigEntry>,
     dailyMemos: Map<LocalDate, DailyMemoInfo>,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -29,7 +29,6 @@ class GetPeriodPostsUseCase {
       }.sortedByDescending { it.createTime ?: it.updateTime }
   }
 
-  @Suppress("MagicNumber")
   private fun rangeBounds(range: ActivityRange): Pair<LocalDate, LocalDate> =
     when (range) {
       is ActivityRange.Week -> {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/presentation/HabitsEffectHandler.kt
@@ -41,7 +41,6 @@ class HabitsEffectHandler(
   private val buildActivityDataUseCase: BuildActivityDataUseCase,
   private val calculateSuccessRateUseCase: CalculateSuccessRateUseCase,
 ) : EffectHandler<HabitsEffect, HabitsAction> {
-  @Suppress("LongMethod")
   override fun invoke(effect: HabitsEffect): Flow<HabitsAction> =
     flow {
       when (effect) {
@@ -101,7 +100,7 @@ class HabitsEffectHandler(
 
         is HabitsEffect.RecalculateActivityData -> {
           Log.d(TAG, "Recalculating for ${effect.range}")
-          val result = calculateActivityData(effect.range, effect.mode, effect.appMode, effect.memos)
+          val result = calculateActivityData(effect.range, effect.mode, effect.memos)
           emit(
             HabitsAction.UpdateActivityData(
               range = effect.range,
@@ -139,7 +138,7 @@ class HabitsEffectHandler(
         .flatMap { range ->
           modes.map { mode ->
             async {
-              val data = calculateActivityData(range, mode, appMode, memos)
+              val data = calculateActivityData(range, mode, memos)
               PrewarmResult(range, mode, appMode, data.weekData, data.configTimeline, data.successRate)
             }
           }
@@ -150,7 +149,6 @@ class HabitsEffectHandler(
   private fun calculateActivityData(
     range: ActivityRange,
     mode: ActivityMode,
-    @Suppress("UnusedParameter") appMode: AppMode,
     memos: List<Memo>,
   ): CachedActivityData {
     val timeZone = TimeZone.currentSystemDefault()
@@ -210,7 +208,6 @@ class HabitsEffectHandler(
     return months
   }
 
-  @Suppress("MagicNumber")
   private fun generateQuarters(
     startDate: LocalDate,
     endDate: LocalDate,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreen.kt
@@ -44,7 +44,6 @@ fun StatsScreen(
   StatsScreenDialogs(derived, onHabitsAction)
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun rememberStatsScreenDerived(
   state: StatsScreenState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenContent.kt
@@ -462,7 +462,6 @@ private fun CompactPostRow(
 
 private const val COMPACT_POST_MAX_LENGTH = 50
 
-@Suppress("LongMethod")
 @Composable
 internal fun StatsMainChart(
   derived: StatsScreenDerivedState,
@@ -675,7 +674,6 @@ private fun HabitActivitySection(
   }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun LastSevenDaysMatrix(
   days: List<ContributionDay>,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenDialogs.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenDialogs.kt
@@ -45,7 +45,6 @@ internal fun EmptyDeleteDialog(
   )
 }
 
-@Suppress("ReturnCount")
 @Composable
 internal fun SingleHabitToggleDialog(
   derived: StatsScreenDerivedState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenModels.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/StatsScreenModels.kt
@@ -40,7 +40,6 @@ internal data class HabitActivitySectionState(
   val habitColor: Long? = null,
 )
 
-@Suppress("LongParameterList")
 internal data class StatsScreenDerivedState(
   val state: StatsScreenState,
   val habitsState: HabitsState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/ContributionGrid.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/habits/view/components/ContributionGrid.kt
@@ -450,7 +450,6 @@ private fun ContributionGridTimelineRow(
   )
 }
 
-@Suppress("CyclomaticComplexMethod")
 @Composable
 private fun ContributionGridTooltip(
   state: ContributionGridState,
@@ -646,7 +645,6 @@ internal data class ChartLayout(
 /**
  * Renders an individual activity cell.
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 private fun ContributionCell(
   state: ContributionCellState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoDataGenerator.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/demo/DemoDataGenerator.kt
@@ -28,7 +28,6 @@ internal data class DemoHabit(
 /**
  * Generates mock memos for demo mode with realistic habit data.
  */
-@Suppress("MagicNumber")
 internal object DemoDataGenerator {
   private val demoHabits =
     listOf(

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/data/remote/MemosApi.kt
@@ -25,7 +25,6 @@ private const val TAG = "MemosApi"
 
 @Inject
 @SingleIn(AppScope::class)
-@Suppress("TooGenericExceptionCaught")
 class MemosApi(
   private val httpClient: HttpClient,
 ) {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/di/MemosDependencies.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/di/MemosDependencies.kt
@@ -9,7 +9,6 @@ import space.be1ski.vibits.shared.feature.memos.domain.usecase.LoadCachedMemosUs
 import space.be1ski.vibits.shared.feature.memos.domain.usecase.LoadMemosUseCase
 import space.be1ski.vibits.shared.feature.memos.domain.usecase.UpdateMemoUseCase
 
-@Suppress("LongParameterList")
 @Inject
 class MemosDependencies(
   val loadMemos: LoadMemosUseCase,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandler.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/presentation/MemosEffectHandler.kt
@@ -15,7 +15,6 @@ import space.be1ski.vibits.shared.feature.memos.domain.usecase.UpdateMemoUseCase
 
 private const val TAG = "MemosEffect"
 
-@Suppress("LongParameterList")
 class MemosEffectHandler(
   private val loadCredentials: LoadCredentialsUseCase,
   private val saveCredentials: SaveCredentialsUseCase,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/view/FeedScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/memos/view/FeedScreen.kt
@@ -58,7 +58,6 @@ import space.be1ski.vibits.shared.generated.title_delete_memo
 /**
  * Feed tab showing the raw memos list.
  */
-@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
 @OptIn(androidx.compose.material.ExperimentalMaterialApi::class)
 @Composable
 fun FeedScreen(

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/mode/view/ModeSelectionScreen.kt
@@ -159,7 +159,6 @@ private fun QuickOnlineDialog(
   )
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun CredentialsSetupDialog(
   state: ModeSelectionState,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
@@ -8,7 +8,6 @@ import space.be1ski.vibits.shared.feature.memos.domain.usecase.CreateMemoUseCase
 class CreateFirstHabitUseCase(
   private val createMemo: CreateMemoUseCase,
 ) {
-  @Suppress("MagicNumber")
   suspend operator fun invoke(
     name: String,
     presetId: String?,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/HabitSetupScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/view/HabitSetupScreen.kt
@@ -51,7 +51,6 @@ import space.be1ski.vibits.shared.generated.title_habit_setup
 private val COLOR_CIRCLE_SIZE = 24.dp
 private val SELECTED_BORDER_WIDTH = 2.dp
 
-@Suppress("LongMethod")
 @OptIn(ExperimentalLayoutApi::class)
 @Composable
 fun HabitSetupScreen(

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/settings/view/SettingsDialogContent.kt
@@ -1,5 +1,3 @@
-@file:Suppress("TooManyFunctions")
-
 package space.be1ski.vibits.shared.feature.settings.view
 
 import androidx.compose.foundation.background
@@ -37,8 +35,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
@@ -154,7 +152,6 @@ fun SettingsDialog(
   }
 }
 
-@Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
 private fun SettingsDialogBody(
   state: SettingsState,
@@ -274,21 +271,20 @@ private fun AppModeSelector(
 
 private const val TOAST_DURATION_MS = 1500L
 
-@Suppress("DEPRECATION")
 @Composable
 private fun AppDetailsSection(
   appDetails: AppDetails,
   appMode: AppMode,
 ) {
-  val clipboardManager = LocalClipboardManager.current
+  val clipboard = LocalClipboard.current
   val scope = rememberCoroutineScope()
   var copiedKey by remember { mutableStateOf<String?>(null) }
   val copiedLabel = stringResource(Res.string.action_copied)
 
   val onCopy: (String, String) -> Unit = { key, value ->
-    clipboardManager.setText(AnnotatedString(value))
-    copiedKey = key
     scope.launch {
+      clipboard.setClipEntry(value.toClipEntry())
+      copiedKey = key
       delay(TOAST_DURATION_MS)
       if (copiedKey == key) copiedKey = null
     }
@@ -431,7 +427,6 @@ private fun LanguageDropdown(
   }
 }
 
-@Suppress("CyclomaticComplexMethod")
 @Composable
 private fun getLanguageLabel(language: AppLanguage): String =
   when (language) {
@@ -494,7 +489,6 @@ private fun ResetConfirmationDialog(
   )
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun ActionsRow(
   showMemos: Boolean,
@@ -576,7 +570,6 @@ private fun ActionsRow(
 
 private const val LOG_TIMESTAMP_LENGTH = 8
 
-@Suppress("LongMethod")
 @Composable
 private fun LogsDialog(onDismiss: () -> Unit) {
   val logs = Log.logs

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/presentation/MainViewController.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/presentation/MainViewController.kt
@@ -8,8 +8,7 @@ import space.be1ski.vibits.shared.app.view.AppRoot
 /**
  * Entry point for embedding Compose UI into an iOS host.
  */
-@Suppress("FunctionNaming", "ktlint:standard:function-naming")
-fun MainViewController(): UIViewController {
+fun createMainViewController(): UIViewController {
   val dependencies = AppGraph.createAppDependencies()
   return ComposeUIViewController { AppRoot(dependencies) }
 }

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/export/FileExporter.kt
@@ -8,7 +8,6 @@ import org.w3c.dom.url.URL
 import org.w3c.files.Blob
 import org.w3c.files.BlobPropertyBag
 
-@Suppress("UNUSED_PARAMETER")
 private fun createBlobParts(content: String): JsArray<JsAny?> = js("([content])")
 
 actual fun createFileExporter(): FileExporter = WasmFileExporter()

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/locale/LocaleProvider.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/core/platform/locale/LocaleProvider.kt
@@ -19,7 +19,6 @@ actual class LocaleProvider {
   }
 }
 
-@Suppress("UNUSED_PARAMETER")
 private fun setCustomLocale(locale: String?) {
   js("window.__customLocale = locale")
 }


### PR DESCRIPTION
## Summary
This PR configures detekt linting rules to handle complexity and style violations through configuration rather than code-level suppressions. By adding appropriate exclusions and annotations to the detekt configuration, we can remove numerous `@Suppress` annotations throughout the codebase, improving code cleanliness.

## Key Changes

### Detekt Configuration (`config/detekt/detekt.yml`)
- **Complexity rules**: Added exclusions for DI modules, view packages, and effect handlers to `LongParameterList`, `LongMethod`, `CyclomaticComplexMethod`, and `TooManyFunctions`
- **Naming rules**: Added exclusions for iOS ViewControllers and annotations for `@Composable` and `@Preview`
- **Style rules**: 
  - Configured `MagicNumber` with common ignored values (0-4, 7, 12, 24, 60, -1)
  - Added exclusions for `UnusedParameter` in wasm/js targets
  - Added `ReturnCount` rule with `@Composable` annotation support
  - Configured `MaxLineLength` to 140 characters
- **Exception handling**: Added exclusion for `TooGenericExceptionCaught` in remote data layer

### Code Changes
- Removed 40+ `@Suppress` annotations across the codebase that are now handled by detekt configuration
- Renamed `MainViewController()` to `createMainViewController()` to follow naming conventions without suppression
- Updated iOS clipboard API usage from deprecated `LocalClipboardManager` to `LocalClipboard` with `toClipEntry()`
- Removed unused `rememberCoroutineScope()` variable in `SwipeableContent.kt`
- Removed unused `appMode` parameter from `calculateActivityData()` in `HabitsEffectHandler`

## Benefits
- Cleaner codebase with fewer inline suppressions
- Centralized rule configuration for easier maintenance
- Better alignment with project structure (DI, view, data layers)
- Improved code readability while maintaining necessary flexibility for complex components

https://claude.ai/code/session_01ADEbVjxN3hwGPPHG6hH2c4