### PR TITLE
Skip habit setup screen for preset habits in onboarding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -401,6 +401,7 @@ Use `@Suppress` annotations only when the lint rule doesn't apply (e.g., `LongPa
 - Use auto-merge with squash (`gh pr merge --auto --squash --delete-branch`).
 - **When user requests changes to existing PR:** amend commits and force-push to the same branch. Do NOT close and recreate PRs.
 - Commit messages: imperative, concise, single topic (e.g., "Simplify README").
+- **Never include session links** — do not add `claude.ai/code/session_*` or any other claude.ai links to commits, PRs, or code.
 - PR titles: use English only (no Cyrillic or other non-ASCII characters).
 - **PR descriptions must be concise and focused:**
   - Brief summary explaining what changed and why

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -6,6 +6,7 @@ import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.shared.app.di.AppScope
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabitStringKeys
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
+import space.be1ski.vibits.shared.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 
 interface HabitPresetsDataSource {
@@ -26,6 +27,6 @@ class HabitPresetsDataSourceImpl : HabitPresetsDataSource {
       HabitPreset(id = DemoHabits.LEARNING, nameKey = DemoHabitStringKeys.LEARNING),
       HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = DemoHabitStringKeys.NO_SUGAR),
       HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = DemoHabitStringKeys.EARLY_SLEEP),
-      HabitPreset(id = "custom", nameKey = "label_habit_preset_custom"),
+      HabitPreset(id = CUSTOM_PRESET_ID, nameKey = "label_habit_preset_custom"),
     )
 }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/model/HabitPreset.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/domain/model/HabitPreset.kt
@@ -1,5 +1,7 @@
 package space.be1ski.vibits.shared.feature.onboarding.domain.model
 
+const val CUSTOM_PRESET_ID = "custom"
+
 data class HabitPreset(
   val id: String,
   val nameKey: String,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/action/OnboardingAction.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/action/OnboardingAction.kt
@@ -27,6 +27,7 @@ sealed interface OnboardingAction : Action {
 
     data class SelectPreset(
       val presetId: String,
+      val localizedName: String,
     ) : Preset
   }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/reducer/OnboardingNavigationReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/reducer/OnboardingNavigationReducer.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.shared.feature.onboarding.presentation.reducer
 
 import space.be1ski.vibits.shared.core.elm.Reducer
 import space.be1ski.vibits.shared.core.elm.reducer
+import space.be1ski.vibits.shared.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.shared.feature.onboarding.presentation.action.OnboardingAction
 import space.be1ski.vibits.shared.feature.onboarding.presentation.effect.OnboardingEffect
 import space.be1ski.vibits.shared.feature.onboarding.presentation.state.OnboardingState
@@ -20,8 +21,21 @@ internal val navigationReducer:
         when (state.currentStep) {
           OnboardingStep.Welcome -> state { copy(currentStep = OnboardingStep.ChoosePreset) }
           OnboardingStep.ChoosePreset -> {
-            if (state.selectedPresetId != null) {
-              state { copy(currentStep = OnboardingStep.HabitSetup) }
+            val presetId = state.selectedPresetId
+            val presetName = state.selectedPresetName
+            if (presetId != null && presetName != null) {
+              if (presetId == CUSTOM_PRESET_ID) {
+                state { copy(currentStep = OnboardingStep.HabitSetup) }
+              } else {
+                state { copy(isCreatingHabit = true, habitName = presetName, creationError = null) }
+                command(
+                  OnboardingEffect.Command.CreateFirstHabit(
+                    presetName,
+                    presetId,
+                    state.selectedColor,
+                  ),
+                )
+              }
             }
           }
           OnboardingStep.HabitSetup -> {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/reducer/OnboardingPresetReducer.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/reducer/OnboardingPresetReducer.kt
@@ -14,7 +14,12 @@ internal val presetReducer: Reducer<OnboardingAction.Preset, OnboardingState, On
       }
 
       is OnboardingAction.Preset.SelectPreset -> {
-        state { copy(selectedPresetId = action.presetId) }
+        state {
+          copy(
+            selectedPresetId = action.presetId,
+            selectedPresetName = action.localizedName,
+          )
+        }
       }
     }
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/state/OnboardingState.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/state/OnboardingState.kt
@@ -7,6 +7,7 @@ data class OnboardingState(
   val currentStep: OnboardingStep = OnboardingStep.Welcome,
   val presets: List<HabitPreset> = emptyList(),
   val selectedPresetId: String? = null,
+  val selectedPresetName: String? = null,
   val habitName: String = "",
   val selectedColor: Long = DefaultHabitColor,
   val isCreatingHabit: Boolean = false,

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/ChoosePresetScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/ChoosePresetScreen.kt
@@ -41,9 +41,8 @@ import space.be1ski.vibits.shared.core.ui.theme.AppColors
 import space.be1ski.vibits.shared.core.ui.theme.resolve
 import space.be1ski.vibits.shared.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.shared.feature.habits.presentation.view.components.localizedDemoHabitName
+import space.be1ski.vibits.shared.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
-import space.be1ski.vibits.shared.feature.onboarding.presentation.action.OnboardingAction
-import space.be1ski.vibits.shared.feature.onboarding.presentation.state.OnboardingState
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_continue
 import space.be1ski.vibits.shared.generated.label_habit_preset_custom
@@ -60,7 +59,7 @@ private fun HabitPreset.localizedName(): String =
 fun ChoosePresetScreen(
   presets: List<HabitPreset>,
   selectedPresetId: String?,
-  onSelectPreset: (String) -> Unit,
+  onSelectPreset: (presetId: String, localizedName: String) -> Unit,
   onContinue: () -> Unit,
   onBack: () -> Unit,
   modifier: Modifier = Modifier,
@@ -93,10 +92,12 @@ fun ChoosePresetScreen(
       verticalArrangement = Arrangement.spacedBy(Indent.s),
     ) {
       items(presets, key = { it.id }) { preset ->
+        val localizedName = preset.localizedName()
         PresetCard(
           preset = preset,
+          localizedName = localizedName,
           isSelected = selectedPresetId == preset.id,
-          onClick = { onSelectPreset(preset.id) },
+          onClick = { onSelectPreset(preset.id, localizedName) },
         )
       }
     }
@@ -118,6 +119,7 @@ fun ChoosePresetScreen(
 @Composable
 private fun PresetCard(
   preset: HabitPreset,
+  localizedName: String,
   isSelected: Boolean,
   onClick: () -> Unit,
   modifier: Modifier = Modifier,
@@ -156,7 +158,7 @@ private fun PresetCard(
       }
 
       Text(
-        text = preset.localizedName(),
+        text = localizedName,
         style = MaterialTheme.typography.bodyLarge,
         color = textColor,
         modifier = Modifier.weight(1f),
@@ -183,6 +185,6 @@ private fun HabitPreset.iconVector(): ImageVector? =
     DemoHabits.LEARNING -> Icons.Default.School
     DemoHabits.NO_SUGAR -> Icons.Default.NoFood
     DemoHabits.EARLY_SLEEP -> Icons.Default.Bedtime
-    "custom" -> Icons.Default.AutoAwesome
+    CUSTOM_PRESET_ID -> Icons.Default.AutoAwesome
     else -> null
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/HabitSetupScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/HabitSetupScreen.kt
@@ -38,6 +38,7 @@ import space.be1ski.vibits.shared.core.ui.theme.AppColors
 import space.be1ski.vibits.shared.core.ui.theme.HabitColors
 import space.be1ski.vibits.shared.core.ui.theme.resolve
 import space.be1ski.vibits.shared.feature.habits.presentation.view.components.localizedDemoHabitName
+import space.be1ski.vibits.shared.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.shared.generated.Res
 import space.be1ski.vibits.shared.generated.action_start_tracking
@@ -73,7 +74,7 @@ fun HabitSetupScreen(
   val selectedPreset = presets.find { it.id == selectedPresetId }
   val localizedPresetName =
     selectedPreset?.let {
-      if (it.id != "custom") getLocalizedPresetName(it.nameKey) else ""
+      if (it.id != CUSTOM_PRESET_ID) getLocalizedPresetName(it.nameKey) else ""
     } ?: ""
 
   // Auto-fill habit name from localized preset name

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/OnboardingScreen.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/view/OnboardingScreen.kt
@@ -44,7 +44,9 @@ fun OnboardingScreen(
         ChoosePresetScreen(
           presets = state.presets,
           selectedPresetId = state.selectedPresetId,
-          onSelectPreset = { onAction(OnboardingAction.Preset.SelectPreset(it)) },
+          onSelectPreset = { presetId, localizedName ->
+            onAction(OnboardingAction.Preset.SelectPreset(presetId, localizedName))
+          },
           onContinue = { onAction(OnboardingAction.Navigation.Continue) },
           onBack = { onAction(OnboardingAction.Navigation.Back) },
           modifier = modifier.fillMaxSize(),

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducerTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/onboarding/presentation/OnboardingReducerTest.kt
@@ -1,8 +1,9 @@
 package space.be1ski.vibits.shared.feature.onboarding.presentation
+
 import space.be1ski.vibits.shared.core.elm.test
+import space.be1ski.vibits.shared.core.ui.theme.DefaultHabitColor
 import space.be1ski.vibits.shared.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.shared.feature.onboarding.presentation.action.OnboardingAction
-import space.be1ski.vibits.shared.feature.onboarding.presentation.effect.OnboardingEffect
 import space.be1ski.vibits.shared.feature.onboarding.presentation.effect.OnboardingEffect.Command
 import space.be1ski.vibits.shared.feature.onboarding.presentation.effect.OnboardingEffect.Notification
 import space.be1ski.vibits.shared.feature.onboarding.presentation.reducer.onboardingReducer
@@ -31,17 +32,26 @@ class OnboardingReducerTest {
     }
 
   @Test
-  fun `when Continue from ChoosePreset with selected preset then moves to HabitSetup`() =
+  fun `when Continue from ChoosePreset with regular preset then creates habit directly`() =
     onboardingReducer.test(
       OnboardingState(
         currentStep = OnboardingStep.ChoosePreset,
         selectedPresetId = "water",
+        selectedPresetName = "Drink Water",
+        selectedColor = DefaultHabitColor,
       ),
     ) {
       send(OnboardingAction.Navigation.Continue)
 
-      assertState { currentStep == OnboardingStep.HabitSetup }
-      assertNoEffects()
+      assertState {
+        isCreatingHabit &&
+          habitName == "Drink Water" &&
+          creationError == null
+      }
+      val effect = assertHasCommand<Command.CreateFirstHabit>()
+      assertEquals("Drink Water", effect.name)
+      assertEquals("water", effect.presetId)
+      assertEquals(DefaultHabitColor, effect.color)
     }
 
   @Test
@@ -50,6 +60,7 @@ class OnboardingReducerTest {
       OnboardingState(
         currentStep = OnboardingStep.ChoosePreset,
         selectedPresetId = "custom",
+        selectedPresetName = "Create your own",
       ),
     ) {
       send(OnboardingAction.Navigation.Continue)
@@ -87,11 +98,14 @@ class OnboardingReducerTest {
     }
 
   @Test
-  fun `when SelectPreset then updates selectedPresetId`() =
+  fun `when SelectPreset then updates selectedPresetId and selectedPresetName`() =
     onboardingReducer.test(OnboardingState()) {
-      send(OnboardingAction.Preset.SelectPreset("water"))
+      send(OnboardingAction.Preset.SelectPreset("water", "Drink Water"))
 
-      assertState { selectedPresetId == "water" }
+      assertState {
+        selectedPresetId == "water" &&
+          selectedPresetName == "Drink Water"
+      }
       assertNoEffects()
     }
 


### PR DESCRIPTION
When a user selects a preset habit (not "Create your own"), skip the
habit setup screen and create the habit directly with the preset's
localized name and default color. The setup screen is now only shown
when "custom" preset is selected, allowing users to enter their own
habit name.

