### PR TITLE
Move HabitsTypes.kt to domain/model

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitContentBuilder.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitContentBuilder.kt
@@ -3,6 +3,8 @@ package space.be1ski.vibits.feature.habits.domain
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.domain.model.HabitTag
+import space.be1ski.vibits.feature.habits.domain.model.IsSelected
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/HabitsTypes.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/HabitsTypes.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.feature.habits.domain
+package space.be1ski.vibits.feature.habits.domain.model
 
 typealias HabitTag = String
 typealias IsSelected = Boolean

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
@@ -1,13 +1,13 @@
 package space.be1ski.vibits.feature.habits.presentation.state
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.feature.habits.domain.HabitTag
-import space.be1ski.vibits.feature.habits.domain.IsSelected
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
 import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.domain.model.HabitTag
+import space.be1ski.vibits.feature.habits.domain.model.IsSelected
 import space.be1ski.vibits.feature.habits.domain.normalizeHabitTag
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 


### PR DESCRIPTION
## Summary
- Moved type aliases to domain/model for consistency with other domain types

## Changes
- Moved `HabitsTypes.kt` from `domain/` to `domain/model/`
- Updated imports in dependent files

## Test plan
- [x] `checkJvm` passes