### PR TITLE
Convert MemoMapper to object

### DIFF
--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImpl.kt
@@ -23,7 +23,6 @@ private const val TAG = "MemosRepository"
 @SingleIn(AppScope::class)
 class MemosRepositoryImpl(
   private val memosApi: MemosApi,
-  private val memoMapper: MemoMapper,
   private val credentialsRepository: CredentialsRepository,
   private val memoCache: MemoCache,
 ) : MemosRepository {
@@ -45,7 +44,7 @@ class MemosRepositoryImpl(
           pageSize = MemosDefaults.DEFAULT_PAGE_SIZE,
           pageToken = nextPageToken,
         )
-      allMemos += memoMapper.toDomainList(response.memos)
+      allMemos += MemoMapper.toDomainList(response.memos)
       nextPageToken = response.nextPageToken?.takeIf { it.isNotBlank() }
       nextPageToken?.let { tokenValue ->
         if (!seenTokens.add(tokenValue)) {
@@ -86,7 +85,7 @@ class MemosRepositoryImpl(
         name = name,
         content = content,
       )
-    val updated = memoMapper.toDomain(dto)
+    val updated = MemoMapper.toDomain(dto)
     runCatching { memoCache.upsertMemo(updated) }
     Log.i(TAG, "Updated memo: $name")
     return updated
@@ -104,7 +103,7 @@ class MemosRepositoryImpl(
         token = token,
         content = content,
       )
-    val created = memoMapper.toDomain(dto)
+    val created = MemoMapper.toDomain(dto)
     runCatching { memoCache.upsertMemo(created) }
     Log.i(TAG, "Created memo: ${created.name}")
     return created

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
@@ -1,17 +1,12 @@
 package space.be1ski.vibits.feature.memos.data.mapper
 
-import dev.zacsweers.metro.Inject
-import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 /**
  * Maps network memo DTOs into domain models.
  */
-@Inject
-@SingleIn(AppScope::class)
-class MemoMapper {
+object MemoMapper {
   /**
    * Converts a [MemoDto] into a domain [Memo].
    */

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImplTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemosRepositoryImplTest.kt
@@ -15,7 +15,6 @@ import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.main.test.FakeCredentialsRepository
 import space.be1ski.vibits.feature.main.test.FakeMemoCache
-import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.test.Test
@@ -49,7 +48,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = credentials,
           memoCache = cache,
         )
@@ -75,7 +73,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
           memoCache = cache,
         )
@@ -104,7 +101,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
           memoCache = cache,
         )
@@ -134,7 +130,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
           memoCache = cache,
         )
@@ -157,7 +152,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
           memoCache = cache,
         )
@@ -175,7 +169,6 @@ class MemosRepositoryImplTest {
       val repository =
         MemosRepositoryImpl(
           memosApi = MemosApi(client),
-          memoMapper = MemoMapper(),
           credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "", token = "")),
           memoCache = FakeMemoCache(),
         )

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepositoryTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepositoryTest.kt
@@ -7,7 +7,6 @@ import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.feature.memos.data.demo.DemoMemosRepository
-import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
 import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosRepository
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache
@@ -504,7 +503,6 @@ private fun createStubOnlineRepository(): MemosRepositoryImpl {
     }
   return MemosRepositoryImpl(
     memosApi = MemosApi(httpClient),
-    memoMapper = MemoMapper(),
     credentialsRepository = FakeCredentialsRepository(),
     memoCache = FakeMemoCache(),
   )

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapperTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapperTest.kt
@@ -7,7 +7,7 @@ import kotlin.test.assertNull
 import kotlin.time.Instant
 
 class MemoMapperTest {
-  private val mapper = MemoMapper()
+  private val mapper = MemoMapper
 
   @Test
   fun `when ISO timestamp then maps to instant`() {

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
@@ -31,7 +31,6 @@ private const val LOG_CONTENT_PREVIEW_LENGTH = 50
 @SingleIn(AppScope::class)
 class SyncEngineImpl(
   private val memosApi: MemosApi,
-  private val memoMapper: MemoMapper,
   private val credentialsRepository: CredentialsRepository,
   private val syncQueue: SyncQueueRepository,
   private val offlineFirstRepository: OfflineFirstMemosRepository,
@@ -41,7 +40,7 @@ class SyncEngineImpl(
   override val isSyncing: Boolean get() = _isSyncing.value
 
   private val operationApplier by lazy {
-    SyncOperationApplier(memosApi, memoMapper, syncQueue, offlineFirstRepository)
+    SyncOperationApplier(memosApi, syncQueue, offlineFirstRepository)
   }
 
   override suspend fun performSync(): SyncResult = withSyncLock { performSyncInternal() }
@@ -201,7 +200,7 @@ class SyncEngineImpl(
           pageSize = MemosDefaults.DEFAULT_PAGE_SIZE,
           pageToken = nextPageToken,
         )
-      allMemos += memoMapper.toDomainList(response.memos)
+      allMemos += MemoMapper.toDomainList(response.memos)
       nextPageToken = response.nextPageToken?.takeIf { it.isNotBlank() }
     } while (nextPageToken != null)
 

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
@@ -34,7 +34,6 @@ data class RetryConfig(
  */
 internal class SyncOperationApplier(
   private val memosApi: MemosApi,
-  private val memoMapper: MemoMapper,
   private val syncQueue: SyncQueueRepository,
   private val offlineFirstRepository: OfflineFirstMemosRepository,
   private val retryConfig: RetryConfig = RetryConfig(),
@@ -97,7 +96,7 @@ internal class SyncOperationApplier(
     token: String,
   ): Boolean {
     val content = operation.content ?: return false
-    val serverMemo = memoMapper.toDomain(memosApi.createMemo(baseUrl, token, content))
+    val serverMemo = MemoMapper.toDomain(memosApi.createMemo(baseUrl, token, content))
 
     operation.memoName?.let { tempName ->
       offlineFirstRepository.updateLocalMemo(tempName, serverMemo)

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImplTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImplTest.kt
@@ -20,7 +20,6 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.main.test.FakeCredentialsRepository
-import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -38,8 +37,6 @@ import kotlin.test.assertTrue
 import kotlin.time.Clock
 
 class SyncEngineImplTest {
-  private val memoMapper = MemoMapper()
-
   private fun createEngine(
     credentials: Credentials = Credentials(baseUrl = "https://memos.example.com", token = "test-token"),
     handler: suspend MockRequestHandleScope.(HttpRequestData) -> HttpResponseData,
@@ -69,7 +66,6 @@ class SyncEngineImplTest {
     val syncEngine =
       SyncEngineImpl(
         memosApi = MemosApi(client),
-        memoMapper = memoMapper,
         credentialsRepository = credentialsRepository,
         syncQueue = syncQueue,
         offlineFirstRepository = offlineFirstRepository,

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
@@ -18,7 +18,6 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
-import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -34,7 +33,6 @@ import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
 
 class SyncOperationApplierTest {
-  private val memoMapper = MemoMapper()
   private val baseUrl = "https://memos.example.com"
   private val token = "test-token"
 
@@ -67,7 +65,7 @@ class SyncOperationApplierTest {
     val fakeQueue = FakeSyncQueue()
     val fakeCache = FakeMemoCache()
     val fakeOfflineRepo = OfflineFirstMemosRepository(fakeCache, fakeQueue)
-    val applier = SyncOperationApplier(MemosApi(client), memoMapper, fakeQueue, fakeOfflineRepo, retryConfig)
+    val applier = SyncOperationApplier(MemosApi(client), fakeQueue, fakeOfflineRepo, retryConfig)
     return Triple(applier, fakeQueue, tracker)
   }
 


### PR DESCRIPTION
## Summary

`MemoMapper` is stateless without dependencies, so per project guidelines it should be an object. This removes it from DI graphs and simplifies the code.

## Changes

- Convert `MemoMapper` from `@Inject @SingleIn(AppScope::class) class` to `object`
- Remove `memoMapper` parameter from `MemosRepositoryImpl` constructor
- Remove `memoMapper` parameter from `SyncEngineImpl` constructor
- Remove `memoMapper` parameter from `SyncOperationApplier` constructor
- Update all test files to use `MemoMapper` directly as an object

## Test plan

- [x] All existing tests pass
- [x] `./gradlew checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)