### PR TITLE
Consolidate duplicate parseInstant to shared utility

### DIFF
--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/InstantParser.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/InstantParser.kt
@@ -1,0 +1,31 @@
+package space.be1ski.vibits.feature.memos.data.mapper
+
+import kotlin.time.Instant
+
+private const val EPOCH_SECONDS_LENGTH = 10
+private const val MILLIS_IN_SECOND = 1000L
+
+/**
+ * Parses a timestamp string into an [Instant].
+ *
+ * Supports the following formats:
+ * - ISO 8601 format (e.g., "2023-01-15T10:30:00Z")
+ * - ISO 8601 without timezone (adds "Z" suffix)
+ * - Numeric timestamps (seconds or milliseconds since epoch)
+ *
+ * @param value The timestamp string to parse
+ * @return The parsed [Instant], or null if parsing fails
+ */
+fun parseInstant(value: String?): Instant? {
+  if (value.isNullOrBlank()) {
+    return null
+  }
+  val trimmed = value.trim()
+  return runCatching { Instant.parse(trimmed) }.getOrNull()
+    ?: runCatching { Instant.parse("${trimmed}Z") }.getOrNull()
+    ?: runCatching {
+      val number = trimmed.toLong()
+      val millis = if (trimmed.length > EPOCH_SECONDS_LENGTH) number else number * MILLIS_IN_SECOND
+      Instant.fromEpochMilliseconds(millis)
+    }.getOrNull()
+}

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
@@ -5,7 +5,6 @@ import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-import kotlin.time.Instant
 
 /**
  * Maps network memo DTOs into domain models.
@@ -13,11 +12,6 @@ import kotlin.time.Instant
 @Inject
 @SingleIn(AppScope::class)
 class MemoMapper {
-  private companion object {
-    const val EPOCH_SECONDS_LENGTH = 10
-    const val MILLIS_IN_SECOND = 1000L
-  }
-
   /**
    * Converts a [MemoDto] into a domain [Memo].
    */
@@ -33,18 +27,4 @@ class MemoMapper {
    * Converts a list of [MemoDto] into domain [Memo] models.
    */
   fun toDomainList(dtos: List<MemoDto>): List<Memo> = dtos.map(::toDomain)
-
-  private fun parseInstant(value: String?): Instant? {
-    if (value.isNullOrBlank()) {
-      return null
-    }
-    val trimmed = value.trim()
-    return runCatching { Instant.parse(trimmed) }.getOrNull()
-      ?: runCatching { Instant.parse("${trimmed}Z") }.getOrNull()
-      ?: runCatching {
-        val number = trimmed.toLong()
-        val millis = if (trimmed.length > EPOCH_SECONDS_LENGTH) number else number * MILLIS_IN_SECOND
-        Instant.fromEpochMilliseconds(millis)
-      }.getOrNull()
-  }
 }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemosRepository.kt
@@ -3,11 +3,11 @@ package space.be1ski.vibits.feature.memos.data.offline
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.feature.memos.data.mapper.parseInstant
 import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 import kotlin.time.Clock
-import kotlin.time.Instant
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
@@ -88,11 +88,4 @@ class OfflineMemosRepository(
       createTime = parseInstant(dto.createTime),
       updateTime = parseInstant(dto.updateTime),
     )
-
-  private fun parseInstant(value: String?): Instant? {
-    if (value.isNullOrBlank()) {
-      return null
-    }
-    return runCatching { Instant.parse(value.trim()) }.getOrNull()
-  }
 }

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/mapper/InstantParserTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/mapper/InstantParserTest.kt
@@ -1,0 +1,60 @@
+package space.be1ski.vibits.feature.memos.data.mapper
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.time.Instant
+
+class InstantParserTest {
+  @Test
+  fun `when null then returns null`() {
+    assertNull(parseInstant(null))
+  }
+
+  @Test
+  fun `when blank then returns null`() {
+    assertNull(parseInstant(""))
+    assertNull(parseInstant("   "))
+  }
+
+  @Test
+  fun `when ISO timestamp then parses correctly`() {
+    val result = parseInstant("2024-01-02T03:04:05Z")
+
+    assertEquals(Instant.parse("2024-01-02T03:04:05Z"), result)
+  }
+
+  @Test
+  fun `when ISO timestamp with whitespace then trims and parses`() {
+    val result = parseInstant("  2024-01-02T03:04:05Z  ")
+
+    assertEquals(Instant.parse("2024-01-02T03:04:05Z"), result)
+  }
+
+  @Test
+  fun `when ISO timestamp without zone then adds UTC`() {
+    val result = parseInstant("2024-01-02T03:04:05")
+
+    assertEquals(Instant.parse("2024-01-02T03:04:05Z"), result)
+  }
+
+  @Test
+  fun `when epoch seconds then converts to millis`() {
+    val result = parseInstant("1700000000")
+
+    assertEquals(Instant.fromEpochMilliseconds(1_700_000_000_000), result)
+  }
+
+  @Test
+  fun `when epoch millis then keeps as millis`() {
+    val result = parseInstant("1700000000000")
+
+    assertEquals(Instant.fromEpochMilliseconds(1_700_000_000_000), result)
+  }
+
+  @Test
+  fun `when invalid format then returns null`() {
+    assertNull(parseInstant("not-a-date"))
+    assertNull(parseInstant("abc123"))
+  }
+}


### PR DESCRIPTION
## Summary
- Extract duplicate `parseInstant` function from `MemoMapper` and `OfflineMemosRepository` into a shared top-level function in `InstantParser.kt`
- The `MemoMapper` version was more robust (handling ISO format, ISO without timezone, and numeric timestamps)
- `OfflineMemosRepository` now benefits from the more complete implementation

## Changes
- Added `InstantParser.kt` with the consolidated `parseInstant()` function
- Updated `MemoMapper.kt` to use the shared utility
- Updated `OfflineMemosRepository.kt` to use the shared utility (removed simpler local implementation)
- Added `InstantParserTest.kt` with comprehensive tests for the utility

## Test plan
- [x] All existing tests pass
- [x] New tests added for the extracted utility function
- [x] `./gradlew checkJvm` passes