### PR TITLE
Move date utilities to core/platform/date

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateUtils.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/date/DateUtils.kt
@@ -1,12 +1,10 @@
-package space.be1ski.vibits.feature.habits.domain.usecase
+package space.be1ski.vibits.core.platform.date
 
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
-import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
 
 /**
  * Returns the Monday of the week containing [date].

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -6,6 +6,7 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.platform.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
@@ -7,6 +7,8 @@ import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
 import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
 import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.platform.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GenerateActivityRangesUseCase {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
@@ -4,6 +4,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.platform.date.startOfWeek
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -2,10 +2,10 @@ package space.be1ski.vibits.feature.habits.presentation.view.components
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
+import space.be1ski.vibits.core.platform.date.quarterIndex
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.usecase.quarterIndex
 
 internal fun buildTimelineLabels(
   weeks: List<ActivityWeek>,

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.core.platform.date.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.usecase.quarterIndex
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 
 /**

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -14,6 +14,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.platform.date.startOfWeek
 import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
@@ -23,8 +25,6 @@ import space.be1ski.vibits.feature.habits.domain.parseConfigFromContent
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityRangeDeltaUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.NavigateActivityRangeUseCase
-import space.be1ski.vibits.feature.habits.domain.usecase.quarterIndex
-import space.be1ski.vibits.feature.habits.domain.usecase.startOfWeek
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.view.StatsScreen


### PR DESCRIPTION
## Summary
Move `startOfWeek()` and `quarterIndex()` utility functions from the habits domain usecase package to core/platform/date package, alongside other date constants and utilities.

## Changes
- Create `core/platform/date/DateUtils.kt` with `startOfWeek()` and `quarterIndex()` functions
- Delete `feature/habits/domain/usecase/DateUtils.kt`
- Update imports in all affected files

🤖 Generated with [Claude Code](https://claude.com/claude-code)