### PR TITLE
Remove duplicate quarterIndex functions from presentation layer

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridModels.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridModels.kt
@@ -1,17 +1,3 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
-import kotlinx.datetime.LocalDate
-import kotlinx.datetime.Month
 
 internal const val QUARTER_START_DAY_LIMIT = 7
-internal const val MONTHS_IN_QUARTER = 3
-internal const val FIRST_QUARTER_INDEX = 1
-
-/**
- * Returns the quarter index (1-4) for a given date.
- */
-fun quarterIndex(date: LocalDate): Int = date.month.ordinal / MONTHS_IN_QUARTER + FIRST_QUARTER_INDEX
-
-/**
- * Returns the quarter index (1-4) for a given month.
- */
-internal fun quarterIndex(month: Month): Int = month.ordinal / MONTHS_IN_QUARTER + FIRST_QUARTER_INDEX

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -1,9 +1,11 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
+
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
+import space.be1ski.vibits.feature.habits.domain.usecase.quarterIndex
 
 internal fun buildTimelineLabels(
   weeks: List<ActivityWeek>,

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -23,12 +23,12 @@ import space.be1ski.vibits.feature.habits.domain.parseConfigFromContent
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityRangeDeltaUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.NavigateActivityRangeUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.usecase.startOfWeek
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.view.StatsScreen
 import space.be1ski.vibits.feature.habits.presentation.view.StatsScreenState
-import space.be1ski.vibits.feature.habits.presentation.view.components.quarterIndex
 import space.be1ski.vibits.feature.main.domain.model.AppState
 import space.be1ski.vibits.feature.main.domain.model.Screen
 import space.be1ski.vibits.feature.main.presentation.action.AppAction


### PR DESCRIPTION
## Summary

Removes code duplication by eliminating duplicate `quarterIndex` functions from the presentation layer that were already defined in the domain layer.

## Changes

- **ContributionGridModels.kt**: Removed duplicate `quarterIndex(LocalDate)` and `quarterIndex(Month)` functions plus their constants (`MONTHS_IN_QUARTER`, `FIRST_QUARTER_INDEX`)
- **ContributionGridTimeline.kt**: Updated import to use `quarterIndex` from domain layer
- **SwipeableContent.kt**: Updated import to use `quarterIndex` from domain layer

## Before/After

**Before:** Two identical `quarterIndex` implementations:
- `feature/habits/domain/.../DateUtils.kt`
- `feature/habits/presentation/.../ContributionGridModels.kt`

**After:** Single implementation in domain layer, presentation layer imports it.

## Test plan

- [x] All tests pass (`./gradlew checkJvm`)
- [x] Build successful