### PR TITLE
Remove unnecessary LongMethod suppressions from reducers

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsConfigReducer.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsConfigReducer.kt
@@ -13,7 +13,6 @@ import kotlin.random.Random
 /**
  * Sub-reducer for config dialog management.
  */
-@Suppress("LongMethod")
 internal val configReducer: Reducer<HabitsAction.Config, HabitsState, HabitsEffect, Nothing> =
   reducer { action, state ->
     when (action) {

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/reducer/MemosLoadingReducer.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/reducer/MemosLoadingReducer.kt
@@ -7,7 +7,6 @@ import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import space.be1ski.vibits.feature.memos.presentation.effect.MemosEffect
 import space.be1ski.vibits.feature.memos.presentation.state.MemosState
 
-@Suppress("LongMethod")
 internal val loadingReducer: Reducer<MemosAction.Loading, MemosState, MemosEffect, Nothing> =
   reducer { action, state ->
     when (action) {


### PR DESCRIPTION
## Summary
Removes `@Suppress("LongMethod")` annotations from reducers that don't actually need them.

## Changes
- Removed suppression from `MemosLoadingReducer.kt`
- Removed suppression from `HabitsConfigReducer.kt`

Both files pass detekt without the suppressions - they were added preemptively but the method lengths are within acceptable limits.

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] Detekt runs without errors on affected modules

Generated with [Claude Code](https://claude.com/claude-code)