### PR TITLE
Move TimeRangeScreen enum to model package

### DIFF
--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/effect/AppEffectHandler.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/effect/AppEffectHandler.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.sideEffect
 import space.be1ski.vibits.feature.main.presentation.action.AppAction
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeScreen
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveTimeRangeTabUseCase
-import space.be1ski.vibits.feature.settings.domain.usecase.TimeRangeScreen
 
 internal class AppEffectHandler(
   private val saveTimeRangeTab: SaveTimeRangeTabUseCase,

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/TimeRangeScreen.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/TimeRangeScreen.kt
@@ -1,0 +1,3 @@
+package space.be1ski.vibits.feature.settings.domain.model
+
+enum class TimeRangeScreen { HABITS, POSTS }

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveTimeRangeTabUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveTimeRangeTabUseCase.kt
@@ -1,10 +1,9 @@
 package space.be1ski.vibits.feature.settings.domain.usecase
 
 import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeScreen
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.domain.repository.PreferencesRepository
-
-enum class TimeRangeScreen { HABITS, POSTS }
 
 @Inject
 class SaveTimeRangeTabUseCase(

--- a/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveTimeRangeTabUseCaseTest.kt
+++ b/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveTimeRangeTabUseCaseTest.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.settings.domain.usecase
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.feature.main.test.FakePreferencesRepository
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeScreen
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
 import kotlin.test.Test


### PR DESCRIPTION
## Summary

Moves `TimeRangeScreen` enum from use case file to model package for better code organization.

## Changes

- Create `TimeRangeScreen.kt` in `settings/domain/model/`
- Update imports in dependent files

## Test plan

- [x] Run `./gradlew checkJvm`