### PR TITLE
Fix date utilities package and remove unused fun interface

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateConstants.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateConstants.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.platform.date
+package space.be1ski.vibits.core.date
 
 const val DAYS_IN_WEEK = 7
 const val MONTHS_IN_QUARTER = 3

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateUtils.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateUtils.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.platform.date
+package space.be1ski.vibits.core.date
 
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek
@@ -6,9 +6,6 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 
-/**
- * Returns the Monday of the week containing [date].
- */
 fun startOfWeek(date: LocalDate): LocalDate {
   var start = date
   while (start.dayOfWeek != DayOfWeek.MONDAY) {
@@ -17,12 +14,6 @@ fun startOfWeek(date: LocalDate): LocalDate {
   return start
 }
 
-/**
- * Returns the quarter index (1-4) for a date.
- */
 fun quarterIndex(date: LocalDate): Int = quarterIndex(date.month)
 
-/**
- * Returns the quarter index (1-4) for a month.
- */
 fun quarterIndex(month: Month): Int = month.ordinal / MONTHS_IN_QUARTER + FIRST_QUARTER_INDEX

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 
 /**
  * Fully prepared dataset for activity charts.

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -5,8 +5,8 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
@@ -3,12 +3,12 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GenerateActivityRangesUseCase {

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -5,12 +5,12 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_MONTH_OF_YEAR
-import space.be1ski.vibits.core.platform.date.LAST_DAY_OF_DECEMBER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_MONTH_OF_YEAR
+import space.be1ski.vibits.core.date.LAST_DAY_OF_DECEMBER
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -5,11 +5,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
@@ -4,8 +4,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -38,7 +38,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_configure_habits
 import space.be1ski.vibits.core.strings.generated.action_hide_memos

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.day_fri
 import space.be1ski.vibits.core.strings.generated.day_mon

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.habits.presentation.view.components
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.date.quarterIndex
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.date.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
@@ -5,10 +5,10 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -14,8 +14,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_next

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.memos.domain.repository
 /**
  * Manages offline memo storage operations.
  */
-fun interface MemoStorageManager {
+interface MemoStorageManager {
   /**
    * Clears all memos from offline storage.
    */

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -8,7 +8,7 @@ import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
-fun interface HabitPresetsDataSource {
+interface HabitPresetsDataSource {
   fun getPresets(): List<HabitPreset>
 }
 


### PR DESCRIPTION
## Summary

- Move `DateConstants` and `DateUtils` from `core.platform.date` to `core.date` package (they are not expect/actual declarations)
- Remove unused `fun` modifier from `MemoStorageManager` and `HabitPresetsDataSource` interfaces (SAM conversion was never used)

## Changes

- **DateConstants.kt** and **DateUtils.kt**: Moved from `*.platform.*` package to `*.date.*` within the same module
- **MemoStorageManager**: Removed `fun` modifier
- **HabitPresetsDataSource**: Removed `fun` modifier
- Updated all imports across 16 files

## Test plan

- [x] `./gradlew checkJvm` passes