### PR TITLE
Create core:utils module for date and logging utilities

### DIFF
--- a/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
+++ b/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.core.platform.logging
 
-import space.be1ski.vibits.core.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.LogLevel
 
-internal actual fun platformLog(
+actual fun platformLog(
   level: LogLevel,
   tag: String,
   message: String,

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/logging/LogLevel.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/logging/LogLevel.kt
@@ -1,0 +1,8 @@
+package space.be1ski.vibits.core.platform.logging
+
+enum class LogLevel {
+  DEBUG,
+  INFO,
+  WARN,
+  ERROR,
+}

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
@@ -1,12 +1,10 @@
 package space.be1ski.vibits.core.platform.logging
 
-import space.be1ski.vibits.core.logging.LogLevel
-
 /**
  * Platform-specific log output.
  * Uses SLF4J on JVM platforms, println on others.
  */
-internal expect fun platformLog(
+expect fun platformLog(
   level: LogLevel,
   tag: String,
   message: String,

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
@@ -1,11 +1,11 @@
 package space.be1ski.vibits.core.platform.logging
 
 import org.slf4j.LoggerFactory
-import space.be1ski.vibits.core.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.LogLevel
 
 private val logger = LoggerFactory.getLogger("Vibits")
 
-internal actual fun platformLog(
+actual fun platformLog(
   level: LogLevel,
   tag: String,
   message: String,

--- a/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
+++ b/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.core.platform.logging
 
-import space.be1ski.vibits.core.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.LogLevel
 
-internal actual fun platformLog(
+actual fun platformLog(
   level: LogLevel,
   tag: String,
   message: String,

--- a/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
+++ b/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/logging/PlatformLog.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.core.platform.logging
 
-import space.be1ski.vibits.core.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.LogLevel
 
-internal actual fun platformLog(
+actual fun platformLog(
   level: LogLevel,
   tag: String,
   message: String,

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
       dependencies {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
+        implementation(projects.core.utils)
         implementation(libs.compose.resources)
         implementation(libs.compose.foundation)
         implementation(libs.compose.material3)

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
@@ -17,7 +17,7 @@ import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import space.be1ski.vibits.core.logging.LogEntry
-import space.be1ski.vibits.core.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.LogLevel
 
 private const val LOG_TIMESTAMP_LENGTH = 8
 private val MaxHeight = 400.dp

--- a/core/utils/build.gradle.kts
+++ b/core/utils/build.gradle.kts
@@ -1,6 +1,5 @@
 plugins {
   id("vibits.kmp.library")
-  id("vibits.kmp.metro")
 }
 
 kotlin {
@@ -8,13 +7,12 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
-        implementation(projects.core.utils)
-        implementation(projects.feature.settings.domain)
+        implementation(libs.kotlinx.atomicfu)
+        implementation(libs.kotlinx.datetime)
       }
     }
     commonTest {
       dependencies {
-        implementation(projects.feature.main)
         implementation(kotlin("test"))
         implementation(libs.kotlinx.coroutines.test)
       }

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateConstants.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateConstants.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.platform.date
+package space.be1ski.vibits.core.date
 
 const val DAYS_IN_WEEK = 7
 const val MONTHS_IN_QUARTER = 3

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateUtils.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/date/DateUtils.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.platform.date
+package space.be1ski.vibits.core.date
 
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/logging/Log.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/logging/Log.kt
@@ -4,6 +4,7 @@ import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.platform.logging.platformLog
 import kotlin.time.Clock
 
@@ -99,13 +100,6 @@ data class LogEntry(
   val tag: String,
   val message: String,
 )
-
-enum class LogLevel {
-  DEBUG,
-  INFO,
-  WARN,
-  ERROR,
-}
 
 private const val DEFAULT_URL_MAX_LENGTH = 50
 

--- a/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/logging/LogTest.kt
+++ b/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/logging/LogTest.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.core.platform.logging.LogLevel
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/feature/auth/data/build.gradle.kts
+++ b/feature/auth/data/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
       }
     }

--- a/feature/auth/domain/build.gradle.kts
+++ b/feature/auth/domain/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
+        implementation(projects.core.utils)
         implementation(libs.kotlinx.coroutines.core)
       }
     }

--- a/feature/habits/domain/build.gradle.kts
+++ b/feature/habits/domain/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
       dependencies {
         implementation(projects.core.platform)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.memos.domain)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.datetime)

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityWeekData.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 
 /**
  * Fully prepared dataset for activity charts.

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -5,8 +5,8 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
@@ -3,12 +3,12 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GenerateActivityRangesUseCase {

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -5,12 +5,12 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_MONTH_OF_YEAR
-import space.be1ski.vibits.core.platform.date.LAST_DAY_OF_DECEMBER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_MONTH_OF_YEAR
+import space.be1ski.vibits.core.date.LAST_DAY_OF_DECEMBER
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -5,11 +5,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
@@ -4,8 +4,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/feature/habits/presentation/build.gradle.kts
+++ b/feature/habits/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.memos.domain)
         implementation(libs.compose.resources)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -38,7 +38,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_configure_habits
 import space.be1ski.vibits.core.strings.generated.action_hide_memos

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -47,7 +47,7 @@ import androidx.compose.ui.window.PopupPositionProvider
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.day_fri
 import space.be1ski.vibits.core.strings.generated.day_mon

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.habits.presentation.view.components
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.date.quarterIndex
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
         api(projects.core.platform)
         api(projects.core.strings)
         api(projects.core.ui)
+        api(projects.core.utils)
         api(projects.feature.auth.data)
         api(projects.feature.auth.domain)
         api(projects.feature.habits.domain)

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/AdjustDateForTabChangeUseCase.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.platform.date.quarterIndex
+import space.be1ski.vibits.core.date.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeEndDateUseCase.kt
@@ -5,10 +5,10 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/domain/usecase/GetActivityRangeStartDateUseCase.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.main.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.platform.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.platform.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -14,8 +14,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.date.quarterIndex
-import space.be1ski.vibits.core.platform.date.startOfWeek
+import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/TimeRangeControls.kt
@@ -24,7 +24,7 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_next

--- a/feature/memos/data/build.gradle.kts
+++ b/feature/memos/data/build.gradle.kts
@@ -18,6 +18,7 @@ kotlin {
       dependencies {
         implementation(projects.core.platform)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.memos.domain)

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.memos.domain.repository
 /**
  * Manages offline memo storage operations.
  */
-fun interface MemoStorageManager {
+interface MemoStorageManager {
   /**
    * Clears all memos from offline storage.
    */

--- a/feature/memos/presentation/build.gradle.kts
+++ b/feature/memos/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.habits.presentation)

--- a/feature/mode/presentation/build.gradle.kts
+++ b/feature/mode/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.memos.domain)
         implementation(projects.feature.mode.domain)

--- a/feature/onboarding/data/build.gradle.kts
+++ b/feature/onboarding/data/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
+        implementation(projects.core.utils)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.memos.data)
         implementation(projects.feature.memos.domain)

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -8,7 +8,7 @@ import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
-fun interface HabitPresetsDataSource {
+interface HabitPresetsDataSource {
   fun getPresets(): List<HabitPreset>
 }
 

--- a/feature/onboarding/presentation/build.gradle.kts
+++ b/feature/onboarding/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.habits.presentation)
         implementation(projects.feature.onboarding.domain)

--- a/feature/settings/presentation/build.gradle.kts
+++ b/feature/settings/presentation/build.gradle.kts
@@ -11,6 +11,7 @@ kotlin {
         implementation(projects.core.platform)
         implementation(projects.core.strings)
         implementation(projects.core.ui)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.memos.data)
         implementation(projects.feature.memos.domain)

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -55,10 +55,10 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.logging.Log
-import space.be1ski.vibits.core.logging.LogLevel
 import space.be1ski.vibits.core.platform.app.AppDetails
 import space.be1ski.vibits.core.platform.export.createFileExporter
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel

--- a/feature/sync/data/build.gradle.kts
+++ b/feature/sync/data/build.gradle.kts
@@ -15,6 +15,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
+        implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.memos.data)
         implementation(projects.feature.memos.domain)

--- a/feature/sync/domain/build.gradle.kts
+++ b/feature/sync/domain/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
     commonMain {
       dependencies {
         implementation(projects.core.platform)
+        implementation(projects.core.utils)
         implementation(projects.feature.memos.domain)
         implementation(libs.kotlinx.coroutines.core)
         implementation(libs.kotlinx.datetime)

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -32,11 +32,12 @@ include(
 
   ":feature:main",
 
-  ":core:platform",
   ":core:elm",
   ":core:elm:test",
-  ":core:ui",
+  ":core:platform",
   ":core:strings",
+  ":core:ui",
+  ":core:utils",
 
   ":feature:auth:domain",
   ":feature:auth:data",


### PR DESCRIPTION
## Summary

- Create new `core:utils` module for non-platform utilities
- Move date utilities (DateConstants, DateUtils) from `core.platform.date` to `core.date`
- Move logging utilities (Log, LogEntry) from `core.logging` to new module
- Keep LogLevel in `core.platform.logging` (used by expect/actual platformLog)

## Changes

**New module: core:utils**
- `core.date.DateConstants` - date-related constants
- `core.date.DateUtils` - startOfWeek(), quarterIndex() functions
- `core.logging.Log` - in-memory log storage
- `core.logging.LogEntry` - log entry data class
- `core.logging.maskUrl()` - URL masking extension

**Fixes**
- Remove unused `fun` modifier from MemoStorageManager and HabitPresetsDataSource
- Make platformLog public (was internal) for cross-module use

**Updated dependencies**
- 14 feature modules now depend on core:utils
- core:ui now depends on core:utils

## Test plan

- [x] `./gradlew checkJvm` passes
- [x] All existing tests pass