### PR TITLE
Use fun interface for HabitPresetsDataSource

### DIFF
--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -8,7 +8,7 @@ import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
-interface HabitPresetsDataSource {
+fun interface HabitPresetsDataSource {
   fun getPresets(): List<HabitPreset>
 }
 


### PR DESCRIPTION
## Summary

Converts `HabitPresetsDataSource` to a `fun interface` following project guidelines for single-method interfaces with DI-provided implementations.

## Changes

- Add `fun` keyword to `HabitPresetsDataSource` interface declaration

## Test plan

- [x] Run `./gradlew checkJvm`