### PR TITLE
Remove unused coroutine scope from SwipeablePagerContent

### DIFF
--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -9,7 +9,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
@@ -137,9 +136,6 @@ private fun SwipeablePagerContent(
       initialPage = initialPage,
       pageCount = { pageCount },
     )
-
-  @Suppress("UNUSED_VARIABLE")
-  val scope = rememberCoroutineScope()
 
   LaunchedEffect(currentDelta, minDelta) {
     val targetPage = (currentDelta - minDelta).coerceIn(0, pageCount - 1)

--- a/feature/mode/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/ModeUseCasesTest.kt
+++ b/feature/mode/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/ModeUseCasesTest.kt
@@ -5,6 +5,7 @@ import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.usecase.LoadCredentialsUseCase
 import space.be1ski.vibits.feature.main.test.FakeAppModeRepository
 import space.be1ski.vibits.feature.main.test.FakeCredentialsRepository
+import space.be1ski.vibits.feature.main.test.FakeMemoStorageManager
 import space.be1ski.vibits.feature.main.test.FakeOnboardingStore
 import space.be1ski.vibits.feature.main.test.FakePreferencesRepository
 import kotlin.test.Test
@@ -236,5 +237,44 @@ class FixInvalidOnlineModeUseCaseTest {
     assertEquals(AppMode.NOT_SELECTED, result)
     assertEquals(AppMode.NOT_SELECTED, repository.storedMode)
     assertEquals(1, repository.saveCalls)
+  }
+}
+
+class ResetAppWithMemosUseCaseTest {
+  private fun createUseCase(
+    appModeRepository: FakeAppModeRepository = FakeAppModeRepository(initial = AppMode.ONLINE),
+    credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
+    preferencesRepository: FakePreferencesRepository = FakePreferencesRepository(),
+    onboardingStore: FakeOnboardingStore = FakeOnboardingStore(),
+    memoStorageManager: FakeMemoStorageManager = FakeMemoStorageManager(),
+  ): Pair<ResetAppWithMemosUseCase, FakeMemoStorageManager> {
+    val resetAppUseCase =
+      ResetAppUseCase(
+        appModeRepository,
+        credentialsRepository,
+        preferencesRepository,
+        onboardingStore,
+      )
+    val useCase = ResetAppWithMemosUseCase(resetAppUseCase, memoStorageManager)
+    return useCase to memoStorageManager
+  }
+
+  @Test
+  fun `when invoke then calls resetApp`() {
+    val appModeRepository = FakeAppModeRepository(initial = AppMode.ONLINE)
+    val (useCase, _) = createUseCase(appModeRepository = appModeRepository)
+
+    useCase()
+
+    assertEquals(AppMode.NOT_SELECTED, appModeRepository.storedMode)
+  }
+
+  @Test
+  fun `when invoke then clears all memos`() {
+    val (useCase, memoStorageManager) = createUseCase()
+
+    useCase()
+
+    assertEquals(1, memoStorageManager.clearAllCalls)
   }
 }


### PR DESCRIPTION
## Summary

Remove unused `rememberCoroutineScope()` and its `@Suppress("UNUSED_VARIABLE")` annotation from `SwipeablePagerContent`.

## Changes

- Removed unused `scope` variable declaration with its suppression annotation
- Removed unused `rememberCoroutineScope` import

## Test plan

- [x] Verified `./gradlew checkJvm` passes
- [x] Compilation successful