### PR TITLE
Remove unnecessary @Suppress annotations from Settings reducers

### DIFF
--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsResetReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsResetReducer.kt
@@ -6,7 +6,6 @@ import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
 
-@Suppress("LongMethod")
 internal val resetReducer: Reducer<SettingsAction.Reset, SettingsState, SettingsEffect.Command, SettingsEffect.Notification> =
   reducer { action, state ->
     when (action) {

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
@@ -7,7 +7,6 @@ import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
 
-@Suppress("LongMethod")
 internal val saveAndLogsReducer: Reducer<SettingsAction.SaveAndLogs, SettingsState, SettingsEffect.Command, SettingsEffect.Notification> =
   reducer { action, state ->
     when (action) {


### PR DESCRIPTION
## Summary

Remove unnecessary `@Suppress("LongMethod")` annotations from two Settings reducers that are well under the detekt threshold.

## Changes

- `SettingsResetReducer.kt` - 36 lines (threshold: 60)
- `SettingsSaveAndLogsReducer.kt` - 45 lines (threshold: 60)

## Test plan

- [x] `./gradlew :feature:settings:presentation:detekt` passes without suppressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)