### PR TITLE
Move PrewarmResult to domain/model

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/PrewarmResult.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/PrewarmResult.kt
@@ -1,0 +1,15 @@
+package space.be1ski.vibits.feature.habits.domain.model
+
+import space.be1ski.vibits.core.platform.mode.AppMode
+
+/**
+ * Result from prewarming activity data for a specific range and mode.
+ */
+data class PrewarmResult(
+  val range: ActivityRange,
+  val mode: ActivityMode,
+  val appMode: AppMode,
+  val weekData: ActivityWeekData,
+  val configTimeline: List<HabitsConfigEntry>,
+  val successRate: SuccessRateData?,
+)

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/PrewarmActivityDataUseCase.kt
@@ -8,10 +8,7 @@ import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
-import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
-import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
+import space.be1ski.vibits.feature.habits.domain.model.PrewarmResult
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 class PrewarmActivityDataUseCase(
@@ -41,12 +38,3 @@ class PrewarmActivityDataUseCase(
     }
   }
 }
-
-data class PrewarmResult(
-  val range: ActivityRange,
-  val mode: ActivityMode,
-  val appMode: AppMode,
-  val weekData: ActivityWeekData,
-  val configTimeline: List<HabitsConfigEntry>,
-  val successRate: SuccessRateData?,
-)


### PR DESCRIPTION
## Summary
- Consistent with CachedActivityData refactor, moved PrewarmResult to domain/model

## Changes
- Created `PrewarmResult.kt` in `domain/model/`
- Removed inline definition from `PrewarmActivityDataUseCase`
- Updated imports

## Test plan
- [x] `checkJvm` passes