### PR TITLE
Refactor AppReducer to follow sub-reducer pattern

### DIFF
--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/action/AppAction.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/action/AppAction.kt
@@ -11,50 +11,59 @@ import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
  * Actions for the App coordinator feature.
  */
 sealed interface AppAction : Action {
-  // Navigation
-  data class SelectScreen(
-    val screen: Screen,
-  ) : AppAction
+  /** Navigation actions. */
+  sealed interface Navigation : AppAction {
+    data class SelectScreen(
+      val screen: Screen,
+    ) : Navigation
+  }
 
-  data class SetHabitsTimeRangeTab(
-    val tab: TimeRangeTab,
-  ) : AppAction
+  /** Time range and date-related actions. */
+  sealed interface TimeRange : AppAction {
+    data class SetHabitsTab(
+      val tab: TimeRangeTab,
+    ) : TimeRange
 
-  data class SetPostsTimeRangeTab(
-    val tab: TimeRangeTab,
-  ) : AppAction
+    data class SetPostsTab(
+      val tab: TimeRangeTab,
+    ) : TimeRange
 
-  data class SetPeriodStartDate(
-    val date: LocalDate,
-  ) : AppAction
+    data class SetPeriodStartDate(
+      val date: LocalDate,
+    ) : TimeRange
 
-  data class SetActivityRange(
-    val range: ActivityRange,
-  ) : AppAction
+    data class SetActivityRange(
+      val range: ActivityRange,
+    ) : TimeRange
 
-  data class ChangeHabitsTab(
-    val oldTab: TimeRangeTab,
-    val newTab: TimeRangeTab,
-  ) : AppAction
+    data class ChangeHabitsTab(
+      val oldTab: TimeRangeTab,
+      val newTab: TimeRangeTab,
+    ) : TimeRange
 
-  data class ChangePostsTab(
-    val oldTab: TimeRangeTab,
-    val newTab: TimeRangeTab,
-  ) : AppAction
+    data class ChangePostsTab(
+      val oldTab: TimeRangeTab,
+      val newTab: TimeRangeTab,
+    ) : TimeRange
 
-  data class ResetToHome(
-    val today: LocalDate,
-  ) : AppAction
+    data class ResetToHome(
+      val today: LocalDate,
+    ) : TimeRange
+  }
 
-  // Mode
-  data class SetAppMode(
-    val mode: AppMode,
-  ) : AppAction
+  /** App mode actions. */
+  sealed interface Mode : AppAction {
+    data class SetAppMode(
+      val mode: AppMode,
+    ) : Mode
+  }
 
-  // UI state
-  data object MarkAutoLoaded : AppAction
+  /** UI state actions. */
+  sealed interface UI : AppAction {
+    data object MarkAutoLoaded : UI
 
-  data class SetPostsListExpanded(
-    val expanded: Boolean,
-  ) : AppAction
+    data class SetPostsListExpanded(
+      val expanded: Boolean,
+    ) : UI
+  }
 }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppModeReducer.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppModeReducer.kt
@@ -1,0 +1,16 @@
+package space.be1ski.vibits.feature.main.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.main.domain.model.AppState
+import space.be1ski.vibits.feature.main.presentation.action.AppAction
+import space.be1ski.vibits.feature.main.presentation.effect.AppEffect
+
+internal val modeReducer: Reducer<AppAction.Mode, AppState, AppEffect, Nothing> =
+  reducer { action, state ->
+    when (action) {
+      is AppAction.Mode.SetAppMode -> {
+        state { state.copy(appMode = action.mode) }
+      }
+    }
+  }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppNavigationReducer.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppNavigationReducer.kt
@@ -1,0 +1,16 @@
+package space.be1ski.vibits.feature.main.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.main.domain.model.AppState
+import space.be1ski.vibits.feature.main.presentation.action.AppAction
+import space.be1ski.vibits.feature.main.presentation.effect.AppEffect
+
+internal val navigationReducer: Reducer<AppAction.Navigation, AppState, AppEffect, Nothing> =
+  reducer { action, state ->
+    when (action) {
+      is AppAction.Navigation.SelectScreen -> {
+        state { state.copy(selectedScreen = action.screen) }
+      }
+    }
+  }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppReducer.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppReducer.kt
@@ -1,75 +1,20 @@
 package space.be1ski.vibits.feature.main.presentation.reducer
 
 import space.be1ski.vibits.core.elm.Reducer
-import space.be1ski.vibits.core.elm.reducer
 import space.be1ski.vibits.feature.main.domain.model.AppState
-import space.be1ski.vibits.feature.main.domain.model.Screen
-import space.be1ski.vibits.feature.main.domain.usecase.AdjustDateForTabChangeUseCase
-import space.be1ski.vibits.feature.main.domain.usecase.GetActivityRangeStartDateUseCase
 import space.be1ski.vibits.feature.main.presentation.action.AppAction
 import space.be1ski.vibits.feature.main.presentation.effect.AppEffect
-import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 
 /**
  * Pure reducer for the App coordinator feature.
+ * Delegates to sub-reducers based on action type.
  */
 internal val appReducer: Reducer<AppAction, AppState, AppEffect, Nothing> =
-  reducer { action, state ->
+  { action, state ->
     when (action) {
-      is AppAction.SelectScreen -> {
-        state { state.copy(selectedScreen = action.screen) }
-      }
-
-      is AppAction.SetHabitsTimeRangeTab -> {
-        state { state.copy(habitsTimeRangeTab = action.tab) }
-        command(AppEffect.SaveHabitsTimeRangeTab(action.tab))
-      }
-
-      is AppAction.SetPostsTimeRangeTab -> {
-        state { state.copy(postsTimeRangeTab = action.tab) }
-        command(AppEffect.SavePostsTimeRangeTab(action.tab))
-      }
-
-      is AppAction.SetPeriodStartDate -> {
-        state { state.copy(periodStartDate = action.date) }
-      }
-
-      is AppAction.SetActivityRange -> {
-        state { state.copy(periodStartDate = GetActivityRangeStartDateUseCase(action.range)) }
-      }
-
-      is AppAction.ChangeHabitsTab -> {
-        val adjustedDate = AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
-        state { state.copy(habitsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
-        command(AppEffect.SaveHabitsTimeRangeTab(action.newTab))
-      }
-
-      is AppAction.ChangePostsTab -> {
-        val adjustedDate = AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
-        state { state.copy(postsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
-        command(AppEffect.SavePostsTimeRangeTab(action.newTab))
-      }
-
-      is AppAction.ResetToHome -> {
-        state {
-          when (state.selectedScreen) {
-            Screen.HABITS -> state.copy(periodStartDate = action.today, habitsTimeRangeTab = TimeRangeTab.WEEKS)
-            Screen.STATS -> state.copy(periodStartDate = action.today, postsTimeRangeTab = TimeRangeTab.WEEKS)
-            Screen.FEED -> state.copy(periodStartDate = action.today)
-          }
-        }
-      }
-
-      is AppAction.SetAppMode -> {
-        state { state.copy(appMode = action.mode) }
-      }
-
-      is AppAction.MarkAutoLoaded -> {
-        state { state.copy(autoLoaded = true) }
-      }
-
-      is AppAction.SetPostsListExpanded -> {
-        state { state.copy(postsListExpanded = action.expanded) }
-      }
+      is AppAction.Navigation -> navigationReducer(action, state)
+      is AppAction.TimeRange -> timeRangeReducer(action, state)
+      is AppAction.Mode -> modeReducer(action, state)
+      is AppAction.UI -> uiReducer(action, state)
     }
   }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppTimeRangeReducer.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppTimeRangeReducer.kt
@@ -1,0 +1,60 @@
+package space.be1ski.vibits.feature.main.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.main.domain.model.AppState
+import space.be1ski.vibits.feature.main.domain.model.Screen
+import space.be1ski.vibits.feature.main.domain.usecase.AdjustDateForTabChangeUseCase
+import space.be1ski.vibits.feature.main.domain.usecase.GetActivityRangeStartDateUseCase
+import space.be1ski.vibits.feature.main.presentation.action.AppAction
+import space.be1ski.vibits.feature.main.presentation.effect.AppEffect
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
+
+internal val timeRangeReducer: Reducer<AppAction.TimeRange, AppState, AppEffect, Nothing> =
+  reducer { action, state ->
+    when (action) {
+      is AppAction.TimeRange.SetHabitsTab -> {
+        state { state.copy(habitsTimeRangeTab = action.tab) }
+        command(AppEffect.SaveHabitsTimeRangeTab(action.tab))
+      }
+
+      is AppAction.TimeRange.SetPostsTab -> {
+        state { state.copy(postsTimeRangeTab = action.tab) }
+        command(AppEffect.SavePostsTimeRangeTab(action.tab))
+      }
+
+      is AppAction.TimeRange.SetPeriodStartDate -> {
+        state { state.copy(periodStartDate = action.date) }
+      }
+
+      is AppAction.TimeRange.SetActivityRange -> {
+        state { state.copy(periodStartDate = GetActivityRangeStartDateUseCase(action.range)) }
+      }
+
+      is AppAction.TimeRange.ChangeHabitsTab -> {
+        val adjustedDate =
+          AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
+        state { state.copy(habitsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
+        command(AppEffect.SaveHabitsTimeRangeTab(action.newTab))
+      }
+
+      is AppAction.TimeRange.ChangePostsTab -> {
+        val adjustedDate =
+          AdjustDateForTabChangeUseCase(state.periodStartDate, action.oldTab, action.newTab)
+        state { state.copy(postsTimeRangeTab = action.newTab, periodStartDate = adjustedDate) }
+        command(AppEffect.SavePostsTimeRangeTab(action.newTab))
+      }
+
+      is AppAction.TimeRange.ResetToHome -> {
+        state {
+          when (state.selectedScreen) {
+            Screen.HABITS ->
+              state.copy(periodStartDate = action.today, habitsTimeRangeTab = TimeRangeTab.WEEKS)
+            Screen.STATS ->
+              state.copy(periodStartDate = action.today, postsTimeRangeTab = TimeRangeTab.WEEKS)
+            Screen.FEED -> state.copy(periodStartDate = action.today)
+          }
+        }
+      }
+    }
+  }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppUIReducer.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/presentation/reducer/AppUIReducer.kt
@@ -1,0 +1,20 @@
+package space.be1ski.vibits.feature.main.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.feature.main.domain.model.AppState
+import space.be1ski.vibits.feature.main.presentation.action.AppAction
+import space.be1ski.vibits.feature.main.presentation.effect.AppEffect
+
+internal val uiReducer: Reducer<AppAction.UI, AppState, AppEffect, Nothing> =
+  reducer { action, state ->
+    when (action) {
+      is AppAction.UI.MarkAutoLoaded -> {
+        state { state.copy(autoLoaded = true) }
+      }
+
+      is AppAction.UI.SetPostsListExpanded -> {
+        state { state.copy(postsListExpanded = action.expanded) }
+      }
+    }
+  }

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/FeatureCoordinator.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/FeatureCoordinator.kt
@@ -62,7 +62,7 @@ internal fun FeatureCoordinator(
         !memosState.isLoading &&
         (skipCredentialsCheck || memosState.hasCredentials)
     if (shouldAutoLoad) {
-      dispatchApp(AppAction.MarkAutoLoaded)
+      dispatchApp(AppAction.UI.MarkAutoLoaded)
       dispatchMemos(MemosAction.Loading.LoadMemos)
     }
   }
@@ -80,7 +80,7 @@ private fun handleNotification(
 ) {
   when (effect) {
     is SettingsEffect.Notification.ModeChanged -> {
-      dispatchApp(AppAction.SetAppMode(effect.newMode))
+      dispatchApp(AppAction.Mode.SetAppMode(effect.newMode))
       dispatchMemos(MemosAction.Loading.ResetForModeChange(effect.newMode))
       dispatchMemos(MemosAction.Loading.LoadMemos)
       dispatchHabits(HabitsAction.Cache.InvalidateAllCache)

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/ScaffoldCallbacks.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/ScaffoldCallbacks.kt
@@ -64,8 +64,8 @@ internal fun rememberScaffoldCallbacks(
       { newTab: TimeRangeTab ->
         onHabitsAction(HabitsAction.Selection.ClearSelection)
         when (appState.selectedScreen) {
-          Screen.HABITS -> onAppAction(AppAction.ChangeHabitsTab(appState.habitsTimeRangeTab, newTab))
-          Screen.STATS -> onAppAction(AppAction.ChangePostsTab(appState.postsTimeRangeTab, newTab))
+          Screen.HABITS -> onAppAction(AppAction.TimeRange.ChangeHabitsTab(appState.habitsTimeRangeTab, newTab))
+          Screen.STATS -> onAppAction(AppAction.TimeRange.ChangePostsTab(appState.postsTimeRangeTab, newTab))
           Screen.FEED -> {}
         }
       }
@@ -75,7 +75,7 @@ internal fun rememberScaffoldCallbacks(
       {
         val newRange = NavigateActivityRangeUseCase(activityRange, -1)
         onHabitsAction(HabitsAction.Selection.ClearSelection)
-        onAppAction(AppAction.SetActivityRange(newRange))
+        onAppAction(AppAction.TimeRange.SetActivityRange(newRange))
       }
     }
   val onNavigateForward =
@@ -83,7 +83,7 @@ internal fun rememberScaffoldCallbacks(
       {
         val newRange = NavigateActivityRangeUseCase(activityRange, 1)
         onHabitsAction(HabitsAction.Selection.ClearSelection)
-        onAppAction(AppAction.SetActivityRange(newRange))
+        onAppAction(AppAction.TimeRange.SetActivityRange(newRange))
       }
     }
   return ScaffoldCallbacks(

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/SwipeableContent.kt
@@ -149,7 +149,7 @@ private fun SwipeablePagerContent(
       val delta = page + minDelta
       val newRange = NavigateActivityRangeUseCase(currentRange, delta)
       if (newRange != currentActivityRange) {
-        onAppAction(AppAction.SetActivityRange(newRange))
+        onAppAction(AppAction.TimeRange.SetActivityRange(newRange))
         onHabitsAction(HabitsAction.Selection.ClearSelection)
       }
     }
@@ -216,7 +216,7 @@ private fun MemosTabContent(
         habitsState = habitsState,
         onHabitsAction = onHabitsAction,
         postsListExpanded = appState.postsListExpanded,
-        onPostsListExpandedChange = { onAppAction(AppAction.SetPostsListExpanded(it)) },
+        onPostsListExpandedChange = { onAppAction(AppAction.UI.SetPostsListExpanded(it)) },
       )
     Screen.FEED ->
       FeedScreen(

--- a/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/VibitsAppComponents.kt
+++ b/feature/main/src/commonMain/kotlin/space/be1ski/vibits/feature/main/view/VibitsAppComponents.kt
@@ -136,9 +136,9 @@ internal fun MemosBottomNavigation(
       onClick = {
         onClearSelection()
         if (appState.selectedScreen == Screen.HABITS) {
-          onAppAction(AppAction.ResetToHome(currentLocalDate()))
+          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
         } else {
-          onAppAction(AppAction.SelectScreen(Screen.HABITS))
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.HABITS))
         }
       },
       icon = {
@@ -154,9 +154,9 @@ internal fun MemosBottomNavigation(
       onClick = {
         onClearSelection()
         if (appState.selectedScreen == Screen.STATS) {
-          onAppAction(AppAction.ResetToHome(currentLocalDate()))
+          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
         } else {
-          onAppAction(AppAction.SelectScreen(Screen.STATS))
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.STATS))
         }
       },
       icon = {
@@ -174,7 +174,7 @@ internal fun MemosBottomNavigation(
         if (appState.selectedScreen == Screen.FEED) {
           onFeedScrollToTop()
         } else {
-          onAppAction(AppAction.SelectScreen(Screen.FEED))
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.FEED))
         }
       },
       icon = {

--- a/feature/main/src/commonTest/kotlin/space/be1ski/vibits/feature/main/presentation/AppReducerTest.kt
+++ b/feature/main/src/commonTest/kotlin/space/be1ski/vibits/feature/main/presentation/AppReducerTest.kt
@@ -1,4 +1,5 @@
 package space.be1ski.vibits.feature.main.presentation
+
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import space.be1ski.vibits.core.elm.test.test
@@ -17,18 +18,18 @@ class AppReducerTest {
   private val testDate = LocalDate(2024, Month.MARCH, 15)
 
   @Test
-  fun `when SelectScreen then updates selected screen`() =
+  fun `when Navigation SelectScreen then updates selected screen`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
-      send(AppAction.SelectScreen(Screen.STATS))
+      send(AppAction.Navigation.SelectScreen(Screen.STATS))
 
       assertState { selectedScreen == Screen.STATS }
       assertNoEffects()
     }
 
   @Test
-  fun `when SetHabitsTimeRangeTab then updates tab and emits save effect`() =
+  fun `when TimeRange SetHabitsTab then updates tab and emits save effect`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
-      send(AppAction.SetHabitsTimeRangeTab(TimeRangeTab.MONTHS))
+      send(AppAction.TimeRange.SetHabitsTab(TimeRangeTab.MONTHS))
 
       assertState { habitsTimeRangeTab == TimeRangeTab.MONTHS }
       val effect = assertHasCommand<AppEffect.SaveHabitsTimeRangeTab>()
@@ -36,9 +37,9 @@ class AppReducerTest {
     }
 
   @Test
-  fun `when SetPostsTimeRangeTab then updates tab and emits save effect`() =
+  fun `when TimeRange SetPostsTab then updates tab and emits save effect`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
-      send(AppAction.SetPostsTimeRangeTab(TimeRangeTab.QUARTERS))
+      send(AppAction.TimeRange.SetPostsTab(TimeRangeTab.QUARTERS))
 
       assertState { postsTimeRangeTab == TimeRangeTab.QUARTERS }
       val effect = assertHasCommand<AppEffect.SavePostsTimeRangeTab>()
@@ -46,47 +47,47 @@ class AppReducerTest {
     }
 
   @Test
-  fun `when SetPeriodStartDate then updates date`() =
+  fun `when TimeRange SetPeriodStartDate then updates date`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
       val newDate = LocalDate(2024, Month.JUNE, 1)
 
-      send(AppAction.SetPeriodStartDate(newDate))
+      send(AppAction.TimeRange.SetPeriodStartDate(newDate))
 
       assertState { periodStartDate == newDate }
       assertNoEffects()
     }
 
   @Test
-  fun `when SetActivityRange then updates period start date from range`() =
+  fun `when TimeRange SetActivityRange then updates period start date from range`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
       val range = ActivityRange.Month(2024, Month.JUNE)
 
-      send(AppAction.SetActivityRange(range))
+      send(AppAction.TimeRange.SetActivityRange(range))
 
       assertState { periodStartDate == LocalDate(2024, Month.JUNE, 1) }
       assertNoEffects()
     }
 
   @Test
-  fun `when ChangeHabitsTab then updates tab and adjusts date`() =
+  fun `when TimeRange ChangeHabitsTab then updates tab and adjusts date`() =
     appReducer.test(AppState(periodStartDate = testDate, habitsTimeRangeTab = TimeRangeTab.MONTHS)) {
-      send(AppAction.ChangeHabitsTab(oldTab = TimeRangeTab.MONTHS, newTab = TimeRangeTab.WEEKS))
+      send(AppAction.TimeRange.ChangeHabitsTab(oldTab = TimeRangeTab.MONTHS, newTab = TimeRangeTab.WEEKS))
 
       assertState { habitsTimeRangeTab == TimeRangeTab.WEEKS && periodStartDate == LocalDate(2024, Month.MARCH, 31) }
       assertHasCommand<AppEffect.SaveHabitsTimeRangeTab>()
     }
 
   @Test
-  fun `when ChangePostsTab then updates tab and adjusts date`() =
+  fun `when TimeRange ChangePostsTab then updates tab and adjusts date`() =
     appReducer.test(AppState(periodStartDate = testDate, postsTimeRangeTab = TimeRangeTab.YEARS)) {
-      send(AppAction.ChangePostsTab(oldTab = TimeRangeTab.YEARS, newTab = TimeRangeTab.QUARTERS))
+      send(AppAction.TimeRange.ChangePostsTab(oldTab = TimeRangeTab.YEARS, newTab = TimeRangeTab.QUARTERS))
 
       assertState { postsTimeRangeTab == TimeRangeTab.QUARTERS && periodStartDate == LocalDate(2024, Month.DECEMBER, 31) }
       assertHasCommand<AppEffect.SavePostsTimeRangeTab>()
     }
 
   @Test
-  fun `when ResetToHome on HABITS screen then resets date and tab`() =
+  fun `when TimeRange ResetToHome on HABITS screen then resets date and tab`() =
     appReducer.test(
       AppState(
         periodStartDate = testDate,
@@ -96,14 +97,14 @@ class AppReducerTest {
     ) {
       val today = LocalDate(2024, Month.JANUARY, 1)
 
-      send(AppAction.ResetToHome(today))
+      send(AppAction.TimeRange.ResetToHome(today))
 
       assertState { periodStartDate == today && habitsTimeRangeTab == TimeRangeTab.WEEKS }
       assertNoEffects()
     }
 
   @Test
-  fun `when ResetToHome on STATS screen then resets date and tab`() =
+  fun `when TimeRange ResetToHome on STATS screen then resets date and tab`() =
     appReducer.test(
       AppState(
         periodStartDate = testDate,
@@ -113,45 +114,45 @@ class AppReducerTest {
     ) {
       val today = LocalDate(2024, Month.JANUARY, 1)
 
-      send(AppAction.ResetToHome(today))
+      send(AppAction.TimeRange.ResetToHome(today))
 
       assertState { periodStartDate == today && postsTimeRangeTab == TimeRangeTab.WEEKS }
       assertNoEffects()
     }
 
   @Test
-  fun `when ResetToHome on FEED screen then resets only date`() =
+  fun `when TimeRange ResetToHome on FEED screen then resets only date`() =
     appReducer.test(AppState(periodStartDate = testDate, selectedScreen = Screen.FEED)) {
       val today = LocalDate(2024, Month.JANUARY, 1)
 
-      send(AppAction.ResetToHome(today))
+      send(AppAction.TimeRange.ResetToHome(today))
 
       assertState { periodStartDate == today }
       assertNoEffects()
     }
 
   @Test
-  fun `when SetAppMode then updates app mode`() =
+  fun `when Mode SetAppMode then updates app mode`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
-      send(AppAction.SetAppMode(AppMode.ONLINE))
+      send(AppAction.Mode.SetAppMode(AppMode.ONLINE))
 
       assertState { appMode == AppMode.ONLINE }
       assertNoEffects()
     }
 
   @Test
-  fun `when MarkAutoLoaded then sets autoLoaded to true`() =
+  fun `when UI MarkAutoLoaded then sets autoLoaded to true`() =
     appReducer.test(AppState(periodStartDate = testDate, autoLoaded = false)) {
-      send(AppAction.MarkAutoLoaded)
+      send(AppAction.UI.MarkAutoLoaded)
 
       assertState { autoLoaded }
       assertNoEffects()
     }
 
   @Test
-  fun `when SetPostsListExpanded then updates expanded state`() =
+  fun `when UI SetPostsListExpanded then updates expanded state`() =
     appReducer.test(AppState(periodStartDate = testDate, postsListExpanded = false)) {
-      send(AppAction.SetPostsListExpanded(true))
+      send(AppAction.UI.SetPostsListExpanded(true))
 
       assertState { postsListExpanded }
       assertNoEffects()


### PR DESCRIPTION
## Summary

- Refactored `AppReducer` from a monolithic ~75-line reducer to follow the sub-reducer pattern
- Grouped 11 actions into 4 sealed subtypes: `Navigation`, `TimeRange`, `Mode`, `UI`
- Created 4 focused sub-reducers

## Changes

- **AppAction.kt**: Reorganized actions into 4 sealed interface groups
- **AppReducer.kt**: Now delegates to sub-reducers via exhaustive `when` expression
- **New sub-reducer files**:
  - `AppNavigationReducer.kt` - handles `Navigation.SelectScreen`
  - `AppTimeRangeReducer.kt` - handles time range actions (SetHabitsTab, SetPostsTab, SetPeriodStartDate, SetActivityRange, ChangeHabitsTab, ChangePostsTab, ResetToHome)
  - `AppModeReducer.kt` - handles `Mode.SetAppMode`
  - `AppUIReducer.kt` - handles UI state actions (MarkAutoLoaded, SetPostsListExpanded)
- Updated view files with new action names
- Updated test file with new action names

## Test plan

- [x] `./gradlew checkJvm` passes
- [x] All existing tests updated with new action names

🤖 Generated with [Claude Code](https://claude.com/claude-code)