### PR TITLE
Enable Android resources for Compose Multiplatform

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
@@ -9,6 +9,8 @@ kotlin {
     namespace = project.androidNamespace()
     compileSdk = 36
     minSdk = 31
+    // Required for Compose Multiplatform resources to work with the new KMP Android plugin
+    androidResources.enable = true
   }
 
   jvm("desktop")


### PR DESCRIPTION
## Summary
- Enable `androidResources` in the KMP Android library convention plugin
- Fixes Compose Multiplatform resources not being included in APK assets

## Changes
The new `com.android.kotlin.multiplatform.library` plugin (AGP 8.8.0+) requires explicit enabling of Android resources for Compose Multiplatform resources to work. Without this setting, `.cvr` files are generated but not packaged into the APK, causing `MissingResourceException` at runtime.

## Test plan
- [x] Build passes (`./gradlew checkJvm`)
- [x] APK contains compose resources in `assets/composeResources/`
- [x] App launches without `MissingResourceException`