### PR TITLE
Convert stateless use cases to objects

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCase.kt
@@ -9,7 +9,7 @@ import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 /**
  * Builds a ContributionDay for a specific date with habits configuration.
  */
-class BuildHabitDayUseCase {
+object BuildHabitDayUseCase {
   operator fun invoke(
     date: LocalDate,
     habitsConfig: List<HabitConfig>,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -17,7 +17,7 @@ import space.be1ski.vibits.feature.memos.domain.model.Memo
 /**
  * Returns posts (non-habit memos) for a given activity range.
  */
-class GetPeriodPostsUseCase {
+object GetPeriodPostsUseCase {
   operator fun invoke(
     memos: List<Memo>,
     range: ActivityRange,

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCaseTest.kt
@@ -10,7 +10,7 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class BuildHabitDayUseCaseTest {
-  private val useCase = BuildHabitDayUseCase()
+  private val useCase = BuildHabitDayUseCase
 
   @Test
   fun `when habitsConfig is empty then returns null`() {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCaseTest.kt
@@ -33,7 +33,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 3", Instant.parse("2024-01-07T10:00:00Z")), // Sunday (last day)
         createMemo("Post 4", Instant.parse("2024-01-08T10:00:00Z")), // Next Monday (outside)
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Week(startDate), timeZone)
 
@@ -52,7 +52,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 3", Instant.parse("2024-01-31T10:00:00Z")), // Last day
         createMemo("Post 4", Instant.parse("2024-02-01T10:00:00Z")), // Next month (outside)
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Month(year = 2024, month = Month.JANUARY), timeZone)
 
@@ -71,7 +71,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 3", Instant.parse("2024-03-31T10:00:00Z")), // Q1 end
         createMemo("Post 4", Instant.parse("2024-04-01T10:00:00Z")), // Q2 start (outside)
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Quarter(year = 2024, index = 1), timeZone)
 
@@ -90,7 +90,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 3", Instant.parse("2024-06-30T10:00:00Z")), // Q2 end (Jun)
         createMemo("Post 4", Instant.parse("2024-07-01T10:00:00Z")), // Q3 start (outside)
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Quarter(year = 2024, index = 2), timeZone)
 
@@ -106,7 +106,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 3", Instant.parse("2024-12-31T10:00:00Z")), // Last day
         createMemo("Post 4", Instant.parse("2025-01-01T10:00:00Z")), // Next year (outside)
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Year(year = 2024), timeZone)
 
@@ -128,7 +128,7 @@ class GetPeriodPostsUseCaseTest {
           updateTime = Instant.parse("2024-01-02T10:00:00Z"),
         ),
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Week(LocalDate(2024, 1, 1)), timeZone)
 
@@ -148,7 +148,7 @@ class GetPeriodPostsUseCaseTest {
           updateTime = null,
         ),
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Week(LocalDate(2024, 1, 1)), timeZone)
 
@@ -167,7 +167,7 @@ class GetPeriodPostsUseCaseTest {
           updateTime = Instant.parse("2024-01-01T10:00:00Z"),
         ),
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Week(LocalDate(2024, 1, 1)), timeZone)
 
@@ -182,7 +182,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 1", Instant.parse("2023-12-31T10:00:00Z")), // Before range
         createMemo("Post 2", Instant.parse("2024-01-08T10:00:00Z")), // After range
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Week(LocalDate(2024, 1, 1)), timeZone)
 
@@ -191,7 +191,7 @@ class GetPeriodPostsUseCaseTest {
 
   @Test
   fun `when empty memos list then returns empty list`() {
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(emptyList(), ActivityRange.Week(LocalDate(2024, 1, 1)), timeZone)
 
@@ -205,7 +205,7 @@ class GetPeriodPostsUseCaseTest {
         createMemo("Post 1", Instant.parse("2024-02-29T10:00:00Z")), // Leap day
         createMemo("Post 2", Instant.parse("2024-03-01T10:00:00Z")), // Next month
       )
-    val useCase = GetPeriodPostsUseCase()
+    val useCase = GetPeriodPostsUseCase
 
     val result = useCase(memos, ActivityRange.Month(year = 2024, month = Month.FEBRUARY), timeZone)
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -123,10 +123,9 @@ private fun rememberStatsScreenDerived(
     }
   // Success rate comes from TEA cache
   val finalSuccessRateData = successRateData
-  val getPeriodPosts = remember { GetPeriodPostsUseCase() }
   val periodPosts =
     remember(memos, range, timeZone) {
-      getPeriodPosts(memos, range, timeZone)
+      GetPeriodPostsUseCase(memos, range, timeZone)
     }
   return StatsScreenDerivedState(
     state = state,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenHelpers.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenHelpers.kt
@@ -6,10 +6,8 @@ import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.usecase.BuildHabitDayUseCase
 
-private val buildHabitDayUseCase = BuildHabitDayUseCase()
-
 fun buildHabitDay(
   date: LocalDate,
   habitsConfig: List<HabitConfig>,
   dailyMemo: DailyMemoInfo?,
-): ContributionDay? = buildHabitDayUseCase(date, habitsConfig, dailyMemo)
+): ContributionDay? = BuildHabitDayUseCase(date, habitsConfig, dailyMemo)


### PR DESCRIPTION
## Summary

`BuildHabitDayUseCase` and `GetPeriodPostsUseCase` are stateless with no constructor dependencies, so per project guidelines they should be objects with `operator fun invoke`.

## Changes

- Convert `BuildHabitDayUseCase` from class to object
- Convert `GetPeriodPostsUseCase` from class to object
- Update test files to use objects directly instead of instantiating
- Simplify call sites in `StatsScreen.kt` and `StatsScreenHelpers.kt`

## Test plan

- [x] All existing tests pass
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)