### PR TITLE
Add critical reminder to always write tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -204,6 +204,12 @@ We use [Metro](https://zacsweers.github.io/metro/) for compile-time DI.
 
 We follow TDD for business logic and aim for high coverage.
 
+**CRITICAL: Always add tests for new code.** When implementing new features, actions, commands, reducers, or any business logic:
+1. Write tests immediately, not as an afterthought
+2. Ensure all new code paths are covered
+3. Verify tests pass before committing
+4. Never skip tests "to do later" — do them now
+
 ### Running Tests
 
 - Run shared unit tests: `./gradlew :shared:desktopTest`


### PR DESCRIPTION
## Summary

Added prominent reminder in Testing Guidelines to always write tests immediately when implementing new code.

## Changes

Added "CRITICAL" section at the top of Testing Guidelines with clear requirements:
1. Write tests immediately, not as an afterthought
2. Ensure all new code paths are covered
3. Verify tests pass before committing
4. Never skip tests "to do later" — do them now

## Context

This addresses the issue from PR #128 where reducer test was initially missed, causing codecov failure. Making the test requirement more prominent and explicit will help prevent similar issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)