### PR TITLE
Extract credentials validation to reusable utilities

### DIFF
--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/Credentials.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/Credentials.kt
@@ -7,3 +7,17 @@ data class Credentials(
   val baseUrl: String,
   val token: String,
 )
+
+val Credentials.isFilled: Boolean
+  get() = baseUrl.trim().isNotBlank() && token.trim().isNotBlank()
+
+fun Credentials.trimmed(): Credentials =
+  Credentials(
+    baseUrl = baseUrl.trim(),
+    token = token.trim(),
+  )
+
+fun Credentials.requireFilled(): Credentials {
+  check(isFilled) { "Base URL and token are required." }
+  return trimmed()
+}

--- a/feature/auth/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/domain/model/CredentialsTest.kt
+++ b/feature/auth/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/domain/model/CredentialsTest.kt
@@ -1,0 +1,136 @@
+package space.be1ski.vibits.feature.auth.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class CredentialsTest {
+  @Test
+  fun `when both baseUrl and token are filled then isFilled returns true`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "abc123")
+
+    assertTrue(credentials.isFilled)
+  }
+
+  @Test
+  fun `when baseUrl and token have leading and trailing spaces then isFilled returns true`() {
+    val credentials = Credentials(baseUrl = "  https://example.com  ", token = "  abc123  ")
+
+    assertTrue(credentials.isFilled)
+  }
+
+  @Test
+  fun `when baseUrl is blank then isFilled returns false`() {
+    val credentials = Credentials(baseUrl = "", token = "abc123")
+
+    assertFalse(credentials.isFilled)
+  }
+
+  @Test
+  fun `when baseUrl is only whitespace then isFilled returns false`() {
+    val credentials = Credentials(baseUrl = "   ", token = "abc123")
+
+    assertFalse(credentials.isFilled)
+  }
+
+  @Test
+  fun `when token is blank then isFilled returns false`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "")
+
+    assertFalse(credentials.isFilled)
+  }
+
+  @Test
+  fun `when token is only whitespace then isFilled returns false`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "   ")
+
+    assertFalse(credentials.isFilled)
+  }
+
+  @Test
+  fun `when both baseUrl and token are blank then isFilled returns false`() {
+    val credentials = Credentials(baseUrl = "", token = "")
+
+    assertFalse(credentials.isFilled)
+  }
+
+  @Test
+  fun `when trimmed then returns credentials with trimmed values`() {
+    val credentials = Credentials(baseUrl = "  https://example.com  ", token = "  abc123  ")
+
+    val trimmed = credentials.trimmed()
+
+    assertEquals("https://example.com", trimmed.baseUrl)
+    assertEquals("abc123", trimmed.token)
+  }
+
+  @Test
+  fun `when trimmed on already trimmed credentials then returns equivalent credentials`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "abc123")
+
+    val trimmed = credentials.trimmed()
+
+    assertEquals(credentials.baseUrl, trimmed.baseUrl)
+    assertEquals(credentials.token, trimmed.token)
+  }
+
+  @Test
+  fun `when requireFilled on filled credentials then returns trimmed credentials`() {
+    val credentials = Credentials(baseUrl = "  https://example.com  ", token = "  abc123  ")
+
+    val result = credentials.requireFilled()
+
+    assertEquals("https://example.com", result.baseUrl)
+    assertEquals("abc123", result.token)
+  }
+
+  @Test
+  fun `when requireFilled on empty baseUrl then throws IllegalStateException`() {
+    val credentials = Credentials(baseUrl = "", token = "abc123")
+
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        credentials.requireFilled()
+      }
+
+    assertEquals("Base URL and token are required.", exception.message)
+  }
+
+  @Test
+  fun `when requireFilled on whitespace baseUrl then throws IllegalStateException`() {
+    val credentials = Credentials(baseUrl = "   ", token = "abc123")
+
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        credentials.requireFilled()
+      }
+
+    assertEquals("Base URL and token are required.", exception.message)
+  }
+
+  @Test
+  fun `when requireFilled on empty token then throws IllegalStateException`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "")
+
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        credentials.requireFilled()
+      }
+
+    assertEquals("Base URL and token are required.", exception.message)
+  }
+
+  @Test
+  fun `when requireFilled on whitespace token then throws IllegalStateException`() {
+    val credentials = Credentials(baseUrl = "https://example.com", token = "   ")
+
+    val exception =
+      assertFailsWith<IllegalStateException> {
+        credentials.requireFilled()
+      }
+
+    assertEquals("Base URL and token are required.", exception.message)
+  }
+}

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImpl.kt
@@ -4,6 +4,7 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.feature.auth.domain.model.requireFilled
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache
@@ -30,10 +31,7 @@ class MemosRepositoryImpl(
    * Loads memos from the server using stored credentials and paginated API calls.
    */
   override suspend fun listMemos(): List<Memo> {
-    val credentials = credentialsRepository.load()
-    val baseUrl = credentials.baseUrl.trim()
-    val token = credentials.token.trim()
-    check(baseUrl.isNotBlank() && token.isNotBlank()) { "Base URL and token are required." }
+    val (baseUrl, token) = credentialsRepository.load().requireFilled()
     val allMemos = mutableListOf<Memo>()
     val seenTokens = mutableSetOf<String>()
     var nextPageToken: String? = null
@@ -80,10 +78,7 @@ class MemosRepositoryImpl(
     name: String,
     content: String,
   ): Memo {
-    val credentials = credentialsRepository.load()
-    val baseUrl = credentials.baseUrl.trim()
-    val token = credentials.token.trim()
-    check(baseUrl.isNotBlank() && token.isNotBlank()) { "Base URL and token are required." }
+    val (baseUrl, token) = credentialsRepository.load().requireFilled()
     val dto =
       memosApi.updateMemo(
         baseUrl = baseUrl,
@@ -102,10 +97,7 @@ class MemosRepositoryImpl(
    */
   override suspend fun createMemo(content: String): Memo {
     Log.d(TAG, "Creating memo...")
-    val credentials = credentialsRepository.load()
-    val baseUrl = credentials.baseUrl.trim()
-    val token = credentials.token.trim()
-    check(baseUrl.isNotBlank() && token.isNotBlank()) { "Base URL and token are required." }
+    val (baseUrl, token) = credentialsRepository.load().requireFilled()
     val dto =
       memosApi.createMemo(
         baseUrl = baseUrl,
@@ -123,10 +115,7 @@ class MemosRepositoryImpl(
    */
   override suspend fun deleteMemo(name: String) {
     Log.d(TAG, "Deleting memo: $name")
-    val credentials = credentialsRepository.load()
-    val baseUrl = credentials.baseUrl.trim()
-    val token = credentials.token.trim()
-    check(baseUrl.isNotBlank() && token.isNotBlank()) { "Base URL and token are required." }
+    val (baseUrl, token) = credentialsRepository.load().requireFilled()
     memosApi.deleteMemo(
       baseUrl = baseUrl,
       token = token,

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
@@ -7,6 +7,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.feature.auth.domain.model.isFilled
+import space.be1ski.vibits.feature.auth.domain.model.trimmed
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
@@ -60,17 +62,18 @@ class SyncEngineImpl(
 
   private suspend fun performSyncInternal(): SyncResult {
     val credentials = credentialsRepository.load()
-    if (credentials.baseUrl.isBlank() || credentials.token.isBlank()) {
+    if (!credentials.isFilled) {
       Log.w(TAG, "No credentials configured")
       return SyncResult.NoCredentials
     }
+    val (baseUrl, token) = credentials.trimmed()
 
     // Reset any IN_PROGRESS operations from previous crash/kill
     syncQueue.resetInProgressToPending()
 
     return runCatching {
       Log.i(TAG, "Starting sync...")
-      executeSyncFlow(credentials.baseUrl.trim(), credentials.token.trim())
+      executeSyncFlow(baseUrl, token)
     }.getOrElse { e ->
       Log.e(TAG, "Sync failed", e)
       SyncResult.Error(e.message ?: "Sync failed", e)
@@ -137,13 +140,14 @@ class SyncEngineImpl(
 
   private suspend fun forceServerSyncInternal(): SyncResult {
     val credentials = credentialsRepository.load()
-    if (credentials.baseUrl.isBlank() || credentials.token.isBlank()) {
+    if (!credentials.isFilled) {
       return SyncResult.NoCredentials
     }
+    val (baseUrl, token) = credentials.trimmed()
 
     return runCatching {
       Log.i(TAG, "Forcing server sync...")
-      val serverMemos = fetchServerMemos(credentials.baseUrl.trim(), credentials.token.trim())
+      val serverMemos = fetchServerMemos(baseUrl, token)
 
       val pendingOperations = syncQueue.getPendingOperations()
       pendingOperations.forEach { syncQueue.removeOperation(it.id) }
@@ -160,12 +164,10 @@ class SyncEngineImpl(
 
   private suspend fun forceLocalSyncInternal(): SyncResult {
     val credentials = credentialsRepository.load()
-    if (credentials.baseUrl.isBlank() || credentials.token.isBlank()) {
+    if (!credentials.isFilled) {
       return SyncResult.NoCredentials
     }
-
-    val baseUrl = credentials.baseUrl.trim()
-    val token = credentials.token.trim()
+    val (baseUrl, token) = credentials.trimmed()
 
     return runCatching {
       Log.i(TAG, "Forcing local sync...")


### PR DESCRIPTION
## Summary
- Add `isFilled`, `trimmed()`, and `requireFilled()` extension functions to `Credentials` for consistent validation and trimming
- Refactor `MemosRepositoryImpl` and `SyncEngineImpl` to use these utilities instead of duplicating validation logic

## Changes
- **Credentials.kt**: Added three new extension functions for validation and trimming
- **CredentialsTest.kt**: Comprehensive tests for the new utilities (14 test cases)
- **MemosRepositoryImpl.kt**: Refactored to use `requireFilled()` instead of manual validation
- **SyncEngineImpl.kt**: Refactored to use `isFilled` and `trimmed()` instead of manual checks

## Test plan
- [x] All unit tests pass (`./gradlew checkJvm`)
- [x] New tests cover all edge cases for credentials validation