### PR TITLE
Extract normalizeBaseUrl extension in MemosApi

### DIFF
--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
@@ -23,6 +23,8 @@ import space.be1ski.vibits.feature.memos.data.remote.dto.UpdateMemoRequestDto
 
 private const val TAG = "MemosApi"
 
+private fun String.normalizeBaseUrl(): String = trim().trimEnd('/')
+
 @Inject
 @SingleIn(AppScope::class)
 @Suppress("TooGenericExceptionCaught")
@@ -35,8 +37,7 @@ class MemosApi(
     pageSize: Int,
     pageToken: String?,
   ): ListMemosResponseDto {
-    val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
-    val fullUrl = "$normalizedBaseUrl/api/v1/memos"
+    val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/memos"
     Log.i(TAG, "GET $fullUrl")
     return try {
       val response: ListMemosResponseDto =
@@ -63,8 +64,7 @@ class MemosApi(
     name: String,
     content: String,
   ): MemoDto {
-    val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
-    val fullUrl = "$normalizedBaseUrl/api/v1/$name"
+    val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/$name"
     Log.i(TAG, "PATCH $fullUrl")
     return try {
       val response: MemoDto =
@@ -88,8 +88,7 @@ class MemosApi(
     token: String,
     content: String,
   ): MemoDto {
-    val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
-    val fullUrl = "$normalizedBaseUrl/api/v1/memos"
+    val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/memos"
     Log.i(TAG, "POST $fullUrl")
     return try {
       val response: MemoDto =
@@ -112,8 +111,7 @@ class MemosApi(
     token: String,
     name: String,
   ) {
-    val normalizedBaseUrl = baseUrl.trim().trimEnd('/')
-    val fullUrl = "$normalizedBaseUrl/api/v1/$name"
+    val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/$name"
     Log.i(TAG, "DELETE $fullUrl")
     try {
       httpClient.delete(fullUrl) {


### PR DESCRIPTION
## Summary
- Extract duplicate `baseUrl.trim().trimEnd('/')` pattern to reusable `normalizeBaseUrl()` extension function

## Changes
- Add `private fun String.normalizeBaseUrl()` extension function
- Replace 4 duplicate normalization calls with the new extension

## Test plan
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)