### PR TITLE
Consolidate HABITS_HASHTAG constant to PostTags

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CountDailyPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CountDailyPostsUseCase.kt
@@ -4,8 +4,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-
-private const val HABITS_HASHTAG = "#habits"
+import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
 /**
  * Counts daily posts within a date range.
@@ -19,7 +18,7 @@ object CountDailyPostsUseCase {
   ): Map<LocalDate, Int> {
     val counts = mutableMapOf<LocalDate, Int>()
     memos.forEach { memo ->
-      if (memo.content.contains(HABITS_HASHTAG)) {
+      if (memo.content.contains(PostTags.HABITS_HASHTAG)) {
         return@forEach
       }
       val date = parseMemoDate(memo, timeZone) ?: return@forEach

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/FilterPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/FilterPostsUseCase.kt
@@ -1,13 +1,12 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-
-private const val HABITS_HASHTAG = "#habits"
+import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
 /**
  * Filters out habit tracking memos from a list.
  * Returns only regular posts (memos without #habits hashtag).
  */
 object FilterPostsUseCase {
-  operator fun invoke(memos: List<Memo>): List<Memo> = memos.filter { !it.content.contains(HABITS_HASHTAG) }
+  operator fun invoke(memos: List<Memo>): List<Memo> = memos.filter { !it.content.contains(PostTags.HABITS_HASHTAG) }
 }

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTags.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTags.kt
@@ -12,4 +12,7 @@ object PostTags {
   // Tag prefixes used for parsing and normalization
   const val HABITS_PREFIX = "#habits/"
   const val HABIT_PREFIX = "#habit/"
+
+  // Base hashtag for filtering all habits-related content
+  const val HABITS_HASHTAG = "#habits"
 }


### PR DESCRIPTION
## Summary
- Move duplicate `HABITS_HASHTAG` constant from `FilterPostsUseCase.kt` and `CountDailyPostsUseCase.kt` to centralized `PostTags` object

## Changes
- Add `HABITS_HASHTAG = "#habits"` to `PostTags.kt`
- Update `FilterPostsUseCase` to import from `PostTags`
- Update `CountDailyPostsUseCase` to import from `PostTags`

## Test plan
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)