### PR TITLE
Fix sync queue handling for temporary memos

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -4,6 +4,9 @@ coverage:
       default:
         target: 90%
         threshold: 1%
+    patch:
+      default:
+        target: 93%
 
 comment:
   layout: "reach, diff, flags, files"

--- a/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
+++ b/shared/src/androidMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
@@ -41,6 +41,11 @@ private class AndroidSyncOperationStore : SyncOperationStore {
     daoOrNull()?.updateMemoName(id, memoName)
   }
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean = daoOrNull()?.updateContent(id, content)?.let { it > 0 } ?: false
+
   override suspend fun removeOperation(id: String) {
     daoOrNull()?.deleteById(id)
   }

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/OfflineFirstMemosRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/OfflineFirstMemosRepository.kt
@@ -70,6 +70,8 @@ class OfflineFirstMemosRepository(
 
   /**
    * Updates a memo locally and queues it for sync.
+   * For temporary memos, coalesces the update into the pending CREATE operation
+   * to ensure the latest content is synced when the CREATE is applied.
    * Thread-safe.
    */
   suspend fun updateMemoLocally(
@@ -95,23 +97,53 @@ class OfflineFirstMemosRepository(
       memoCache.upsertMemo(memo)
       Log.d(TAG, "Updated memo locally: $name")
 
-      // Queue for sync
-      val operation =
-        SyncOperation(
-          id = OperationId.generate(),
-          type = SyncOperationType.UPDATE,
-          memoName = name,
-          content = content,
-          createdAt = now,
-        )
-      syncQueue.addOperation(operation)
-      Log.d(TAG, "Queued UPDATE operation: ${operation.id}")
+      // For temp memos, try to update the pending CREATE operation instead of enqueueing UPDATE
+      if (TempMemoName.isTemporary(name)) {
+        val pendingCreate =
+          syncQueue.getPendingOperations().find {
+            it.type == SyncOperationType.CREATE && it.memoName == name
+          }
+        if (pendingCreate != null) {
+          // Atomically update content only if still PENDING (avoids race with concurrent sync)
+          val updated = syncQueue.updateContent(pendingCreate.id, content)
+          if (updated) {
+            Log.d(TAG, "Updated content in pending CREATE: ${pendingCreate.id}")
+          } else {
+            // CREATE is no longer pending (being synced), fall back to UPDATE
+            Log.d(TAG, "CREATE no longer pending, enqueueing UPDATE: ${pendingCreate.id}")
+            enqueueUpdateOperation(name, content, now)
+          }
+        } else {
+          Log.w(TAG, "No pending CREATE found for temp memo: $name, enqueueing UPDATE")
+          enqueueUpdateOperation(name, content, now)
+        }
+      } else {
+        enqueueUpdateOperation(name, content, now)
+      }
 
       memo
     }
 
+  private suspend fun enqueueUpdateOperation(
+    name: String,
+    content: String,
+    createdAt: kotlin.time.Instant,
+  ) {
+    val operation =
+      SyncOperation(
+        id = OperationId.generate(),
+        type = SyncOperationType.UPDATE,
+        memoName = name,
+        content = content,
+        createdAt = createdAt,
+      )
+    syncQueue.addOperation(operation)
+    Log.d(TAG, "Queued UPDATE operation: ${operation.id}")
+  }
+
   /**
    * Deletes a memo locally and queues it for sync.
+   * For temporary memos, removes the pending CREATE operation instead of enqueueing DELETE.
    * Thread-safe.
    */
   suspend fun deleteMemoLocally(name: String) =
@@ -133,8 +165,17 @@ class OfflineFirstMemosRepository(
         syncQueue.addOperation(operation)
         Log.d(TAG, "Queued DELETE operation: ${operation.id}")
       } else {
-        // For temp memos that were never synced, just remove any pending CREATE operation
-        Log.d(TAG, "Skipped sync for temporary memo: $name")
+        // For temp memos that were never synced, remove any pending CREATE operation
+        val pendingCreate =
+          syncQueue.getPendingOperations().find {
+            it.type == SyncOperationType.CREATE && it.memoName == name
+          }
+        if (pendingCreate != null) {
+          syncQueue.removeOperation(pendingCreate.id)
+          Log.d(TAG, "Removed pending CREATE for temp memo: ${pendingCreate.id}")
+        } else {
+          Log.d(TAG, "No pending CREATE found for temp memo: $name")
+        }
       }
     }
 

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncQueueRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncQueueRepositoryImpl.kt
@@ -18,6 +18,7 @@ import space.be1ski.vibits.shared.feature.sync.domain.repository.SyncQueueReposi
  * Thread-safe implementation of SyncQueueRepository.
  * Uses a mutex to ensure thread-safe access to the underlying store.
  */
+@Suppress("TooManyFunctions")
 @Inject
 @SingleIn(AppScope::class)
 @ContributesBinding(AppScope::class)
@@ -55,6 +56,14 @@ class SyncQueueRepositoryImpl(
   ) = mutex.withLock {
     store.updateMemoName(id, memoName)
   }
+
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean =
+    mutex.withLock {
+      store.updateContent(id, content)
+    }
 
   override suspend fun removeOperation(id: String) =
     mutex.withLock {

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
@@ -40,6 +40,15 @@ interface SyncOperationStore {
   )
 
   /**
+   * Updates the content of a pending operation.
+   * @return true if the operation was found and updated, false otherwise
+   */
+  suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean
+
+  /**
    * Removes an operation.
    */
   suspend fun removeOperation(id: String)

--- a/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/domain/repository/SyncQueueRepository.kt
+++ b/shared/src/commonMain/kotlin/space/be1ski/vibits/shared/feature/sync/domain/repository/SyncQueueRepository.kt
@@ -56,6 +56,16 @@ interface SyncQueueRepository : SyncStatusProvider {
   )
 
   /**
+   * Updates the content of a pending operation.
+   * Used to coalesce updates to temporary memos into the pending CREATE operation.
+   * @return true if the operation was found and updated, false otherwise
+   */
+  suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean
+
+  /**
    * Removes a synced operation from the queue.
    */
   suspend fun removeOperation(id: String)
@@ -64,7 +74,7 @@ interface SyncQueueRepository : SyncStatusProvider {
    * Clears operations from the queue.
    * @param syncedOnly If true, only clears synced operations. If false, clears all operations.
    */
-  suspend fun clearOperations(syncedOnly: Boolean = true)
+  suspend fun clearOperations(syncedOnly: Boolean)
 
   /**
    * Resets IN_PROGRESS operations back to PENDING.

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/memos/data/ModeAwareMemosRepositoryTest.kt
@@ -294,6 +294,18 @@ private class TrackingSyncQueueRepository : SyncQueueRepository {
     }
   }
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean {
+    val index = addedOperations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+    if (index >= 0) {
+      addedOperations[index] = addedOperations[index].copy(content = content)
+      return true
+    }
+    return false
+  }
+
   override suspend fun removeOperation(id: String) {
     addedOperations.removeAll { it.id == id }
   }
@@ -382,6 +394,18 @@ private class FakeSyncQueueRepository : SyncQueueRepository {
     if (index >= 0) {
       operations[index] = operations[index].copy(memoName = memoName)
     }
+  }
+
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean {
+    val index = operations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+    if (index >= 0) {
+      operations[index] = operations[index].copy(content = content)
+      return true
+    }
+    return false
   }
 
   override suspend fun removeOperation(id: String) {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/OfflineFirstMemosRepositoryTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/OfflineFirstMemosRepositoryTest.kt
@@ -119,6 +119,192 @@ class OfflineFirstMemosRepositoryTest {
     }
 
   @Test
+  fun `when deleteMemoLocally with temp memo then removes pending CREATE operation`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+
+      // Create a temp memo (this adds a CREATE operation to the queue)
+      val memo = repository.createMemoLocally("Content")
+      assertEquals(1, queue.operations.size)
+      assertEquals(SyncOperationType.CREATE, queue.operations.first().type)
+
+      // Delete the temp memo
+      repository.deleteMemoLocally(memo.name)
+
+      // Memo is removed from cache
+      assertTrue(cache.memos.isEmpty())
+
+      // Pending CREATE operation is removed
+      assertTrue(queue.operations.isEmpty())
+    }
+
+  @Test
+  fun `when updateMemoLocally with temp memo then coalesces into pending CREATE`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+
+      // Create a temp memo (this adds a CREATE operation to the queue)
+      val memo = repository.createMemoLocally("Original content")
+      assertEquals(1, queue.operations.size)
+      val createOperation = queue.operations.first()
+      assertEquals(SyncOperationType.CREATE, createOperation.type)
+      assertEquals("Original content", createOperation.content)
+
+      // Update the temp memo
+      repository.updateMemoLocally(memo.name, "Updated content")
+
+      // Cache is updated
+      assertEquals(1, cache.memos.size)
+      assertEquals("Updated content", cache.memos.first().content)
+
+      // Still only one operation (the CREATE), not a separate UPDATE
+      assertEquals(1, queue.operations.size)
+      assertEquals(SyncOperationType.CREATE, queue.operations.first().type)
+      // Content in CREATE operation is updated
+      assertEquals("Updated content", queue.operations.first().content)
+    }
+
+  @Test
+  fun `when updateMemoLocally with temp memo then finds correct CREATE among multiple operations`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+
+      // Add some unrelated operations to the queue first
+      queue.addOperation(
+        SyncOperation(
+          id = "other-1",
+          type = SyncOperationType.UPDATE,
+          memoName = "memos/other",
+          content = "other",
+        ),
+      )
+      queue.addOperation(
+        SyncOperation(
+          id = "other-2",
+          type = SyncOperationType.CREATE,
+          memoName = "local_different_name",
+          content = "different",
+        ),
+      )
+
+      // Create a temp memo
+      val memo = repository.createMemoLocally("Original content")
+      assertEquals(3, queue.operations.size)
+
+      // Update the temp memo - should find the correct CREATE
+      repository.updateMemoLocally(memo.name, "Updated content")
+
+      // Only the correct CREATE should be updated
+      val targetCreate = queue.operations.find { it.memoName == memo.name }
+      assertEquals("Updated content", targetCreate?.content)
+
+      // Other operations unchanged
+      assertEquals("other", queue.operations.find { it.id == "other-1" }?.content)
+      assertEquals("different", queue.operations.find { it.id == "other-2" }?.content)
+    }
+
+  @Test
+  fun `when updateMemoLocally with server memo then queues UPDATE operation`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+      cache.memos.add(Memo(name = "memos/123", content = "Original"))
+
+      repository.updateMemoLocally("memos/123", "Updated content")
+
+      // UPDATE operation is queued (not coalesced since it's not a temp memo)
+      assertEquals(1, queue.operations.size)
+      assertEquals(SyncOperationType.UPDATE, queue.operations.first().type)
+      assertEquals("memos/123", queue.operations.first().memoName)
+      assertEquals("Updated content", queue.operations.first().content)
+    }
+
+  @Test
+  fun `when updateMemoLocally with non-existing memo then uses current time for createTime`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+      // Don't add memo to cache - simulates updating a memo not in cache
+
+      val memo = repository.updateMemoLocally("memos/new", "Content")
+
+      // Memo is created with current time for both createTime and updateTime
+      assertNotNull(memo.createTime)
+      assertNotNull(memo.updateTime)
+      assertEquals(memo.createTime, memo.updateTime)
+
+      // Memo is in cache
+      assertEquals(1, cache.memos.size)
+
+      // UPDATE operation is queued
+      assertEquals(1, queue.operations.size)
+      assertEquals(SyncOperationType.UPDATE, queue.operations.first().type)
+    }
+
+  @Test
+  fun `when updateMemoLocally with existing memo among others then finds correct one`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+      // Add multiple memos, only one matches
+      cache.memos.add(Memo(name = "memos/other1", content = "Other 1"))
+      cache.memos.add(Memo(name = "memos/target", content = "Original", createTime = Instant.fromEpochMilliseconds(1000L)))
+      cache.memos.add(Memo(name = "memos/other2", content = "Other 2"))
+
+      val memo = repository.updateMemoLocally("memos/target", "Updated")
+
+      // Create time is preserved from the found existing memo
+      assertEquals(Instant.fromEpochMilliseconds(1000L), memo.createTime)
+      assertEquals("Updated", memo.content)
+    }
+
+  @Test
+  fun `when updateMemoLocally with temp memo and CREATE no longer pending then falls back to UPDATE`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+
+      // Create a temp memo (this adds a CREATE operation to the queue)
+      val memo = repository.createMemoLocally("Original content")
+      assertEquals(1, queue.operations.size)
+
+      // Simulate race condition: getPendingOperations returns CREATE, but updateContent fails
+      queue.simulateUpdateContentRace = true
+
+      // Update the temp memo while sync is racing
+      repository.updateMemoLocally(memo.name, "Updated content")
+
+      // Cache is updated
+      assertEquals("Updated content", cache.memos.first().content)
+
+      // CREATE content is NOT updated (race condition simulated)
+      assertEquals("Original content", queue.operations.first().content)
+
+      // An UPDATE operation is enqueued as fallback
+      assertEquals(2, queue.operations.size)
+      val updateOp = queue.operations.last()
+      assertEquals(SyncOperationType.UPDATE, updateOp.type)
+      assertEquals(memo.name, updateOp.memoName)
+      assertEquals("Updated content", updateOp.content)
+    }
+
+  @Test
+  fun `when updateMemoLocally with temp memo and no CREATE in queue then enqueues UPDATE`() =
+    runTest {
+      val (repository, cache, queue) = createRepository()
+
+      // Add temp memo directly to cache without CREATE operation
+      val tempName = "local_123456_78901"
+      cache.memos.add(Memo(name = tempName, content = "Original"))
+
+      repository.updateMemoLocally(tempName, "Updated content")
+
+      // Cache is updated
+      assertEquals("Updated content", cache.memos.first().content)
+
+      // UPDATE is enqueued since no CREATE was found
+      assertEquals(1, queue.operations.size)
+      assertEquals(SyncOperationType.UPDATE, queue.operations.first().type)
+      assertEquals(tempName, queue.operations.first().memoName)
+    }
+
+  @Test
   fun `when getCachedMemos then returns all memos from cache`() =
     runTest {
       val (repository, cache, _) = createRepository()
@@ -148,6 +334,28 @@ class OfflineFirstMemosRepositoryTest {
       assertEquals(2, cache.memos.size)
       assertEquals("memos/1", cache.memos[0].name)
       assertEquals("memos/2", cache.memos[1].name)
+    }
+
+  @Test
+  fun `when replaceAllMemos with local temp memos then preserves them`() =
+    runTest {
+      val (repository, cache, _) = createRepository()
+      // Add a local temp memo that should be preserved
+      cache.memos.add(Memo(name = "local_123456_78901", content = "Local temp"))
+      cache.memos.add(Memo(name = "memos/old", content = "Old"))
+
+      val serverMemos =
+        listOf(
+          Memo(name = "memos/1", content = "One"),
+          Memo(name = "memos/2", content = "Two"),
+        )
+      repository.replaceAllMemos(serverMemos)
+
+      // Server memos + preserved local temp
+      assertEquals(3, cache.memos.size)
+      assertTrue(cache.memos.any { it.name == "memos/1" })
+      assertTrue(cache.memos.any { it.name == "memos/2" })
+      assertTrue(cache.memos.any { it.name == "local_123456_78901" })
     }
 
   @Test
@@ -215,6 +423,9 @@ class OfflineFirstMemosRepositoryTest {
   private class FakeSyncQueueRepository : SyncQueueRepository {
     val operations = mutableListOf<SyncOperation>()
 
+    /** When true, updateContent always returns false to simulate race condition */
+    var simulateUpdateContentRace = false
+
     override suspend fun addOperation(operation: SyncOperation) {
       operations.add(operation)
     }
@@ -241,6 +452,19 @@ class OfflineFirstMemosRepositoryTest {
       if (index >= 0) {
         operations[index] = operations[index].copy(memoName = memoName)
       }
+    }
+
+    override suspend fun updateContent(
+      id: String,
+      content: String,
+    ): Boolean {
+      if (simulateUpdateContentRace) return false
+      val index = operations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+      if (index >= 0) {
+        operations[index] = operations[index].copy(content = content)
+        return true
+      }
+      return false
     }
 
     override suspend fun removeOperation(id: String) {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncEngineImplTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncEngineImplTest.kt
@@ -612,6 +612,18 @@ class SyncEngineImplTest {
       }
     }
 
+    override suspend fun updateContent(
+      id: String,
+      content: String,
+    ): Boolean {
+      val index = operations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+      if (index >= 0) {
+        operations[index] = operations[index].copy(content = content)
+        return true
+      }
+      return false
+    }
+
     override suspend fun removeOperation(id: String) {
       operations.removeAll { it.id == id }
     }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncOperationApplierTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncOperationApplierTest.kt
@@ -482,6 +482,18 @@ class SyncOperationApplierTest {
       }
     }
 
+    override suspend fun updateContent(
+      id: String,
+      content: String,
+    ): Boolean {
+      val index = operations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+      if (index >= 0) {
+        operations[index] = operations[index].copy(content = content)
+        return true
+      }
+      return false
+    }
+
     override suspend fun removeOperation(id: String) {
       operations.removeAll { it.id == id }
     }

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncQueueRepositoryImplTest.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/feature/sync/data/SyncQueueRepositoryImplTest.kt
@@ -108,6 +108,42 @@ class SyncQueueRepositoryImplTest {
     }
 
   @Test
+  fun `when updateContent with pending operation then updates and returns true`() =
+    runTest {
+      val (repository, store) = createRepository()
+      store.operations["op1"] =
+        SyncOperation(
+          id = "op1",
+          type = SyncOperationType.CREATE,
+          content = "old content",
+          status = SyncOperationStatus.PENDING,
+        )
+
+      val result = repository.updateContent("op1", "new content")
+
+      assertTrue(result)
+      assertEquals("new content", store.operations["op1"]?.content)
+    }
+
+  @Test
+  fun `when updateContent with non-pending operation then returns false`() =
+    runTest {
+      val (repository, store) = createRepository()
+      store.operations["op1"] =
+        SyncOperation(
+          id = "op1",
+          type = SyncOperationType.CREATE,
+          content = "old content",
+          status = SyncOperationStatus.IN_PROGRESS,
+        )
+
+      val result = repository.updateContent("op1", "new content")
+
+      assertTrue(!result)
+      assertEquals("old content", store.operations["op1"]?.content)
+    }
+
+  @Test
   fun `when removeOperation then removes from store`() =
     runTest {
       val (repository, store) = createRepository()
@@ -221,6 +257,19 @@ class SyncQueueRepositoryImplTest {
     ) {
       operations[id]?.let { operations[id] = it.copy(memoName = memoName) }
       notifyChange()
+    }
+
+    override suspend fun updateContent(
+      id: String,
+      content: String,
+    ): Boolean {
+      val op = operations[id]
+      if (op != null && op.status == SyncOperationStatus.PENDING) {
+        operations[id] = op.copy(content = content)
+        notifyChange()
+        return true
+      }
+      return false
     }
 
     override suspend fun removeOperation(id: String) {

--- a/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
+++ b/shared/src/commonTest/kotlin/space/be1ski/vibits/shared/test/Fakes.kt
@@ -218,6 +218,18 @@ class FakeSyncQueueRepository : SyncQueueRepository {
     }
   }
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean {
+    val index = operations.indexOfFirst { it.id == id && it.status == SyncOperationStatus.PENDING }
+    if (index >= 0) {
+      operations[index] = operations[index].copy(content = content)
+      return true
+    }
+    return false
+  }
+
   override suspend fun removeOperation(id: String) {
     operations.removeAll { it.id == id }
   }

--- a/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
+++ b/shared/src/desktopMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
@@ -33,6 +33,11 @@ private class DesktopSyncOperationStore : SyncOperationStore {
     dao.updateMemoName(id, memoName)
   }
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean = dao.updateContent(id, content) > 0
+
   override suspend fun removeOperation(id: String) {
     dao.deleteById(id)
   }

--- a/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
+++ b/shared/src/iosMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
@@ -33,6 +33,11 @@ private class IosSyncOperationStore : SyncOperationStore {
     dao.updateMemoName(id, memoName)
   }
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean = dao.updateContent(id, content) > 0
+
   override suspend fun removeOperation(id: String) {
     dao.deleteById(id)
   }

--- a/shared/src/roomMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/room/SyncOperationDao.kt
+++ b/shared/src/roomMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/room/SyncOperationDao.kt
@@ -61,6 +61,16 @@ interface SyncOperationDao {
   )
 
   /**
+   * Updates the content of a pending operation.
+   * @return number of rows affected (1 if found, 0 if not)
+   */
+  @Query("UPDATE sync_operations SET content = :content WHERE id = :id AND status = 'PENDING'")
+  suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Int
+
+  /**
    * Deletes an operation by ID.
    */
   @Query("DELETE FROM sync_operations WHERE id = :id")

--- a/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
+++ b/shared/src/wasmJsMain/kotlin/space/be1ski/vibits/shared/feature/sync/data/platform/SyncOperationStore.kt
@@ -25,6 +25,11 @@ private class WasmSyncOperationStore : SyncOperationStore {
     memoName: String,
   ) = Unit
 
+  override suspend fun updateContent(
+    id: String,
+    content: String,
+  ): Boolean = false
+
   override suspend fun removeOperation(id: String) = Unit
 
   override suspend fun clearOperations(syncedOnly: Boolean) = Unit


### PR DESCRIPTION
## Summary

Fixes two correctness issues in the offline-first sync flow for temporary memos:

- **Updates before first sync:** When a memo is created offline and edited before sync, updates now coalesce into the pending CREATE operation instead of creating separate UPDATE operations that would be skipped
- **Deletes before first sync:** When a memo is created offline and deleted before sync, the pending CREATE operation is now removed to prevent the memo from being recreated on the server

## Changes

- Add `updateContent` method to sync queue repository chain (interface, impl, DAO, all platforms)
- Modify `updateMemoLocally` to detect temp memos and update the pending CREATE content
- Modify `deleteMemoLocally` to find and remove pending CREATE for temp memos
- Add tests for both scenarios

## Test plan

- [x] `./gradlew checkAll` passes
- [x] New tests verify coalescing behavior for temp memo updates
- [x] New tests verify CREATE removal for temp memo deletes

🤖 Generated with [Claude Code](https://claude.com/claude-code)