### PR TITLE
Refactor ModeSelectionReducer to follow sub-reducer pattern

### DIFF
--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/action/ModeSelectionAction.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/action/ModeSelectionAction.kt
@@ -4,39 +4,51 @@ import space.be1ski.vibits.core.elm.Action
 import space.be1ski.vibits.core.platform.mode.AppMode
 
 sealed interface ModeSelectionAction : Action {
-  // Stored credentials check
-  data object StoredCredentialsFound : ModeSelectionAction
+  /** Stored credentials detection actions. */
+  sealed interface StoredCredentials : ModeSelectionAction {
+    data object Found : StoredCredentials
 
-  data object StoredCredentialsNotFound : ModeSelectionAction
+    data object NotFound : StoredCredentials
+  }
 
-  // Quick online dialog
-  data object DismissQuickOnlineDialog : ModeSelectionAction
+  /** Quick online dialog actions. */
+  sealed interface QuickOnline : ModeSelectionAction {
+    data object Dismiss : QuickOnline
 
-  data object UseStoredCredentials : ModeSelectionAction
+    data object UseStoredCredentials : QuickOnline
+  }
 
-  // Dialog lifecycle
-  data object ShowCredentialsDialog : ModeSelectionAction
+  /** Credentials dialog lifecycle actions. */
+  sealed interface Dialog : ModeSelectionAction {
+    data object Show : Dialog
 
-  data object DismissCredentialsDialog : ModeSelectionAction
+    data object Dismiss : Dialog
+  }
 
-  // Credentials input
-  data class UpdateBaseUrl(
-    val value: String,
-  ) : ModeSelectionAction
+  /** Credentials input actions. */
+  sealed interface Input : ModeSelectionAction {
+    data class UpdateBaseUrl(
+      val value: String,
+    ) : Input
 
-  data class UpdateToken(
-    val value: String,
-  ) : ModeSelectionAction
+    data class UpdateToken(
+      val value: String,
+    ) : Input
+  }
 
-  // Validation flow
-  data object Submit : ModeSelectionAction
+  /** Validation flow actions. */
+  sealed interface Validation : ModeSelectionAction {
+    data object Submit : Validation
 
-  data object ValidationSucceeded : ModeSelectionAction
+    data object Succeeded : Validation
 
-  data object ValidationFailed : ModeSelectionAction
+    data object Failed : Validation
+  }
 
-  // Mode selection (for offline/demo)
-  data class SelectMode(
-    val mode: AppMode,
-  ) : ModeSelectionAction
+  /** Mode selection actions. */
+  sealed interface Selection : ModeSelectionAction {
+    data class SelectMode(
+      val mode: AppMode,
+    ) : Selection
+  }
 }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
@@ -37,10 +37,10 @@ class ModeSelectionCredentialsEffectHandler(
       val credentials = loadCredentials()
       if (credentials.isFilled) {
         Log.d(TAG, "Stored credentials found after initialization")
-        emit(ModeSelectionAction.StoredCredentialsFound)
+        emit(ModeSelectionAction.StoredCredentials.Found)
       } else {
         Log.d(TAG, "No stored credentials after initialization")
-        emit(ModeSelectionAction.StoredCredentialsNotFound)
+        emit(ModeSelectionAction.StoredCredentials.NotFound)
       }
     }
 
@@ -49,10 +49,10 @@ class ModeSelectionCredentialsEffectHandler(
       val credentials = loadCredentials()
       if (credentials.isFilled) {
         Log.d(TAG, "Stored credentials found")
-        emit(ModeSelectionAction.StoredCredentialsFound)
+        emit(ModeSelectionAction.StoredCredentials.Found)
       } else {
         Log.d(TAG, "No stored credentials")
-        emit(ModeSelectionAction.StoredCredentialsNotFound)
+        emit(ModeSelectionAction.StoredCredentials.NotFound)
       }
     }
 
@@ -63,16 +63,16 @@ class ModeSelectionCredentialsEffectHandler(
       val credentials = loadCredentials()
       Log.d(TAG, "Using stored credentials: baseUrl=${credentials.baseUrl.maskUrl()}")
       connectionTester(credentials.baseUrl, credentials.token)
-        .onSuccess { emit(ModeSelectionAction.ValidationSucceeded) }
-        .onFailure { emit(ModeSelectionAction.ValidationFailed) }
+        .onSuccess { emit(ModeSelectionAction.Validation.Succeeded) }
+        .onFailure { emit(ModeSelectionAction.Validation.Failed) }
     }
 
   private fun handleValidateCredentials(command: ModeSelectionEffect.Command.ValidateCredentials): Flow<ModeSelectionAction> =
     actions {
       Log.d(TAG, "Testing connection")
       connectionTester(command.baseUrl, command.token)
-        .onSuccess { emit(ModeSelectionAction.ValidationSucceeded) }
-        .onFailure { emit(ModeSelectionAction.ValidationFailed) }
+        .onSuccess { emit(ModeSelectionAction.Validation.Succeeded) }
+        .onFailure { emit(ModeSelectionAction.Validation.Failed) }
     }
 
   private fun handleSaveCredentials(command: ModeSelectionEffect.Command.SaveCredentials): Flow<ModeSelectionAction> =

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeDialogReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeDialogReducer.kt
@@ -1,0 +1,29 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val dialogReducer: Reducer<ModeSelectionAction.Dialog, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.Dialog.Show -> {
+        state { state.copy(showCredentialsDialog = true, error = null) }
+      }
+
+      is ModeSelectionAction.Dialog.Dismiss -> {
+        state {
+          state.copy(
+            showCredentialsDialog = false,
+            baseUrl = "",
+            token = "",
+            isValidating = false,
+            error = null,
+          )
+        }
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeInputReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeInputReducer.kt
@@ -1,0 +1,21 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val inputReducer: Reducer<ModeSelectionAction.Input, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.Input.UpdateBaseUrl -> {
+        state { state.copy(baseUrl = action.value, error = null) }
+      }
+
+      is ModeSelectionAction.Input.UpdateToken -> {
+        state { state.copy(token = action.value, error = null) }
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeQuickOnlineReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeQuickOnlineReducer.kt
@@ -1,0 +1,22 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val quickOnlineReducer: Reducer<ModeSelectionAction.QuickOnline, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.QuickOnline.Dismiss -> {
+        state { state.copy(showQuickOnlineDialog = false) }
+      }
+
+      is ModeSelectionAction.QuickOnline.UseStoredCredentials -> {
+        state { state.copy(showQuickOnlineDialog = false, isValidating = true) }
+        command(Command.UseStoredCredentialsWithValidation)
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionReducer.kt
@@ -1,99 +1,18 @@
 package space.be1ski.vibits.feature.mode.presentation.reducer
 
 import space.be1ski.vibits.core.elm.Reducer
-import space.be1ski.vibits.core.elm.reducer
-import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
-import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionError
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
 
 val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> =
-  reducer { action, state ->
+  { action, state ->
     when (action) {
-      is ModeSelectionAction.StoredCredentialsFound -> {
-        state { state.copy(hasStoredCredentials = true, showQuickOnlineDialog = true) }
-      }
-
-      is ModeSelectionAction.StoredCredentialsNotFound -> {
-        state { state.copy(hasStoredCredentials = false) }
-      }
-
-      is ModeSelectionAction.DismissQuickOnlineDialog -> {
-        state { state.copy(showQuickOnlineDialog = false) }
-      }
-
-      is ModeSelectionAction.UseStoredCredentials -> {
-        state { state.copy(showQuickOnlineDialog = false, isValidating = true) }
-        command(ModeSelectionEffect.Command.UseStoredCredentialsWithValidation)
-      }
-
-      is ModeSelectionAction.ShowCredentialsDialog -> {
-        state { state.copy(showCredentialsDialog = true, error = null) }
-      }
-
-      is ModeSelectionAction.DismissCredentialsDialog -> {
-        state {
-          state.copy(
-            showCredentialsDialog = false,
-            baseUrl = "",
-            token = "",
-            isValidating = false,
-            error = null,
-          )
-        }
-      }
-
-      is ModeSelectionAction.UpdateBaseUrl -> {
-        state { state.copy(baseUrl = action.value, error = null) }
-      }
-
-      is ModeSelectionAction.UpdateToken -> {
-        state { state.copy(token = action.value, error = null) }
-      }
-
-      is ModeSelectionAction.Submit -> {
-        val baseUrl = state.baseUrl.trim()
-        val token = state.token.trim()
-        if (baseUrl.isBlank() || token.isBlank()) {
-          state { state.copy(error = ModeSelectionError.FILL_ALL_FIELDS) }
-        } else {
-          state { state.copy(isValidating = true, error = null) }
-          command(ModeSelectionEffect.Command.ValidateCredentials(baseUrl, token))
-        }
-      }
-
-      is ModeSelectionAction.ValidationSucceeded -> {
-        // Capture credentials before clearing state
-        val wasManuallyEntered = state.baseUrl.isNotBlank() && state.token.isNotBlank()
-        val capturedBaseUrl = state.baseUrl.trim()
-        val capturedToken = state.token.trim()
-
-        state {
-          state.copy(
-            showCredentialsDialog = false,
-            isValidating = false,
-            baseUrl = "",
-            token = "",
-            error = null,
-          )
-        }
-        // Only save credentials if they were manually entered
-        if (wasManuallyEntered) {
-          command(ModeSelectionEffect.Command.SaveCredentials(capturedBaseUrl, capturedToken))
-        }
-        command(ModeSelectionEffect.Command.SaveMode(AppMode.ONLINE))
-        notify(ModeSelectionEffect.Notification.ModeSelected(AppMode.ONLINE))
-      }
-
-      is ModeSelectionAction.ValidationFailed -> {
-        state { state.copy(isValidating = false, error = ModeSelectionError.CONNECTION_FAILED) }
-      }
-
-      is ModeSelectionAction.SelectMode -> {
-        state { state.copy(showQuickOnlineDialog = false) }
-        command(ModeSelectionEffect.Command.SaveMode(action.mode))
-        notify(ModeSelectionEffect.Notification.ModeSelected(action.mode))
-      }
+      is ModeSelectionAction.StoredCredentials -> storedCredentialsReducer(action, state)
+      is ModeSelectionAction.QuickOnline -> quickOnlineReducer(action, state)
+      is ModeSelectionAction.Dialog -> dialogReducer(action, state)
+      is ModeSelectionAction.Input -> inputReducer(action, state)
+      is ModeSelectionAction.Validation -> validationReducer(action, state)
+      is ModeSelectionAction.Selection -> selectionReducer(action, state)
     }
   }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionSubReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionSubReducer.kt
@@ -1,0 +1,19 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val selectionReducer: Reducer<ModeSelectionAction.Selection, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.Selection.SelectMode -> {
+        state { state.copy(showQuickOnlineDialog = false) }
+        command(Command.SaveMode(action.mode))
+        notify(Notification.ModeSelected(action.mode))
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeStoredCredentialsReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeStoredCredentialsReducer.kt
@@ -1,0 +1,22 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val storedCredentialsReducer:
+  Reducer<ModeSelectionAction.StoredCredentials, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.StoredCredentials.Found -> {
+        state { state.copy(hasStoredCredentials = true, showQuickOnlineDialog = true) }
+      }
+
+      is ModeSelectionAction.StoredCredentials.NotFound -> {
+        state { state.copy(hasStoredCredentials = false) }
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
@@ -1,0 +1,51 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionError
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val validationReducer: Reducer<ModeSelectionAction.Validation, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.Validation.Submit -> {
+        val baseUrl = state.baseUrl.trim()
+        val token = state.token.trim()
+        if (baseUrl.isBlank() || token.isBlank()) {
+          state { state.copy(error = ModeSelectionError.FILL_ALL_FIELDS) }
+        } else {
+          state { state.copy(isValidating = true, error = null) }
+          command(Command.ValidateCredentials(baseUrl, token))
+        }
+      }
+
+      is ModeSelectionAction.Validation.Succeeded -> {
+        val wasManuallyEntered = state.baseUrl.isNotBlank() && state.token.isNotBlank()
+        val capturedBaseUrl = state.baseUrl.trim()
+        val capturedToken = state.token.trim()
+
+        state {
+          state.copy(
+            showCredentialsDialog = false,
+            isValidating = false,
+            baseUrl = "",
+            token = "",
+            error = null,
+          )
+        }
+        if (wasManuallyEntered) {
+          command(Command.SaveCredentials(capturedBaseUrl, capturedToken))
+        }
+        command(Command.SaveMode(AppMode.ONLINE))
+        notify(Notification.ModeSelected(AppMode.ONLINE))
+      }
+
+      is ModeSelectionAction.Validation.Failed -> {
+        state { state.copy(isValidating = false, error = ModeSelectionError.CONNECTION_FAILED) }
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/view/ModeSelectionScreen.kt
@@ -86,7 +86,7 @@ fun ModeSelectionScreen(
       title = stringResource(Res.string.mode_online_title),
       description = stringResource(Res.string.mode_online_desc),
       isPrimary = true,
-      onClick = { dispatch(ModeSelectionAction.ShowCredentialsDialog) },
+      onClick = { dispatch(ModeSelectionAction.Dialog.Show) },
     )
 
     Spacer(modifier = Modifier.height(Indent.m))
@@ -95,7 +95,7 @@ fun ModeSelectionScreen(
       title = stringResource(Res.string.mode_offline_title),
       description = stringResource(Res.string.mode_offline_desc),
       isPrimary = false,
-      onClick = { dispatch(ModeSelectionAction.SelectMode(AppMode.OFFLINE)) },
+      onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.OFFLINE)) },
     )
 
     Spacer(modifier = Modifier.height(Indent.m))
@@ -104,7 +104,7 @@ fun ModeSelectionScreen(
       title = stringResource(Res.string.mode_demo_title),
       description = stringResource(Res.string.mode_demo_desc),
       isPrimary = false,
-      onClick = { dispatch(ModeSelectionAction.SelectMode(AppMode.DEMO)) },
+      onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO)) },
     )
   }
 
@@ -129,12 +129,12 @@ private fun QuickOnlineDialog(
   dispatch: (ModeSelectionAction) -> Unit,
 ) {
   AlertDialog(
-    onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.DismissQuickOnlineDialog) },
+    onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.QuickOnline.Dismiss) },
     title = { Text(stringResource(Res.string.mode_quick_online_title)) },
     text = { Text(stringResource(Res.string.mode_quick_online_desc)) },
     confirmButton = {
       Button(
-        onClick = { dispatch(ModeSelectionAction.UseStoredCredentials) },
+        onClick = { dispatch(ModeSelectionAction.QuickOnline.UseStoredCredentials) },
         enabled = !state.isValidating,
       ) {
         if (state.isValidating) {
@@ -150,7 +150,7 @@ private fun QuickOnlineDialog(
     },
     dismissButton = {
       TextButton(
-        onClick = { dispatch(ModeSelectionAction.DismissQuickOnlineDialog) },
+        onClick = { dispatch(ModeSelectionAction.QuickOnline.Dismiss) },
         enabled = !state.isValidating,
       ) {
         Text(stringResource(Res.string.action_cancel))
@@ -173,13 +173,13 @@ private fun CredentialsSetupDialog(
     }
 
   AlertDialog(
-    onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.DismissCredentialsDialog) },
+    onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.Dialog.Dismiss) },
     title = { Text(stringResource(Res.string.mode_online_title)) },
     text = {
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
         TextField(
           value = state.baseUrl,
-          onValueChange = { dispatch(ModeSelectionAction.UpdateBaseUrl(it)) },
+          onValueChange = { dispatch(ModeSelectionAction.Input.UpdateBaseUrl(it)) },
           label = { Text(stringResource(Res.string.label_base_url)) },
           placeholder = { Text(stringResource(Res.string.hint_base_url)) },
           enabled = !state.isValidating,
@@ -188,7 +188,7 @@ private fun CredentialsSetupDialog(
         )
         TextField(
           value = state.token,
-          onValueChange = { dispatch(ModeSelectionAction.UpdateToken(it)) },
+          onValueChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
           label = { Text(stringResource(Res.string.label_access_token)) },
           visualTransformation = PasswordVisualTransformation(),
           enabled = !state.isValidating,
@@ -206,7 +206,7 @@ private fun CredentialsSetupDialog(
     },
     confirmButton = {
       Button(
-        onClick = { dispatch(ModeSelectionAction.Submit) },
+        onClick = { dispatch(ModeSelectionAction.Validation.Submit) },
         enabled = !state.isValidating,
       ) {
         if (state.isValidating) {
@@ -222,7 +222,7 @@ private fun CredentialsSetupDialog(
     },
     dismissButton = {
       TextButton(
-        onClick = { dispatch(ModeSelectionAction.DismissCredentialsDialog) },
+        onClick = { dispatch(ModeSelectionAction.Dialog.Dismiss) },
         enabled = !state.isValidating,
       ) {
         Text(stringResource(Res.string.action_cancel))

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -26,7 +26,7 @@ class ModeSelectionEffectHandlerTest {
           Command.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
         ).toList()
 
-      assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
+      assertEquals(listOf(ModeSelectionAction.Validation.Succeeded), actions)
     }
 
   @Test
@@ -39,7 +39,7 @@ class ModeSelectionEffectHandlerTest {
           Command.ValidateCredentials(baseUrl = "https://test.com", token = "token"),
         ).toList()
 
-      assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
+      assertEquals(listOf(ModeSelectionAction.Validation.Failed), actions)
     }
 
   @Test
@@ -83,7 +83,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.InitializeFromLocalConfig).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found), actions)
     }
 
   @Test
@@ -97,7 +97,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.InitializeFromLocalConfig).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound), actions)
     }
 
   @Test
@@ -115,7 +115,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.CheckStoredCredentials).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentialsFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found), actions)
     }
 
   @Test
@@ -126,7 +126,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.CheckStoredCredentials).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentialsNotFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound), actions)
     }
 
   @Test
@@ -144,7 +144,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.UseStoredCredentialsWithValidation).toList()
 
-      assertEquals(listOf(ModeSelectionAction.ValidationSucceeded), actions)
+      assertEquals(listOf(ModeSelectionAction.Validation.Succeeded), actions)
     }
 
   @Test
@@ -162,7 +162,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.UseStoredCredentialsWithValidation).toList()
 
-      assertEquals(listOf(ModeSelectionAction.ValidationFailed), actions)
+      assertEquals(listOf(ModeSelectionAction.Validation.Failed), actions)
     }
 
   private fun createHandler(

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -13,16 +13,16 @@ import kotlin.test.assertEquals
 
 class ModeSelectionReducerTest {
   @Test
-  fun `when ShowCredentialsDialog then shows dialog and clears error`() =
+  fun `when Dialog Show then shows dialog and clears error`() =
     modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
-      send(ModeSelectionAction.ShowCredentialsDialog)
+      send(ModeSelectionAction.Dialog.Show)
 
       assertState { showCredentialsDialog && error == null }
       assertNoEffects()
     }
 
   @Test
-  fun `when DismissCredentialsDialog then hides dialog and resets state`() =
+  fun `when Dialog Dismiss then hides dialog and resets state`() =
     modeSelectionReducer.test(
       ModeSelectionState(
         showCredentialsDialog = true,
@@ -32,7 +32,7 @@ class ModeSelectionReducerTest {
         error = ModeSelectionError.CONNECTION_FAILED,
       ),
     ) {
-      send(ModeSelectionAction.DismissCredentialsDialog)
+      send(ModeSelectionAction.Dialog.Dismiss)
 
       assertState {
         !showCredentialsDialog &&
@@ -45,54 +45,54 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when UpdateBaseUrl then updates baseUrl and clears error`() =
+  fun `when Input UpdateBaseUrl then updates baseUrl and clears error`() =
     modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
-      send(ModeSelectionAction.UpdateBaseUrl("https://new.api.com"))
+      send(ModeSelectionAction.Input.UpdateBaseUrl("https://new.api.com"))
 
       assertState { baseUrl == "https://new.api.com" && error == null }
       assertNoEffects()
     }
 
   @Test
-  fun `when UpdateToken then updates token and clears error`() =
+  fun `when Input UpdateToken then updates token and clears error`() =
     modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
-      send(ModeSelectionAction.UpdateToken("new-token"))
+      send(ModeSelectionAction.Input.UpdateToken("new-token"))
 
       assertState { token == "new-token" && error == null }
       assertNoEffects()
     }
 
   @Test
-  fun `when Submit with empty credentials then shows error`() =
+  fun `when Validation Submit with empty credentials then shows error`() =
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "", token = "")) {
-      send(ModeSelectionAction.Submit)
+      send(ModeSelectionAction.Validation.Submit)
 
       assertState { error == ModeSelectionError.FILL_ALL_FIELDS && !isValidating }
       assertNoEffects()
     }
 
   @Test
-  fun `when Submit with blank baseUrl then shows error`() =
+  fun `when Validation Submit with blank baseUrl then shows error`() =
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "  ", token = "token123")) {
-      send(ModeSelectionAction.Submit)
+      send(ModeSelectionAction.Validation.Submit)
 
       assertState { error == ModeSelectionError.FILL_ALL_FIELDS }
       assertNoEffects()
     }
 
   @Test
-  fun `when Submit with blank token then shows error`() =
+  fun `when Validation Submit with blank token then shows error`() =
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "https://api.com", token = "  ")) {
-      send(ModeSelectionAction.Submit)
+      send(ModeSelectionAction.Validation.Submit)
 
       assertState { error == ModeSelectionError.FILL_ALL_FIELDS }
       assertNoEffects()
     }
 
   @Test
-  fun `when Submit with valid credentials then starts validation`() =
+  fun `when Validation Submit with valid credentials then starts validation`() =
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "https://api.com", token = "token123")) {
-      send(ModeSelectionAction.Submit)
+      send(ModeSelectionAction.Validation.Submit)
 
       assertState { isValidating && error == null }
       val effect = assertHasCommand<Command.ValidateCredentials>()
@@ -101,14 +101,14 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when Submit then trims credentials before validation`() =
+  fun `when Validation Submit then trims credentials before validation`() =
     modeSelectionReducer.test(
       ModeSelectionState(
         baseUrl = "  https://api.com  ",
         token = "  token123  ",
       ),
     ) {
-      send(ModeSelectionAction.Submit)
+      send(ModeSelectionAction.Validation.Submit)
 
       val effect = assertHasCommand<Command.ValidateCredentials>()
       assertEquals("https://api.com", effect.baseUrl)
@@ -116,7 +116,7 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when ValidationSucceeded then closes dialog saves and notifies`() =
+  fun `when Validation Succeeded then closes dialog saves and notifies`() =
     modeSelectionReducer.test(
       ModeSelectionState(
         showCredentialsDialog = true,
@@ -125,7 +125,7 @@ class ModeSelectionReducerTest {
         isValidating = true,
       ),
     ) {
-      send(ModeSelectionAction.ValidationSucceeded)
+      send(ModeSelectionAction.Validation.Succeeded)
 
       assertState {
         !showCredentialsDialog &&
@@ -141,7 +141,7 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when ValidationSucceeded then saves trimmed credentials`() =
+  fun `when Validation Succeeded then saves trimmed credentials`() =
     modeSelectionReducer.test(
       ModeSelectionState(
         showCredentialsDialog = true,
@@ -150,7 +150,7 @@ class ModeSelectionReducerTest {
         isValidating = true,
       ),
     ) {
-      send(ModeSelectionAction.ValidationSucceeded)
+      send(ModeSelectionAction.Validation.Succeeded)
 
       val effect = assertHasCommand<Command.SaveCredentials>()
       assertEquals("https://api.com", effect.baseUrl)
@@ -158,9 +158,9 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when ValidationSucceeded then saves ONLINE mode`() =
+  fun `when Validation Succeeded then saves ONLINE mode`() =
     modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
-      send(ModeSelectionAction.ValidationSucceeded)
+      send(ModeSelectionAction.Validation.Succeeded)
 
       val effect = assertHasCommand<Command.SaveMode>()
       assertEquals(AppMode.ONLINE, effect.mode)
@@ -170,18 +170,18 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when ValidationFailed then stops validating and shows error`() =
+  fun `when Validation Failed then stops validating and shows error`() =
     modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
-      send(ModeSelectionAction.ValidationFailed)
+      send(ModeSelectionAction.Validation.Failed)
 
       assertState { !isValidating && error == ModeSelectionError.CONNECTION_FAILED }
       assertNoEffects()
     }
 
   @Test
-  fun `when SelectMode OFFLINE then saves and notifies`() =
+  fun `when Selection SelectMode OFFLINE then saves and notifies`() =
     modeSelectionReducer.test(ModeSelectionState()) {
-      send(ModeSelectionAction.SelectMode(AppMode.OFFLINE))
+      send(ModeSelectionAction.Selection.SelectMode(AppMode.OFFLINE))
 
       assertCommandCount(1)
       val effect = assertHasCommand<Command.SaveMode>()
@@ -192,9 +192,9 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when SelectMode DEMO then saves and notifies`() =
+  fun `when Selection SelectMode DEMO then saves and notifies`() =
     modeSelectionReducer.test(ModeSelectionState()) {
-      send(ModeSelectionAction.SelectMode(AppMode.DEMO))
+      send(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO))
 
       assertCommandCount(1)
       val effect = assertHasCommand<Command.SaveMode>()
@@ -205,45 +205,45 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when StoredCredentialsFound then sets flag and shows quick online dialog`() =
+  fun `when StoredCredentials Found then sets flag and shows quick online dialog`() =
     modeSelectionReducer.test(ModeSelectionState()) {
-      send(ModeSelectionAction.StoredCredentialsFound)
+      send(ModeSelectionAction.StoredCredentials.Found)
 
       assertState { hasStoredCredentials && showQuickOnlineDialog }
       assertNoEffects()
     }
 
   @Test
-  fun `when StoredCredentialsNotFound then clears flag`() =
+  fun `when StoredCredentials NotFound then clears flag`() =
     modeSelectionReducer.test(ModeSelectionState(hasStoredCredentials = true)) {
-      send(ModeSelectionAction.StoredCredentialsNotFound)
+      send(ModeSelectionAction.StoredCredentials.NotFound)
 
       assertState { !hasStoredCredentials }
       assertNoEffects()
     }
 
   @Test
-  fun `when DismissQuickOnlineDialog then hides dialog`() =
+  fun `when QuickOnline Dismiss then hides dialog`() =
     modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
-      send(ModeSelectionAction.DismissQuickOnlineDialog)
+      send(ModeSelectionAction.QuickOnline.Dismiss)
 
       assertState { !showQuickOnlineDialog }
       assertNoEffects()
     }
 
   @Test
-  fun `when UseStoredCredentials then closes dialog and starts validation`() =
+  fun `when QuickOnline UseStoredCredentials then closes dialog and starts validation`() =
     modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
-      send(ModeSelectionAction.UseStoredCredentials)
+      send(ModeSelectionAction.QuickOnline.UseStoredCredentials)
 
       assertState { !showQuickOnlineDialog && isValidating }
       assertCommands(Command.UseStoredCredentialsWithValidation)
     }
 
   @Test
-  fun `when ValidationSucceeded with empty state then does not save credentials`() =
+  fun `when Validation Succeeded with empty state then does not save credentials`() =
     modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
-      send(ModeSelectionAction.ValidationSucceeded)
+      send(ModeSelectionAction.Validation.Succeeded)
 
       assertState { !isValidating && baseUrl == "" && token == "" }
       assertCommandCount(1)
@@ -252,9 +252,9 @@ class ModeSelectionReducerTest {
     }
 
   @Test
-  fun `when SelectMode then closes quick online dialog`() =
+  fun `when Selection SelectMode then closes quick online dialog`() =
     modeSelectionReducer.test(ModeSelectionState(showQuickOnlineDialog = true)) {
-      send(ModeSelectionAction.SelectMode(AppMode.DEMO))
+      send(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO))
 
       assertState { !showQuickOnlineDialog }
       assertCommandCount(1)


### PR DESCRIPTION
## Summary

- Refactored `ModeSelectionReducer` from a monolithic ~100-line reducer to follow the sub-reducer pattern as per CLAUDE.md
- Grouped actions into 6 sealed subtypes: `StoredCredentials`, `QuickOnline`, `Dialog`, `Input`, `Validation`, `Selection`
- Created 6 focused sub-reducers (~15-30 lines each)

## Changes

- **ModeSelectionAction.kt**: Reorganized actions into 6 sealed interface groups
- **ModeSelectionReducer.kt**: Now delegates to sub-reducers via exhaustive `when` expression
- **New sub-reducer files**:
  - `ModeStoredCredentialsReducer.kt` - handles `StoredCredentials.Found`/`NotFound`
  - `ModeQuickOnlineReducer.kt` - handles `QuickOnline.Dismiss`/`UseStoredCredentials`
  - `ModeDialogReducer.kt` - handles `Dialog.Show`/`Dismiss`
  - `ModeInputReducer.kt` - handles `Input.UpdateBaseUrl`/`UpdateToken`
  - `ModeValidationReducer.kt` - handles `Validation.Submit`/`Succeeded`/`Failed`
  - `ModeSelectionSubReducer.kt` - handles `Selection.SelectMode`
- Updated `ModeSelectionScreen.kt` with new action names
- Updated `ModeSelectionCredentialsEffectHandler.kt` with new action names
- Updated all test files with new action names

## Test plan

- [x] `./gradlew checkJvm` passes
- [x] Mode presentation tests pass
- [x] All existing tests updated with new action names

🤖 Generated with [Claude Code](https://claude.com/claude-code)