### PR TITLE
Remove unnecessary @Suppress from HabitsEditorReducer

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
@@ -17,7 +17,6 @@ import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 /**
  * Sub-reducer for editor lifecycle and interactions.
  */
-@Suppress("LongMethod", "CyclomaticComplexMethod")
 internal val editorReducer: Reducer<HabitsAction.Editor, HabitsState, HabitsEffect, Nothing> =
   reducer { action, state ->
     when (action) {


### PR DESCRIPTION
## Summary
- Removed `@Suppress("LongMethod", "CyclomaticComplexMethod")` annotation that was no longer needed

## Changes
- Deleted suppression from `HabitsEditorReducer.kt`
- Detekt passes without the annotation

## Test plan
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)