### PR TITLE
Use ignoreCase instead of lowercase() in ClassifyPostTypeUseCase

### DIFF
--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/usecase/ClassifyPostTypeUseCase.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/usecase/ClassifyPostTypeUseCase.kt
@@ -6,13 +6,13 @@ import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
 object ClassifyPostTypeUseCase {
   operator fun invoke(memo: Memo): PostFilter {
-    val content = memo.content.lowercase()
+    val content = memo.content
 
     return when {
-      content.contains(PostTags.HABITS_CONFIG.lowercase()) ||
-        content.contains(PostTags.HABITS_CONFIG_ALT.lowercase()) -> PostFilter.CONFIG
-      content.contains(PostTags.HABITS_DAILY.lowercase()) ||
-        content.contains(PostTags.DAILY.lowercase()) -> PostFilter.HABIT_TRACKING
+      content.contains(PostTags.HABITS_CONFIG, ignoreCase = true) ||
+        content.contains(PostTags.HABITS_CONFIG_ALT, ignoreCase = true) -> PostFilter.CONFIG
+      content.contains(PostTags.HABITS_DAILY, ignoreCase = true) ||
+        content.contains(PostTags.DAILY, ignoreCase = true) -> PostFilter.HABIT_TRACKING
       else -> PostFilter.REGULAR
     }
   }


### PR DESCRIPTION
## Summary
- Replace redundant `lowercase()` calls with `ignoreCase = true` parameter
- Avoids creating temporary lowercase copy of the entire content string

## Changes
- Updated `ClassifyPostTypeUseCase` to use `contains(..., ignoreCase = true)` instead of `content.lowercase().contains(tag.lowercase())`

## Test plan
- [x] All existing tests pass
- [x] `./gradlew checkJvm` passes