### PR TITLE
Consolidate date constants to core/platform

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.core.platform.date
+
+const val DAYS_IN_WEEK = 7
+const val MONTHS_IN_QUARTER = 3
+const val MONTHS_IN_YEAR = 12
+const val QUARTERS_IN_YEAR = 4
+const val FIRST_DAY_OF_MONTH = 1

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -5,6 +5,7 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
@@ -13,8 +14,6 @@ import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
 import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-
-private const val DAYS_IN_WEEK = 7
 
 /**
  * Use case for building activity data.

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
@@ -1,10 +1,9 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-
-private const val DAYS_IN_WEEK = 7
-private const val QUARTERS_IN_YEAR = 4
-private const val MONTHS_IN_YEAR = 12
 
 /**
  * Calculates the number of periods between two activity ranges.

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateUtils.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateUtils.kt
@@ -5,8 +5,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
 
-private const val MONTHS_IN_QUARTER = 3
 private const val FIRST_QUARTER_INDEX = 1
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -5,11 +5,10 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-
-private const val DAYS_IN_WEEK = 7
-private const val MONTHS_PER_QUARTER = 3
 
 /**
  * Returns posts (non-habit memos) for a given activity range.
@@ -42,9 +41,9 @@ class GetPeriodPostsUseCase {
         start to end
       }
       is ActivityRange.Quarter -> {
-        val startMonth = (range.index - 1) * MONTHS_PER_QUARTER + 1
+        val startMonth = (range.index - 1) * MONTHS_IN_QUARTER + 1
         val start = LocalDate(range.year, startMonth, 1)
-        val end = start.plus(DatePeriod(months = MONTHS_PER_QUARTER)).plus(DatePeriod(days = -1))
+        val end = start.plus(DatePeriod(months = MONTHS_IN_QUARTER)).plus(DatePeriod(days = -1))
         start to end
       }
       is ActivityRange.Year -> {

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -5,13 +5,13 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 
-private const val WEEK_END_OFFSET = 6
-private const val MONTHS_IN_QUARTER = 3
 private const val FIRST_QUARTER_INDEX = 1
-private const val QUARTERS_IN_YEAR = 4
 private const val YEAR_START_DAY = 1
 
 /**
@@ -23,7 +23,7 @@ object GetRangeBoundsUseCase {
       is ActivityRange.Week ->
         RangeBounds(
           start = range.startDate,
-          end = range.startDate.plus(DatePeriod(days = WEEK_END_OFFSET)),
+          end = range.startDate.plus(DatePeriod(days = DAYS_IN_WEEK - 1)),
         )
       is ActivityRange.Month ->
         RangeBounds(

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
@@ -3,10 +3,9 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-
-private const val DAYS_IN_WEEK = 7
-private const val QUARTERS_IN_YEAR = 4
 
 /**
  * Shifts an activity range by delta units (positive = forward, negative = backward).

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -38,6 +38,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_configure_habits
 import space.be1ski.vibits.core.strings.generated.action_hide_memos
@@ -217,7 +218,6 @@ private fun StatsInfoCardLayout(
 
 private val INFO_CARD_MIN_HEIGHT = 40.dp
 
-private const val DAYS_IN_WEEK = 7
 private const val TIME_BLOCKS = 4
 private const val HOURS_PER_BLOCK = 6
 private const val INTENSITY_BASE = 0.3f

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -47,6 +47,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.day_fri
 import space.be1ski.vibits.core.strings.generated.day_mon
@@ -331,7 +332,6 @@ private fun CalendarWeekdayHeader(
   }
 }
 
-private const val DAYS_IN_WEEK = 7
 private const val WEEKEND_LABEL_ALPHA = 0.6f
 private const val WEEKEND_CELL_ALPHA = 0.15f
 

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/model/TimeConstants.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/model/TimeConstants.kt
@@ -1,6 +1,0 @@
-package space.be1ski.vibits.feature.main.domain.model
-
-internal const val FIRST_DAY_OF_MONTH = 1
-internal const val DAYS_IN_WEEK = 7
-internal const val MONTHS_PER_QUARTER = 3
-internal const val MONTHS_IN_YEAR = 12

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
@@ -5,11 +5,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.main.domain.model.DAYS_IN_WEEK
-import space.be1ski.vibits.feature.main.domain.model.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.feature.main.domain.model.MONTHS_IN_YEAR
-import space.be1ski.vibits.feature.main.domain.model.MONTHS_PER_QUARTER
 
 /**
  * Returns the last day of the given activity range.
@@ -23,7 +23,7 @@ object GetActivityRangeEndDateUseCase {
         nextMonth.minus(DatePeriod(days = 1))
       }
       is ActivityRange.Quarter -> {
-        val lastMonthOfQuarter = range.index * MONTHS_PER_QUARTER
+        val lastMonthOfQuarter = range.index * MONTHS_IN_QUARTER
         val firstOfNextQuarter =
           if (lastMonthOfQuarter == MONTHS_IN_YEAR) {
             LocalDate(range.year + 1, Month.JANUARY, FIRST_DAY_OF_MONTH)

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
+import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.main.domain.model.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.feature.main.domain.model.MONTHS_PER_QUARTER
 
 /**
  * Returns the first day of the given activity range.
@@ -15,7 +15,7 @@ object GetActivityRangeStartDateUseCase {
       is ActivityRange.Week -> range.startDate
       is ActivityRange.Month -> LocalDate(range.year, range.month, FIRST_DAY_OF_MONTH)
       is ActivityRange.Quarter -> {
-        val month = Month((range.index - 1) * MONTHS_PER_QUARTER + 1)
+        val month = Month((range.index - 1) * MONTHS_IN_QUARTER + 1)
         LocalDate(range.year, month, FIRST_DAY_OF_MONTH)
       }
       is ActivityRange.Year -> LocalDate(range.year, Month.JANUARY, FIRST_DAY_OF_MONTH)

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_next
@@ -40,8 +41,6 @@ import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.main.domain.model.SuccessRateLevel
 import space.be1ski.vibits.feature.main.domain.usecase.GetSuccessRateLevelUseCase
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
-
-private const val WEEK_END_OFFSET = 6
 
 @Composable
 internal fun TimeRangeControls(
@@ -133,7 +132,7 @@ internal fun formatRangeLabel(
 ): String =
   when (range) {
     is ActivityRange.Week -> {
-      val endDate = range.startDate.plus(DatePeriod(days = WEEK_END_OFFSET))
+      val endDate = range.startDate.plus(DatePeriod(days = DAYS_IN_WEEK - 1))
       val currentYear = currentLocalDate().year
       formatter.weekRange(range.startDate, endDate, currentYear)
     }


### PR DESCRIPTION
## Summary

- Created centralized `DateConstants.kt` in `core/platform/date` to eliminate duplicate private constants
- Deleted obsolete `TimeConstants.kt` from main module
- Updated 12 files across habits/domain, habits/presentation, and main modules to use centralized constants

## Changes

**Added:**
- `core/platform/src/commonMain/kotlin/.../date/DateConstants.kt` with `DAYS_IN_WEEK`, `MONTHS_IN_QUARTER`, `MONTHS_IN_YEAR`, `QUARTERS_IN_YEAR`, `FIRST_DAY_OF_MONTH`

**Deleted:**
- `feature/main/src/commonMain/kotlin/.../TimeConstants.kt` (replaced by centralized version)

**Updated:**
- habits/domain use cases: `BuildActivityDataUseCase`, `CalculateActivityRangeDeltaUseCase`, `DateUtils`, `GetPeriodPostsUseCase`, `GetRangeBoundsUseCase`, `NavigateActivityRangeUseCase`
- habits/presentation views: `StatsScreenContent`, `ContributionGrid`
- main module: `GetActivityRangeEndDateUseCase`, `GetActivityRangeStartDateUseCase`, `TimeRangeControls`

## Test plan

- [x] All existing tests pass
- [x] `./gradlew checkJvm` passes