### PR TITLE
Use fun interface for HabitPresetsDataSource

### DIFF
--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -8,7 +8,7 @@ import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
-interface HabitPresetsDataSource {
+fun interface HabitPresetsDataSource {
   fun getPresets(): List<HabitPreset>
 }
 


### PR DESCRIPTION
## Summary
Convert `HabitPresetsDataSource` interface to `fun interface` pattern for consistency with other single-method interfaces in the codebase (e.g., `MemoStorageManager`, `ConnectionTester`).

## Changes
- Convert `interface HabitPresetsDataSource` to `fun interface HabitPresetsDataSource`

🤖 Generated with [Claude Code](https://claude.com/claude-code)