### PR TITLE
Format log export timestamps to remove T separator

### DIFF
--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/logging/Log.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/core/logging/Log.kt
@@ -12,6 +12,7 @@ import kotlin.time.Clock
  */
 object Log : SynchronizedObject() {
   private const val MAX_LOGS = 500
+  private const val TIMESTAMP_EXPORT_LENGTH = 23 // "2026-01-31 18:37:14.379"
 
   private val _logs = mutableListOf<LogEntry>()
   val logs: List<LogEntry>
@@ -82,9 +83,14 @@ object Log : SynchronizedObject() {
   fun export(): String =
     synchronized(this) {
       _logs.joinToString("\n") { entry ->
-        "${entry.timestamp} ${entry.level.name.first()}/$entry.tag: ${entry.message}"
+        "${formatTimestamp(entry.timestamp)} ${entry.level.name.first()}/${entry.tag}: ${entry.message}"
       }
     }
+
+  private fun formatTimestamp(timestamp: String): String =
+    timestamp
+      .take(TIMESTAMP_EXPORT_LENGTH)
+      .replace('T', ' ')
 }
 
 data class LogEntry(

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/logging/LogTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/core/logging/LogTest.kt
@@ -87,9 +87,17 @@ class LogTest {
 
     val exported = Log.export()
 
-    assertTrue(exported.contains("D/"))
-    assertTrue(exported.contains("TestTag"))
-    assertTrue(exported.contains("Test message"))
+    assertTrue(exported.contains("D/TestTag: Test message"))
+  }
+
+  @Test
+  fun `when export called then timestamp is formatted without T separator`() {
+    Log.d("Tag", "Message")
+
+    val exported = Log.export()
+
+    // Timestamp should be "YYYY-MM-DD HH:MM:SS.mmm" format (no T, no microseconds)
+    assertTrue(exported.matches(Regex("""\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3} D/Tag: Message""")))
   }
 
   @Test


### PR DESCRIPTION
## Summary
Updated the log export functionality to format timestamps in a more human-readable format by removing the ISO 8601 'T' separator and truncating microseconds.

## Changes
- Added `TIMESTAMP_EXPORT_LENGTH` constant (23 characters) to define the expected timestamp format length
- Created new `formatTimestamp()` function that:
  - Truncates timestamps to 23 characters (format: "YYYY-MM-DD HH:MM:SS.mmm")
  - Replaces the 'T' separator with a space for readability
- Updated `export()` function to use the new timestamp formatter
- Enhanced test coverage:
  - Improved existing export test to verify complete log entry format
  - Added new test to validate timestamp format matches expected pattern without 'T' separator

## Implementation Details
The timestamp formatting converts ISO 8601 format (e.g., "2026-01-31T18:37:14.379123") to a more readable format (e.g., "2026-01-31 18:37:14.379") by taking the first 23 characters and replacing 'T' with a space. This maintains millisecond precision while improving human readability in exported logs.
