### PR TITLE
Use fun interface for MemoStorageManager

### DIFF
--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.memos.domain.repository
 /**
  * Manages offline memo storage operations.
  */
-interface MemoStorageManager {
+fun interface MemoStorageManager {
   /**
    * Clears all memos from offline storage.
    */


### PR DESCRIPTION
## Summary

Convert `MemoStorageManager` to `fun interface` for consistency with other single-method functional interfaces in the codebase (e.g., `ConnectionTester`).

## Changes

- Add `fun` modifier to `MemoStorageManager` interface

## Test plan

- [x] `./gradlew checkJvm` passes
- [x] No breaking changes - existing implementations work unchanged