### PR TITLE
Convert CalculateSuccessRateUseCase from @Inject class to object

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
@@ -11,7 +11,6 @@ import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 class CalculateActivityDataUseCase(
   private val buildActivityDataUseCase: BuildActivityDataUseCase,
-  private val calculateSuccessRateUseCase: CalculateSuccessRateUseCase,
 ) {
   operator fun invoke(
     range: ActivityRange,
@@ -35,7 +34,7 @@ class CalculateActivityDataUseCase(
     val configStartDate = configTimeline.firstOrNull()?.date
     val successRate =
       if (mode == ActivityMode.HABITS && configTimeline.isNotEmpty()) {
-        calculateSuccessRateUseCase(weekData, range, today, configStartDate)
+        CalculateSuccessRateUseCase(weekData, range, today, configStartDate)
       } else {
         null
       }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import dev.zacsweers.metro.Inject
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
@@ -9,8 +8,7 @@ import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
 /**
  * Calculates success rate for habits within a given time range.
  */
-@Inject
-class CalculateSuccessRateUseCase {
+object CalculateSuccessRateUseCase {
   operator fun invoke(
     weekData: ActivityWeekData,
     range: ActivityRange,

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCaseTest.kt
@@ -14,8 +14,7 @@ import kotlin.time.Instant
 
 class CalculateActivityDataUseCaseTest {
   private val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase = BuildDayDataUseCase())
-  private val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
-  private val useCase = CalculateActivityDataUseCase(buildActivityDataUseCase, calculateSuccessRateUseCase)
+  private val useCase = CalculateActivityDataUseCase(buildActivityDataUseCase)
 
   @Test
   fun `when memos is empty then returns empty week data`() {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCaseTest.kt
@@ -9,7 +9,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class CalculateSuccessRateUseCaseTest {
-  private val useCase = CalculateSuccessRateUseCase()
+  private val useCase = CalculateSuccessRateUseCase
 
   @Test
   fun `when current week and today is Thursday then calculates Monday to Thursday`() {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCaseTest.kt
@@ -11,11 +11,9 @@ import kotlin.time.Instant
 
 class PrewarmActivityDataUseCaseTest {
   private val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase = BuildDayDataUseCase())
-  private val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
   private val calculateActivityDataUseCase =
     CalculateActivityDataUseCase(
       buildActivityDataUseCase,
-      calculateSuccessRateUseCase,
     )
   private val useCase = PrewarmActivityDataUseCase(calculateActivityDataUseCase)
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsDependencies.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsDependencies.kt
@@ -2,7 +2,6 @@ package space.be1ski.vibits.feature.habits.di
 
 import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase
-import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 
@@ -13,6 +12,5 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 class HabitsDependencies(
   val memosRepository: MemosRepository,
   val buildActivityDataUseCase: BuildActivityDataUseCase,
-  val calculateSuccessRateUseCase: CalculateSuccessRateUseCase,
   val saveDailyHabitMemo: SaveDailyHabitMemoUseCase,
 )

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
@@ -40,14 +40,12 @@ fun createHabitsFeature(
             calculateActivityDataUseCase =
               CalculateActivityDataUseCase(
                 buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-                calculateSuccessRateUseCase = dependencies.calculateSuccessRateUseCase,
               ),
             prewarmActivityDataUseCase =
               PrewarmActivityDataUseCase(
                 calculateActivityDataUseCase =
                   CalculateActivityDataUseCase(
                     buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-                    calculateSuccessRateUseCase = dependencies.calculateSuccessRateUseCase,
                   ),
               ),
           ),

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsEffectHandlerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsEffectHandlerTest.kt
@@ -382,14 +382,10 @@ class HabitsEffectHandlerTest {
           space.be1ski.vibits.feature.habits.domain.usecase
             .BuildDayDataUseCase(),
       )
-    val calculateSuccessRateUseCase =
-      space.be1ski.vibits.feature.habits.domain.usecase
-        .CalculateSuccessRateUseCase()
     val calculateActivityDataUseCase =
       space.be1ski.vibits.feature.habits.domain.usecase
         .CalculateActivityDataUseCase(
           buildActivityDataUseCase = buildActivityDataUseCase,
-          calculateSuccessRateUseCase = calculateSuccessRateUseCase,
         )
     return HabitsEffectHandler(
       memoHandler =

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandlerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandlerTest.kt
@@ -12,7 +12,6 @@ import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.BuildDayDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityDataUseCase
-import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.PrewarmActivityDataUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -29,11 +28,9 @@ class HabitsActivityEffectHandlerTest {
   private fun createHandler(): HabitsActivityEffectHandler {
     val buildDayDataUseCase = BuildDayDataUseCase()
     val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase)
-    val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
     val calculateActivityDataUseCase =
       CalculateActivityDataUseCase(
         buildActivityDataUseCase = buildActivityDataUseCase,
-        calculateSuccessRateUseCase = calculateSuccessRateUseCase,
       )
     val prewarmActivityDataUseCase =
       PrewarmActivityDataUseCase(


### PR DESCRIPTION
## Summary

Converts `CalculateSuccessRateUseCase` from `@Inject class` to `object` following project guidelines for stateless use cases without dependencies.

## Changes

- Convert CalculateSuccessRateUseCase to object (no constructor parameters)
- Remove `calculateSuccessRateUseCase` from HabitsDependencies
- Update CalculateActivityDataUseCase to call object directly
- Update all tests to use object reference

## Test plan

- [x] Run `./gradlew :feature:habits:domain:desktopTest :feature:habits:presentation:desktopTest`