### PR TITLE
Refactor AppModeStore from expect class to interface pattern

### DIFF
--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/di/AppGraph.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/di/AppGraph.kt
@@ -35,6 +35,7 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemoStorageManager
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.feature.mode.data.AppModeRepositoryImpl
 import space.be1ski.vibits.feature.mode.data.platform.AppModeStore
+import space.be1ski.vibits.feature.mode.data.platform.createAppModeStore
 import space.be1ski.vibits.feature.mode.domain.repository.AppModeRepository
 import space.be1ski.vibits.feature.onboarding.data.HabitPresetsDataSource
 import space.be1ski.vibits.feature.onboarding.data.HabitPresetsDataSourceImpl
@@ -110,7 +111,7 @@ abstract class AppGraph {
 
   @Provides
   @SingleIn(AppScope::class)
-  fun appModeStore(): AppModeStore = AppModeStore()
+  fun appModeStore(): AppModeStore = createAppModeStore()
 
   @Provides
   @SingleIn(AppScope::class)

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/test/Fakes.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/test/Fakes.kt
@@ -14,6 +14,8 @@ import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.repository.MemoStorageManager
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
+import space.be1ski.vibits.feature.mode.data.LocalAppMode
+import space.be1ski.vibits.feature.mode.data.platform.AppModeStore
 import space.be1ski.vibits.feature.mode.domain.repository.AppModeRepository
 import space.be1ski.vibits.feature.onboarding.domain.repository.OnboardingStore
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
@@ -177,6 +179,22 @@ class FakeAppModeRepository(
 
   override fun saveMode(mode: AppMode) {
     storedMode = mode
+    saveCalls += 1
+  }
+}
+
+class FakeAppModeStore(
+  initial: LocalAppMode = LocalAppMode(mode = AppMode.NOT_SELECTED),
+) : AppModeStore {
+  var stored: LocalAppMode = initial
+    private set
+  var saveCalls: Int = 0
+    private set
+
+  override fun load(): LocalAppMode = stored
+
+  override fun save(mode: LocalAppMode) {
+    stored = mode
     saveCalls += 1
   }
 }

--- a/feature/mode/data/src/androidMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
+++ b/feature/mode/data/src/androidMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
@@ -6,11 +6,13 @@ import space.be1ski.vibits.core.platform.app.AndroidContextHolder
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.mode.data.LocalAppMode
 
-actual class AppModeStore {
+actual fun createAppModeStore(): AppModeStore = AndroidAppModeStore()
+
+private class AndroidAppModeStore : AppModeStore {
   private val prefsName = "memos_app_mode"
   private val keyMode = "app_mode"
 
-  actual fun load(): LocalAppMode {
+  override fun load(): LocalAppMode {
     if (!AndroidContextHolder.isReady()) {
       return LocalAppMode(mode = AppMode.NOT_SELECTED)
     }
@@ -20,7 +22,7 @@ actual class AppModeStore {
     return LocalAppMode(mode = mode)
   }
 
-  actual fun save(mode: LocalAppMode) {
+  override fun save(mode: LocalAppMode) {
     if (!AndroidContextHolder.isReady()) {
       return
     }

--- a/feature/mode/data/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
+++ b/feature/mode/data/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
@@ -2,8 +2,10 @@ package space.be1ski.vibits.feature.mode.data.platform
 
 import space.be1ski.vibits.feature.mode.data.LocalAppMode
 
-expect class AppModeStore() {
+interface AppModeStore {
   fun load(): LocalAppMode
 
   fun save(mode: LocalAppMode)
 }
+
+expect fun createAppModeStore(): AppModeStore

--- a/feature/mode/data/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/data/AppModeRepositoryImplTest.kt
+++ b/feature/mode/data/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/data/AppModeRepositoryImplTest.kt
@@ -1,0 +1,76 @@
+package space.be1ski.vibits.feature.mode.data
+
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.main.test.FakeAppModeStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class AppModeRepositoryImplTest {
+  @Test
+  fun `when loadMode then returns mode from store`() {
+    val store = FakeAppModeStore(initial = LocalAppMode(mode = AppMode.ONLINE))
+    val repository = AppModeRepositoryImpl(store)
+
+    val result = repository.loadMode()
+
+    assertEquals(AppMode.ONLINE, result)
+  }
+
+  @Test
+  fun `when loadMode with demo mode then returns demo`() {
+    val store = FakeAppModeStore(initial = LocalAppMode(mode = AppMode.DEMO))
+    val repository = AppModeRepositoryImpl(store)
+
+    val result = repository.loadMode()
+
+    assertEquals(AppMode.DEMO, result)
+  }
+
+  @Test
+  fun `when loadMode with offline mode then returns offline`() {
+    val store = FakeAppModeStore(initial = LocalAppMode(mode = AppMode.OFFLINE))
+    val repository = AppModeRepositoryImpl(store)
+
+    val result = repository.loadMode()
+
+    assertEquals(AppMode.OFFLINE, result)
+  }
+
+  @Test
+  fun `when loadMode with not selected then returns not selected`() {
+    val store = FakeAppModeStore(initial = LocalAppMode(mode = AppMode.NOT_SELECTED))
+    val repository = AppModeRepositoryImpl(store)
+
+    val result = repository.loadMode()
+
+    assertEquals(AppMode.NOT_SELECTED, result)
+  }
+
+  @Test
+  fun `when saveMode then persists mode to store`() {
+    val store = FakeAppModeStore()
+    val repository = AppModeRepositoryImpl(store)
+
+    repository.saveMode(AppMode.ONLINE)
+
+    assertEquals(LocalAppMode(mode = AppMode.ONLINE), store.stored)
+    assertEquals(1, store.saveCalls)
+  }
+
+  @Test
+  fun `when saveMode with different modes then persists each correctly`() {
+    val store = FakeAppModeStore()
+    val repository = AppModeRepositoryImpl(store)
+
+    repository.saveMode(AppMode.DEMO)
+    assertEquals(LocalAppMode(mode = AppMode.DEMO), store.stored)
+
+    repository.saveMode(AppMode.OFFLINE)
+    assertEquals(LocalAppMode(mode = AppMode.OFFLINE), store.stored)
+
+    repository.saveMode(AppMode.NOT_SELECTED)
+    assertEquals(LocalAppMode(mode = AppMode.NOT_SELECTED), store.stored)
+
+    assertEquals(3, store.saveCalls)
+  }
+}

--- a/feature/mode/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
+++ b/feature/mode/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
@@ -5,17 +5,19 @@ import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.mode.data.LocalAppMode
 import java.util.prefs.Preferences
 
-actual class AppModeStore {
+actual fun createAppModeStore(): AppModeStore = DesktopAppModeStore()
+
+private class DesktopAppModeStore : AppModeStore {
   private val prefs = Preferences.userRoot().node(DesktopStoragePaths.preferencesNode())
   private val keyMode = "app_mode"
 
-  actual fun load(): LocalAppMode {
+  override fun load(): LocalAppMode {
     val modeName = prefs.get(keyMode, null)
     val mode = modeName?.let { runCatching { AppMode.valueOf(it) }.getOrNull() } ?: AppMode.NOT_SELECTED
     return LocalAppMode(mode = mode)
   }
 
-  actual fun save(mode: LocalAppMode) {
+  override fun save(mode: LocalAppMode) {
     prefs.put(keyMode, mode.mode.name)
   }
 }

--- a/feature/mode/data/src/iosMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
+++ b/feature/mode/data/src/iosMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
@@ -4,17 +4,19 @@ import platform.Foundation.NSUserDefaults
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.mode.data.LocalAppMode
 
-actual class AppModeStore {
+actual fun createAppModeStore(): AppModeStore = IosAppModeStore()
+
+private class IosAppModeStore : AppModeStore {
   private val defaults = NSUserDefaults.standardUserDefaults
   private val keyMode = "app_mode"
 
-  actual fun load(): LocalAppMode {
+  override fun load(): LocalAppMode {
     val modeName = defaults.stringForKey(keyMode)
     val mode = modeName?.let { runCatching { AppMode.valueOf(it) }.getOrNull() } ?: AppMode.NOT_SELECTED
     return LocalAppMode(mode = mode)
   }
 
-  actual fun save(mode: LocalAppMode) {
+  override fun save(mode: LocalAppMode) {
     defaults.setObject(mode.mode.name, forKey = keyMode)
   }
 }

--- a/feature/mode/data/src/wasmJsMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
+++ b/feature/mode/data/src/wasmJsMain/kotlin/space/be1ski/vibits/feature/mode/data/platform/AppModeStore.kt
@@ -6,14 +6,16 @@ import space.be1ski.vibits.feature.mode.data.LocalAppMode
 
 private const val KEY_APP_MODE = "vibits_app_mode"
 
-actual class AppModeStore {
-  actual fun load(): LocalAppMode {
+actual fun createAppModeStore(): AppModeStore = WasmAppModeStore()
+
+private class WasmAppModeStore : AppModeStore {
+  override fun load(): LocalAppMode {
     val modeName = localStorage.getItem(KEY_APP_MODE)
     val mode = modeName?.let { runCatching { AppMode.valueOf(it) }.getOrNull() } ?: AppMode.NOT_SELECTED
     return LocalAppMode(mode = mode)
   }
 
-  actual fun save(mode: LocalAppMode) {
+  override fun save(mode: LocalAppMode) {
     localStorage.setItem(KEY_APP_MODE, mode.mode.name)
   }
 }


### PR DESCRIPTION
## Summary

Converts `AppModeStore` from an expect/actual class pattern to an interface + factory function pattern, enabling unit testing of `AppModeRepositoryImpl`.

## Changes

- Convert `AppModeStore` from expect class to interface in commonMain
- Add `expect fun createAppModeStore()` factory function
- Update platform implementations (Android, Desktop, iOS, WASM) to implement interface
- Add `FakeAppModeStore` to test utilities
- Add `AppModeRepositoryImplTest` with 6 test cases

## Test plan

- [x] All existing tests pass (`./gradlew checkJvm`)
- [x] New `AppModeRepositoryImplTest` covers all load/save scenarios
- [x] Desktop app builds and runs correctly

🤖 Generated with [Claude Code](https://claude.com/code)