### PR TITLE
Consolidate more date constants to DateConstants

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
@@ -5,3 +5,4 @@ const val MONTHS_IN_QUARTER = 3
 const val MONTHS_IN_YEAR = 12
 const val QUARTERS_IN_YEAR = 4
 const val FIRST_DAY_OF_MONTH = 1
+const val FIRST_QUARTER_INDEX = 1

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
@@ -1,8 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
 import kotlinx.datetime.LocalDate
-
-private const val LAST_SEVEN_DAYS = 7
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 
 /**
  * Fully prepared dataset for activity charts.
@@ -21,7 +20,7 @@ data class ActivityWeekData(
  */
 fun ActivityWeekData.lastSevenDays(): List<ContributionDay> {
   val days = weeks.flatMap { it.days }.filter { it.inRange }
-  return days.takeLast(LAST_SEVEN_DAYS)
+  return days.takeLast(DAYS_IN_WEEK)
 }
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateUtils.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateUtils.kt
@@ -5,9 +5,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
+import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
 import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-
-private const val FIRST_QUARTER_INDEX = 1
 
 /**
  * Returns the Monday of the week containing [date].

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -6,13 +6,12 @@ import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
 import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
 import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
-
-private const val FIRST_QUARTER_INDEX = 1
-private const val YEAR_START_DAY = 1
 
 /**
  * Calculates date bounds for an activity range.
@@ -45,9 +44,9 @@ object GetRangeBoundsUseCase {
       }
       is ActivityRange.Year ->
         RangeBounds(
-          start = LocalDate(range.year, Month.JANUARY, YEAR_START_DAY),
+          start = LocalDate(range.year, Month.JANUARY, FIRST_DAY_OF_MONTH),
           end =
-            LocalDate(range.year + 1, Month.JANUARY, YEAR_START_DAY)
+            LocalDate(range.year + 1, Month.JANUARY, FIRST_DAY_OF_MONTH)
               .minus(DatePeriod(days = 1)),
         )
     }


### PR DESCRIPTION
## Summary
- Continue consolidation of date-related constants to centralized `DateConstants.kt`

## Changes
- Add `FIRST_QUARTER_INDEX` to `core/platform/date/DateConstants.kt`
- Remove duplicate `FIRST_QUARTER_INDEX` from `DateUtils.kt` and `GetRangeBoundsUseCase.kt`
- Replace `YEAR_START_DAY` with existing `FIRST_DAY_OF_MONTH` in `GetRangeBoundsUseCase.kt`
- Replace `LAST_SEVEN_DAYS` with existing `DAYS_IN_WEEK` in `ActivityWeekData.kt`

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)