### PR TITLE
Replace date magic numbers with named constants

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateConstants.kt
@@ -6,3 +6,5 @@ const val MONTHS_IN_YEAR = 12
 const val QUARTERS_IN_YEAR = 4
 const val FIRST_DAY_OF_MONTH = 1
 const val FIRST_QUARTER_INDEX = 1
+const val FIRST_MONTH_OF_YEAR = 1
+const val LAST_DAY_OF_DECEMBER = 31

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
@@ -3,6 +3,10 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
+import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GenerateActivityRangesUseCase {
@@ -25,7 +29,7 @@ object GenerateActivityRangesUseCase {
     var cursor = startOfWeek(startDate)
     while (cursor <= endDate) {
       weeks.add(ActivityRange.Week(cursor))
-      cursor = cursor.plus(DatePeriod(days = 7))
+      cursor = cursor.plus(DatePeriod(days = DAYS_IN_WEEK))
     }
     return weeks
   }
@@ -39,13 +43,12 @@ object GenerateActivityRangesUseCase {
     val end = ActivityRange.Month(endDate.year, endDate.month)
     while (cursor.year < end.year || (cursor.year == end.year && cursor.month <= end.month)) {
       months.add(cursor)
-      val nextDate = LocalDate(cursor.year, cursor.month, 1).plus(DatePeriod(months = 1))
+      val nextDate = LocalDate(cursor.year, cursor.month, FIRST_DAY_OF_MONTH).plus(DatePeriod(months = 1))
       cursor = ActivityRange.Month(nextDate.year, nextDate.month)
     }
     return months
   }
 
-  @Suppress("MagicNumber")
   private fun generateQuarters(
     startDate: LocalDate,
     endDate: LocalDate,
@@ -58,8 +61,8 @@ object GenerateActivityRangesUseCase {
     while (yearCursor < endDate.year || (yearCursor == endDate.year && quarterCursor <= endQuarter)) {
       quarters.add(ActivityRange.Quarter(yearCursor, quarterCursor))
       quarterCursor++
-      if (quarterCursor > 4) {
-        quarterCursor = 1
+      if (quarterCursor > QUARTERS_IN_YEAR) {
+        quarterCursor = FIRST_QUARTER_INDEX
         yearCursor++
       }
     }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -6,7 +6,11 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.platform.date.FIRST_MONTH_OF_YEAR
+import space.be1ski.vibits.core.platform.date.LAST_DAY_OF_DECEMBER
 import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
@@ -28,27 +32,26 @@ class GetPeriodPostsUseCase {
       }.sortedByDescending { it.createTime ?: it.updateTime }
   }
 
-  @Suppress("MagicNumber")
   private fun rangeBounds(range: ActivityRange): Pair<LocalDate, LocalDate> =
     when (range) {
       is ActivityRange.Week -> {
         range.startDate to range.startDate.plus(DatePeriod(days = DAYS_IN_WEEK - 1))
       }
       is ActivityRange.Month -> {
-        val start = LocalDate(range.year, range.month, 1)
+        val start = LocalDate(range.year, range.month, FIRST_DAY_OF_MONTH)
         val nextMonth = start.plus(DatePeriod(months = 1))
         val end = nextMonth.plus(DatePeriod(days = -1))
         start to end
       }
       is ActivityRange.Quarter -> {
-        val startMonth = (range.index - 1) * MONTHS_IN_QUARTER + 1
-        val start = LocalDate(range.year, startMonth, 1)
+        val startMonth = (range.index - 1) * MONTHS_IN_QUARTER + FIRST_MONTH_OF_YEAR
+        val start = LocalDate(range.year, startMonth, FIRST_DAY_OF_MONTH)
         val end = start.plus(DatePeriod(months = MONTHS_IN_QUARTER)).plus(DatePeriod(days = -1))
         start to end
       }
       is ActivityRange.Year -> {
-        val start = LocalDate(range.year, 1, 1)
-        val end = LocalDate(range.year, 12, 31)
+        val start = LocalDate(range.year, FIRST_MONTH_OF_YEAR, FIRST_DAY_OF_MONTH)
+        val end = LocalDate(range.year, MONTHS_IN_YEAR, LAST_DAY_OF_DECEMBER)
         start to end
       }
     }


### PR DESCRIPTION
## Summary
- Replace hardcoded numeric literals with named constants from DateConstants
- Remove `@Suppress("MagicNumber")` annotations that are no longer needed

## Changes
- Added `FIRST_MONTH_OF_YEAR` and `LAST_DAY_OF_DECEMBER` to DateConstants.kt
- Updated `GenerateActivityRangesUseCase.kt`:
  - `7` → `DAYS_IN_WEEK`
  - `1` (day) → `FIRST_DAY_OF_MONTH`
  - `4` (quarters) → `QUARTERS_IN_YEAR`
  - `1` (quarter reset) → `FIRST_QUARTER_INDEX`
- Updated `GetPeriodPostsUseCase.kt`:
  - `1` (day) → `FIRST_DAY_OF_MONTH`
  - `1` (month) → `FIRST_MONTH_OF_YEAR`
  - `12` → `MONTHS_IN_YEAR`
  - `31` → `LAST_DAY_OF_DECEMBER`

## Test plan
- [x] Existing tests pass
- [x] ktlint passes
- [x] detekt passes