### PR TITLE
Remove unnecessary @Suppress from HabitsEditorReducer

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
@@ -17,7 +17,6 @@ import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 /**
  * Sub-reducer for editor lifecycle and interactions.
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod")
 internal val editorReducer: Reducer<HabitsAction.Editor, HabitsState, HabitsEffect, Nothing> =
   reducer { action, state ->
     when (action) {


### PR DESCRIPTION
## Summary
- Remove unnecessary `@Suppress("LongMethod", "CyclomaticComplexMethod")` from HabitsEditorReducer

## Changes
- The reducer passes detekt's default thresholds without suppressions
- Follows the same cleanup pattern as PR #168 and PR #157

## Test plan
- [x] detekt passes without suppressions
- [x] Tests pass