### PR TITLE
Add retry logic with exponential backoff to SyncOperationApplier

### DIFF
--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.sync.data
 
+import kotlinx.coroutines.delay
 import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
@@ -9,17 +10,34 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncOperationStatus
 import space.be1ski.vibits.feature.sync.domain.model.SyncOperationType
 import space.be1ski.vibits.feature.sync.domain.model.TempMemoName
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 
 private val TAG = SyncLogTags.SYNC_OPERATION_APPLIER
 
+private const val DEFAULT_MAX_RETRIES = 3
+private val DEFAULT_INITIAL_DELAY = 500.milliseconds
+private val DEFAULT_MAX_DELAY = 10.seconds
+
 /**
- * Applies sync operations to the server.
+ * Configuration for retry behavior.
+ */
+data class RetryConfig(
+  val maxRetries: Int = DEFAULT_MAX_RETRIES,
+  val initialDelay: Duration = DEFAULT_INITIAL_DELAY,
+  val maxDelay: Duration = DEFAULT_MAX_DELAY,
+)
+
+/**
+ * Applies sync operations to the server with automatic retry and exponential backoff.
  */
 internal class SyncOperationApplier(
   private val memosApi: MemosApi,
   private val memoMapper: MemoMapper,
   private val syncQueue: SyncQueueRepository,
   private val offlineFirstRepository: OfflineFirstMemosRepository,
+  private val retryConfig: RetryConfig = RetryConfig(),
 ) {
   suspend fun applyOperations(
     operations: List<SyncOperation>,
@@ -36,26 +54,41 @@ internal class SyncOperationApplier(
   ) {
     syncQueue.updateStatus(operation.id, SyncOperationStatus.IN_PROGRESS)
 
-    runCatching {
-      when (operation.type) {
-        SyncOperationType.CREATE -> applyCreateOperation(operation, baseUrl, token)
-        SyncOperationType.UPDATE -> applyUpdateOperation(operation, baseUrl, token)
-        SyncOperationType.DELETE -> applyDeleteOperation(operation, baseUrl, token)
+    var lastException: Exception? = null
+    var currentDelay = retryConfig.initialDelay
+
+    for (attempt in 0..retryConfig.maxRetries) {
+      val result =
+        runCatching {
+          when (operation.type) {
+            SyncOperationType.CREATE -> applyCreateOperation(operation, baseUrl, token)
+            SyncOperationType.UPDATE -> applyUpdateOperation(operation, baseUrl, token)
+            SyncOperationType.DELETE -> applyDeleteOperation(operation, baseUrl, token)
+          }
+        }
+
+      if (result.isSuccess) {
+        val applied = result.getOrThrow()
+        syncQueue.updateStatus(operation.id, SyncOperationStatus.SYNCED)
+        if (applied) {
+          Log.d(TAG, "Synced operation: ${operation.id}")
+        } else {
+          Log.d(TAG, "Skipped operation (marked as synced): ${operation.id}")
+        }
+        return
       }
-    }.onSuccess { applied ->
-      // Always mark as SYNCED after processing (whether applied or skipped)
-      // This prevents operations getting stuck in IN_PROGRESS state
-      syncQueue.updateStatus(operation.id, SyncOperationStatus.SYNCED)
-      if (applied) {
-        Log.d(TAG, "Synced operation: ${operation.id}")
-      } else {
-        Log.d(TAG, "Skipped operation (marked as synced): ${operation.id}")
+
+      lastException = result.exceptionOrNull() as? Exception
+      if (attempt < retryConfig.maxRetries) {
+        Log.w(TAG, "Operation ${operation.id} failed, retrying in $currentDelay (attempt ${attempt + 1}/${retryConfig.maxRetries})")
+        delay(currentDelay)
+        currentDelay = (currentDelay * 2).coerceAtMost(retryConfig.maxDelay)
       }
-    }.onFailure { e ->
-      syncQueue.updateStatus(operation.id, SyncOperationStatus.FAILED)
-      Log.e(TAG, "Failed to sync operation: ${operation.id}", e)
-      throw e
     }
+
+    syncQueue.updateStatus(operation.id, SyncOperationStatus.FAILED)
+    Log.e(TAG, "Failed to sync operation after ${retryConfig.maxRetries} retries: ${operation.id}", lastException)
+    throw lastException ?: Exception("Unknown error syncing operation ${operation.id}")
   }
 
   private suspend fun applyCreateOperation(

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
@@ -31,6 +31,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.milliseconds
 
 class SyncOperationApplierTest {
   private val memoMapper = MemoMapper()
@@ -38,6 +39,11 @@ class SyncOperationApplierTest {
   private val token = "test-token"
 
   private fun createApplier(
+    handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
+  ): Triple<SyncOperationApplier, FakeSyncQueue, RequestTracker> = createApplierWithRetry(RetryConfig(maxRetries = 0), handler)
+
+  private fun createApplierWithRetry(
+    retryConfig: RetryConfig,
     handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
   ): Triple<SyncOperationApplier, FakeSyncQueue, RequestTracker> {
     val tracker = RequestTracker()
@@ -61,7 +67,7 @@ class SyncOperationApplierTest {
     val fakeQueue = FakeSyncQueue()
     val fakeCache = FakeMemoCache()
     val fakeOfflineRepo = OfflineFirstMemosRepository(fakeCache, fakeQueue)
-    val applier = SyncOperationApplier(MemosApi(client), memoMapper, fakeQueue, fakeOfflineRepo)
+    val applier = SyncOperationApplier(MemosApi(client), memoMapper, fakeQueue, fakeOfflineRepo, retryConfig)
     return Triple(applier, fakeQueue, tracker)
   }
 
@@ -426,6 +432,134 @@ class SyncOperationApplierTest {
       val statusHistory = fakeQueue.statusHistory["op-1"]!!
       assertEquals(SyncOperationStatus.IN_PROGRESS, statusHistory.first())
       assertEquals(SyncOperationStatus.SYNCED, statusHistory.last())
+    }
+
+  // ========== Retry Tests ==========
+
+  @Test
+  fun `when operation fails and retries succeed then status becomes SYNCED`() =
+    runTest {
+      var callCount = 0
+      val retryConfig = RetryConfig(maxRetries = 2, initialDelay = 1.milliseconds, maxDelay = 10.milliseconds)
+      val (applier, fakeQueue, tracker) =
+        createApplierWithRetry(retryConfig) { request ->
+          callCount++
+          if (callCount < 2) {
+            respondError(HttpStatusCode.InternalServerError)
+          } else {
+            respond(
+              content = """{"name":"memos/created-1","content":"created","createTime":"2024-01-01T00:00:00Z"}""",
+              headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+          }
+        }
+      val operation =
+        SyncOperation(
+          id = "op-1",
+          type = SyncOperationType.CREATE,
+          memoName = "local_123_456",
+          content = "content",
+          createdAt = Clock.System.now(),
+          status = SyncOperationStatus.PENDING,
+        )
+      fakeQueue.operations.add(operation)
+
+      applier.applyOperations(listOf(operation), baseUrl, token)
+
+      assertEquals(2, tracker.postCalls)
+      assertEquals(SyncOperationStatus.SYNCED, fakeQueue.statusHistory["op-1"]?.last())
+    }
+
+  @Test
+  fun `when operation fails all retries then status becomes FAILED`() =
+    runTest {
+      val retryConfig = RetryConfig(maxRetries = 2, initialDelay = 1.milliseconds, maxDelay = 10.milliseconds)
+      val (applier, fakeQueue, tracker) =
+        createApplierWithRetry(retryConfig) { respondError(HttpStatusCode.InternalServerError) }
+      val operation =
+        SyncOperation(
+          id = "op-1",
+          type = SyncOperationType.CREATE,
+          memoName = "local_123_456",
+          content = "content",
+          createdAt = Clock.System.now(),
+          status = SyncOperationStatus.PENDING,
+        )
+      fakeQueue.operations.add(operation)
+
+      var exceptionThrown = false
+      try {
+        applier.applyOperations(listOf(operation), baseUrl, token)
+      } catch (e: Exception) {
+        exceptionThrown = true
+      }
+
+      assertTrue(exceptionThrown)
+      assertEquals(3, tracker.postCalls) // Initial + 2 retries
+      assertEquals(SyncOperationStatus.FAILED, fakeQueue.statusHistory["op-1"]?.last())
+    }
+
+  @Test
+  fun `when operation succeeds on third retry then makes expected number of calls`() =
+    runTest {
+      var callCount = 0
+      val retryConfig = RetryConfig(maxRetries = 3, initialDelay = 1.milliseconds, maxDelay = 10.milliseconds)
+      val (applier, fakeQueue, tracker) =
+        createApplierWithRetry(retryConfig) { request ->
+          callCount++
+          if (callCount <= 2) {
+            respondError(HttpStatusCode.ServiceUnavailable)
+          } else {
+            respond(
+              content = """{"name":"memos/created-1","content":"created","createTime":"2024-01-01T00:00:00Z"}""",
+              headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+          }
+        }
+      val operation =
+        SyncOperation(
+          id = "op-1",
+          type = SyncOperationType.CREATE,
+          memoName = "local_123_456",
+          content = "content",
+          createdAt = Clock.System.now(),
+          status = SyncOperationStatus.PENDING,
+        )
+      fakeQueue.operations.add(operation)
+
+      applier.applyOperations(listOf(operation), baseUrl, token)
+
+      assertEquals(3, tracker.postCalls)
+      assertEquals(SyncOperationStatus.SYNCED, fakeQueue.statusHistory["op-1"]?.last())
+    }
+
+  @Test
+  fun `when retry config has zero retries then fails immediately without retry`() =
+    runTest {
+      val retryConfig = RetryConfig(maxRetries = 0, initialDelay = 1.milliseconds, maxDelay = 10.milliseconds)
+      val (applier, fakeQueue, tracker) =
+        createApplierWithRetry(retryConfig) { respondError(HttpStatusCode.InternalServerError) }
+      val operation =
+        SyncOperation(
+          id = "op-1",
+          type = SyncOperationType.CREATE,
+          memoName = "local_123_456",
+          content = "content",
+          createdAt = Clock.System.now(),
+          status = SyncOperationStatus.PENDING,
+        )
+      fakeQueue.operations.add(operation)
+
+      var exceptionThrown = false
+      try {
+        applier.applyOperations(listOf(operation), baseUrl, token)
+      } catch (e: Exception) {
+        exceptionThrown = true
+      }
+
+      assertTrue(exceptionThrown)
+      assertEquals(1, tracker.postCalls)
+      assertEquals(SyncOperationStatus.FAILED, fakeQueue.statusHistory["op-1"]?.last())
     }
 
   // ========== Helper Classes ==========


### PR DESCRIPTION
## Summary

Improves sync reliability by adding automatic retry with exponential backoff for failed operations. Previously, sync operations would immediately fail on the first network error.

## Changes

- Add `RetryConfig` data class with configurable parameters:
  - `maxRetries` (default: 3)
  - `initialDelay` (default: 500ms)
  - `maxDelay` (default: 10s)
- Implement exponential backoff in `applyOperation()` that doubles delay between retries
- Add 4 comprehensive tests for retry behavior

## Test plan

- [x] Verify existing tests pass
- [x] Run `./gradlew checkJvm`
- [x] Test retry success after transient failure
- [x] Test failure after exhausting all retries
- [x] Test zero-retry configuration