### PR TITLE
Convert BuildDayDataUseCase and BuildActivityDataUseCase to objects

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import dev.zacsweers.metro.Inject
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -19,10 +18,7 @@ import space.be1ski.vibits.feature.memos.domain.model.Memo
 /**
  * Use case for building activity data.
  */
-@Inject
-class BuildActivityDataUseCase(
-  private val buildDayDataUseCase: BuildDayDataUseCase,
-) {
+object BuildActivityDataUseCase {
   /**
    * Builds ActivityWeekData for a given range.
    */
@@ -47,7 +43,7 @@ class BuildActivityDataUseCase(
     while (cursor <= bounds.end) {
       val days =
         (0 until DAYS_IN_WEEK).map { offset ->
-          buildDayDataUseCase(
+          BuildDayDataUseCase(
             DayBuildContext(
               date = cursor.plus(DatePeriod(days = offset)),
               bounds = bounds,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.feature.habits.domain.buildHabitStatuses
 import space.be1ski.vibits.feature.habits.domain.extractHabitTagsFromContent
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
@@ -13,8 +12,7 @@ import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
 /**
  * Use case for building a single ContributionDay from context.
  */
-@Inject
-class BuildDayDataUseCase {
+object BuildDayDataUseCase {
   operator fun invoke(context: DayBuildContext): ContributionDay {
     val dailyMemo = context.dailyMemos[context.date]
     val habitsForDay = habitsForDay(context)

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
@@ -10,7 +10,6 @@ import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 class CalculateActivityDataUseCase(
-  private val buildActivityDataUseCase: BuildActivityDataUseCase,
   private val calculateSuccessRateUseCase: CalculateSuccessRateUseCase,
 ) {
   operator fun invoke(
@@ -23,7 +22,7 @@ class CalculateActivityDataUseCase(
     val configTimeline = ExtractHabitsConfigUseCase(memos, timeZone)
     val dailyMemos = ExtractDailyMemosUseCase(memos, timeZone)
     val weekData =
-      buildActivityDataUseCase.buildWeekData(
+      BuildActivityDataUseCase.buildWeekData(
         configTimeline = if (mode == ActivityMode.HABITS) configTimeline else emptyList(),
         dailyMemos = dailyMemos,
         timeZone = timeZone,

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCaseTest.kt
@@ -11,10 +11,7 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class BuildActivityDataUseCaseTest {
-  private val useCase =
-    BuildActivityDataUseCase(
-      buildDayDataUseCase = BuildDayDataUseCase(),
-    )
+  private val useCase = BuildActivityDataUseCase
 
   @Test
   fun `when range is week then buildWeekData returns 7 days`() {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCaseTest.kt
@@ -14,7 +14,7 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class BuildDayDataUseCaseTest {
-  private val useCase = BuildDayDataUseCase()
+  private val useCase = BuildDayDataUseCase
   private val today = LocalDate(2024, 1, 15)
   private val configDate = LocalDate(2024, 1, 10)
   private val habits = listOf(HabitConfig(tag = "#habits/test", label = "Test"))

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCaseTest.kt
@@ -13,9 +13,8 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class CalculateActivityDataUseCaseTest {
-  private val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase = BuildDayDataUseCase())
   private val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
-  private val useCase = CalculateActivityDataUseCase(buildActivityDataUseCase, calculateSuccessRateUseCase)
+  private val useCase = CalculateActivityDataUseCase(calculateSuccessRateUseCase)
 
   @Test
   fun `when memos is empty then returns empty week data`() {

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCaseTest.kt
@@ -10,13 +10,8 @@ import kotlin.test.assertTrue
 import kotlin.time.Instant
 
 class PrewarmActivityDataUseCaseTest {
-  private val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase = BuildDayDataUseCase())
   private val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
-  private val calculateActivityDataUseCase =
-    CalculateActivityDataUseCase(
-      buildActivityDataUseCase,
-      calculateSuccessRateUseCase,
-    )
+  private val calculateActivityDataUseCase = CalculateActivityDataUseCase(calculateSuccessRateUseCase)
   private val useCase = PrewarmActivityDataUseCase(calculateActivityDataUseCase)
 
   @Test

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsDependencies.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsDependencies.kt
@@ -1,7 +1,6 @@
 package space.be1ski.vibits.feature.habits.di
 
 import dev.zacsweers.metro.Inject
-import space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
@@ -12,7 +11,6 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 @Inject
 class HabitsDependencies(
   val memosRepository: MemosRepository,
-  val buildActivityDataUseCase: BuildActivityDataUseCase,
   val calculateSuccessRateUseCase: CalculateSuccessRateUseCase,
   val saveDailyHabitMemo: SaveDailyHabitMemoUseCase,
 )

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
@@ -39,14 +39,12 @@ fun createHabitsFeature(
           HabitsActivityEffectHandler(
             calculateActivityDataUseCase =
               CalculateActivityDataUseCase(
-                buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
                 calculateSuccessRateUseCase = dependencies.calculateSuccessRateUseCase,
               ),
             prewarmActivityDataUseCase =
               PrewarmActivityDataUseCase(
                 calculateActivityDataUseCase =
                   CalculateActivityDataUseCase(
-                    buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
                     calculateSuccessRateUseCase = dependencies.calculateSuccessRateUseCase,
                   ),
               ),

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsEffectHandlerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsEffectHandlerTest.kt
@@ -5,6 +5,9 @@ import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityDataUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.PrewarmActivityDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.effect.HabitsActivityEffectHandler
@@ -376,21 +379,8 @@ class HabitsEffectHandlerTest {
     repository: FakeMemosRepository = FakeMemosRepository(),
     onRefresh: () -> Unit = {},
   ): HabitsEffectHandler {
-    val buildActivityDataUseCase =
-      space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase(
-        buildDayDataUseCase =
-          space.be1ski.vibits.feature.habits.domain.usecase
-            .BuildDayDataUseCase(),
-      )
-    val calculateSuccessRateUseCase =
-      space.be1ski.vibits.feature.habits.domain.usecase
-        .CalculateSuccessRateUseCase()
-    val calculateActivityDataUseCase =
-      space.be1ski.vibits.feature.habits.domain.usecase
-        .CalculateActivityDataUseCase(
-          buildActivityDataUseCase = buildActivityDataUseCase,
-          calculateSuccessRateUseCase = calculateSuccessRateUseCase,
-        )
+    val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
+    val calculateActivityDataUseCase = CalculateActivityDataUseCase(calculateSuccessRateUseCase)
     return HabitsEffectHandler(
       memoHandler =
         HabitsMemoEffectHandler(
@@ -404,11 +394,7 @@ class HabitsEffectHandlerTest {
       activityHandler =
         HabitsActivityEffectHandler(
           calculateActivityDataUseCase = calculateActivityDataUseCase,
-          prewarmActivityDataUseCase =
-            space.be1ski.vibits.feature.habits.domain.usecase
-              .PrewarmActivityDataUseCase(
-                calculateActivityDataUseCase = calculateActivityDataUseCase,
-              ),
+          prewarmActivityDataUseCase = PrewarmActivityDataUseCase(calculateActivityDataUseCase),
         ),
     )
   }

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandlerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandlerTest.kt
@@ -9,8 +9,6 @@ import kotlinx.datetime.atStartOfDayIn
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase
-import space.be1ski.vibits.feature.habits.domain.usecase.BuildDayDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.PrewarmActivityDataUseCase
@@ -27,18 +25,9 @@ class HabitsActivityEffectHandlerTest {
   private val timeZone = TimeZone.UTC
 
   private fun createHandler(): HabitsActivityEffectHandler {
-    val buildDayDataUseCase = BuildDayDataUseCase()
-    val buildActivityDataUseCase = BuildActivityDataUseCase(buildDayDataUseCase)
     val calculateSuccessRateUseCase = CalculateSuccessRateUseCase()
-    val calculateActivityDataUseCase =
-      CalculateActivityDataUseCase(
-        buildActivityDataUseCase = buildActivityDataUseCase,
-        calculateSuccessRateUseCase = calculateSuccessRateUseCase,
-      )
-    val prewarmActivityDataUseCase =
-      PrewarmActivityDataUseCase(
-        calculateActivityDataUseCase = calculateActivityDataUseCase,
-      )
+    val calculateActivityDataUseCase = CalculateActivityDataUseCase(calculateSuccessRateUseCase)
+    val prewarmActivityDataUseCase = PrewarmActivityDataUseCase(calculateActivityDataUseCase)
     return HabitsActivityEffectHandler(
       calculateActivityDataUseCase = calculateActivityDataUseCase,
       prewarmActivityDataUseCase = prewarmActivityDataUseCase,


### PR DESCRIPTION
## Summary

Both `BuildDayDataUseCase` and `BuildActivityDataUseCase` are stateless without constructor dependencies, so per project guidelines they should be objects with `operator fun invoke`.

## Changes

- Convert `BuildDayDataUseCase` from `@Inject class` to `object`
- Convert `BuildActivityDataUseCase` from `@Inject class` to `object`  
- Remove `buildActivityDataUseCase` parameter from `CalculateActivityDataUseCase`
- Remove `buildActivityDataUseCase` from `HabitsDependencies`
- Update all test files to use objects directly

## Test plan

- [x] All existing tests pass
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)