### PR TITLE
Add PostTags extension functions for common checks

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitParser.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitParser.kt
@@ -4,6 +4,9 @@ import space.be1ski.vibits.core.ui.theme.DefaultHabitColor
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isConfigMemo
+import space.be1ski.vibits.feature.memos.domain.model.isConfigTag
+import space.be1ski.vibits.feature.memos.domain.model.stripHabitPrefixes
 
 /** Regex for matching whitespace sequences (for tag normalization). */
 private val WHITESPACE_REGEX = Regex("\\s+")
@@ -83,7 +86,7 @@ fun formatHexColor(color: Long): String {
  */
 fun normalizeHabitTag(raw: String): String {
   val trimmed = raw.trim()
-  val withoutPrefix = trimmed.removePrefix(PostTags.HABITS_PREFIX).removePrefix(PostTags.HABIT_PREFIX)
+  val withoutPrefix = trimmed.stripHabitPrefixes()
   val sanitized = withoutPrefix.replace(WHITESPACE_REGEX, "_")
   return "${PostTags.HABITS_PREFIX}$sanitized"
 }
@@ -91,7 +94,7 @@ fun normalizeHabitTag(raw: String): String {
 /**
  * Extracts a human-readable label from a habit tag.
  */
-fun labelFromTag(tag: String): String = tag.removePrefix(PostTags.HABITS_PREFIX).removePrefix(PostTags.HABIT_PREFIX).replace('_', ' ')
+fun labelFromTag(tag: String): String = tag.stripHabitPrefixes().replace('_', ' ')
 
 /**
  * Builds habit statuses for a day given the memo content and habit configurations.
@@ -164,14 +167,14 @@ fun extractHabitTagsFromContent(content: String?): Set<String> {
  * Returns the list of habits defined in the memo, or empty list if not a config memo.
  */
 fun parseConfigFromContent(content: String): List<HabitConfig> {
-  if (!content.contains(PostTags.HABITS_CONFIG) && !content.contains(PostTags.HABITS_CONFIG_ALT)) {
+  if (!content.isConfigMemo()) {
     return emptyList()
   }
   return content
     .lineSequence()
     .map { it.trim() }
     .filter { it.isNotBlank() }
-    .filterNot { it.startsWith(PostTags.HABITS_CONFIG) || it.startsWith(PostTags.HABITS_CONFIG_ALT) }
+    .filterNot { it.isConfigTag() }
     .mapNotNull { line -> parseHabitConfigLine(line) }
     .distinctBy { it.tag }
     .toList()

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isDailyMemo
 
 /**
  * Extracts daily memos from a list of memos.
@@ -17,7 +17,7 @@ object ExtractDailyMemosUseCase {
   ): Map<LocalDate, DailyMemoInfo> {
     val dailyMemos =
       memos.filter { memo ->
-        memo.content.contains(PostTags.HABITS_DAILY) || memo.content.contains(PostTags.DAILY)
+        memo.content.isDailyMemo()
       }
     return dailyMemos
       .mapNotNull { memo ->

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractHabitsConfigUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractHabitsConfigUseCase.kt
@@ -6,7 +6,8 @@ import kotlinx.datetime.toLocalDateTime
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.habits.domain.parseHabitConfigLine
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isConfigMemo
+import space.be1ski.vibits.feature.memos.domain.model.isConfigTag
 
 /**
  * Extracts habits configuration entries from memos.
@@ -19,9 +20,7 @@ object ExtractHabitsConfigUseCase {
   ): List<HabitsConfigEntry> {
     val entries =
       memos.mapNotNull { memo ->
-        if (!memo.content.contains(PostTags.HABITS_CONFIG) &&
-          !memo.content.contains(PostTags.HABITS_CONFIG_ALT)
-        ) {
+        if (!memo.content.isConfigMemo()) {
           return@mapNotNull null
         }
         // Use createTime for config memos to keep date stable when content is edited
@@ -32,7 +31,7 @@ object ExtractHabitsConfigUseCase {
             .lineSequence()
             .map { it.trim() }
             .filter { it.isNotBlank() }
-            .filterNot { it.startsWith(PostTags.HABITS_CONFIG) || it.startsWith(PostTags.HABITS_CONFIG_ALT) }
+            .filterNot { it.isConfigTag() }
         val habits =
           lines
             .mapNotNull { line -> parseHabitConfigLine(line) }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/MemoParsingUtils.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/MemoParsingUtils.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isDailyMemo
 import kotlin.time.Instant as KtInstant
 
 private val DATE_REGEX = Regex("\\b(\\d{4}-\\d{2}-\\d{2})\\b")
@@ -15,7 +15,7 @@ private val DATE_REGEX = Regex("\\b(\\d{4}-\\d{2}-\\d{2})\\b")
  */
 fun parseDailyDateFromContent(content: String): LocalDate? {
   val match =
-    if (content.contains(PostTags.HABITS_DAILY) || content.contains(PostTags.DAILY)) {
+    if (content.isDailyMemo()) {
       DATE_REGEX.find(content)
     } else {
       null

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTags.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTags.kt
@@ -16,3 +16,23 @@ object PostTags {
   // Base hashtag for filtering all habits-related content
   const val HABITS_HASHTAG = "#habits"
 }
+
+/**
+ * Checks if this string represents a config memo by detecting config tags in content.
+ */
+fun String.isConfigMemo(): Boolean = contains(PostTags.HABITS_CONFIG) || contains(PostTags.HABITS_CONFIG_ALT)
+
+/**
+ * Checks if this string represents a daily habits memo.
+ */
+fun String.isDailyMemo(): Boolean = contains(PostTags.HABITS_DAILY) || contains(PostTags.DAILY)
+
+/**
+ * Checks if this string is a config tag (starts with config prefix).
+ */
+fun String.isConfigTag(): Boolean = startsWith(PostTags.HABITS_CONFIG) || startsWith(PostTags.HABITS_CONFIG_ALT)
+
+/**
+ * Removes habit tag prefixes from this string.
+ */
+fun String.stripHabitPrefixes(): String = removePrefix(PostTags.HABITS_PREFIX).removePrefix(PostTags.HABIT_PREFIX)

--- a/feature/memos/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTagsExtensionsTest.kt
+++ b/feature/memos/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/domain/model/PostTagsExtensionsTest.kt
@@ -1,0 +1,97 @@
+package space.be1ski.vibits.feature.memos.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class PostTagsExtensionsTest {
+  @Test
+  fun `isConfigMemo when contains HABITS_CONFIG then returns true`() {
+    val content = "Some text\n#habits/config\nMore text"
+
+    assertTrue(content.isConfigMemo())
+  }
+
+  @Test
+  fun `isConfigMemo when contains HABITS_CONFIG_ALT then returns true`() {
+    val content = "Some text\n#habits_config\nMore text"
+
+    assertTrue(content.isConfigMemo())
+  }
+
+  @Test
+  fun `isConfigMemo when no config tag then returns false`() {
+    val content = "#habits/exercise"
+
+    assertFalse(content.isConfigMemo())
+  }
+
+  @Test
+  fun `isDailyMemo when contains HABITS_DAILY then returns true`() {
+    val content = "#habits/daily 2024-01-15"
+
+    assertTrue(content.isDailyMemo())
+  }
+
+  @Test
+  fun `isDailyMemo when contains DAILY then returns true`() {
+    val content = "#daily 2024-01-15"
+
+    assertTrue(content.isDailyMemo())
+  }
+
+  @Test
+  fun `isDailyMemo when no daily tag then returns false`() {
+    val content = "#habits/exercise"
+
+    assertFalse(content.isDailyMemo())
+  }
+
+  @Test
+  fun `isConfigTag when starts with HABITS_CONFIG then returns true`() {
+    val tag = "#habits/config"
+
+    assertTrue(tag.isConfigTag())
+  }
+
+  @Test
+  fun `isConfigTag when starts with HABITS_CONFIG_ALT then returns true`() {
+    val tag = "#habits_config"
+
+    assertTrue(tag.isConfigTag())
+  }
+
+  @Test
+  fun `isConfigTag when does not start with config prefix then returns false`() {
+    val tag = "#habits/exercise"
+
+    assertFalse(tag.isConfigTag())
+  }
+
+  @Test
+  fun `stripHabitPrefixes when has HABITS_PREFIX then removes it`() {
+    val tag = "#habits/exercise"
+
+    val result = tag.stripHabitPrefixes()
+
+    kotlin.test.assertEquals("exercise", result)
+  }
+
+  @Test
+  fun `stripHabitPrefixes when has HABIT_PREFIX then removes it`() {
+    val tag = "#habit/reading"
+
+    val result = tag.stripHabitPrefixes()
+
+    kotlin.test.assertEquals("reading", result)
+  }
+
+  @Test
+  fun `stripHabitPrefixes when has no prefix then returns original`() {
+    val tag = "exercise"
+
+    val result = tag.stripHabitPrefixes()
+
+    kotlin.test.assertEquals("exercise", result)
+  }
+}

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/HabitsConfigCard.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/HabitsConfigCard.kt
@@ -25,7 +25,7 @@ import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.parseHabitConfigLine
 import space.be1ski.vibits.feature.habits.presentation.view.components.localizedLabel
 import space.be1ski.vibits.feature.memos.domain.model.Memo
-import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isConfigTag
 
 @Composable
 internal fun HabitsConfigCard(
@@ -39,7 +39,7 @@ internal fun HabitsConfigCard(
       .lineSequence()
       .map { it.trim() }
       .filter { it.isNotBlank() }
-      .filterNot { it.startsWith(PostTags.HABITS_CONFIG) || it.startsWith(PostTags.HABITS_CONFIG_ALT) }
+      .filterNot { it.isConfigTag() }
       .mapNotNull { line -> parseHabitConfigLine(line) }
       .distinctBy { it.tag }
       .toList()

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/OnboardingRepositoryImpl.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/OnboardingRepositoryImpl.kt
@@ -5,7 +5,7 @@ import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
-import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import space.be1ski.vibits.feature.memos.domain.model.isConfigMemo
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.feature.onboarding.domain.repository.OnboardingRepository
 import space.be1ski.vibits.feature.onboarding.domain.repository.OnboardingStore
@@ -40,7 +40,7 @@ class OnboardingRepositoryImpl(
     val memosFile = offlineMemoStorage.load()
     val hasConfig =
       memosFile.memos.any { memo ->
-        memo.content.contains(PostTags.HABITS_CONFIG) || memo.content.contains(PostTags.HABITS_CONFIG_ALT)
+        memo.content.isConfigMemo()
       }
     Log.d(TAG, "hasHabitsConfig() = $hasConfig")
     return hasConfig


### PR DESCRIPTION
## Summary
- Extract repeated patterns in config/daily memo detection into reusable extension functions
- Reduces code duplication across 6 files

## Changes
- Added `isConfigMemo()`: checks for config tags in content
- Added `isDailyMemo()`: checks for daily tags in content
- Added `isConfigTag()`: checks if tag starts with config prefix
- Added `stripHabitPrefixes()`: removes habit prefixes from string
- Updated callers in HabitParser, ExtractHabitsConfigUseCase, ExtractDailyMemosUseCase, MemoParsingUtils, HabitsConfigCard, OnboardingRepositoryImpl
- Added tests for all extension functions

## Test plan
- [x] All existing tests pass
- [x] New tests added for extension functions
- [x] `./gradlew checkJvm` passes