### PR TITLE
Move SaveDailyMemoResult to domain/model

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SaveDailyMemoResult.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SaveDailyMemoResult.kt
@@ -1,0 +1,25 @@
+package space.be1ski.vibits.feature.habits.domain.model
+
+import space.be1ski.vibits.feature.memos.domain.model.Memo
+
+/**
+ * Result of saving a daily habit memo.
+ */
+sealed interface SaveDailyMemoResult {
+  data class Created(
+    val memo: Memo,
+  ) : SaveDailyMemoResult
+
+  data class Updated(
+    val memo: Memo,
+  ) : SaveDailyMemoResult
+
+  data class Deleted(
+    val memoName: String,
+  ) : SaveDailyMemoResult
+
+  data class Error(
+    val message: String,
+    val exception: Throwable? = null,
+  ) : SaveDailyMemoResult
+}

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
@@ -11,32 +11,10 @@ import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.extractCompletedHabits
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
-import space.be1ski.vibits.feature.memos.domain.model.Memo
+import space.be1ski.vibits.feature.habits.domain.model.SaveDailyMemoResult
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 
 private const val TAG = "SaveDailyHabitMemo"
-
-/**
- * Result of saving a daily habit memo.
- */
-sealed interface SaveDailyMemoResult {
-  data class Created(
-    val memo: Memo,
-  ) : SaveDailyMemoResult
-
-  data class Updated(
-    val memo: Memo,
-  ) : SaveDailyMemoResult
-
-  data class Deleted(
-    val memoName: String,
-  ) : SaveDailyMemoResult
-
-  data class Error(
-    val message: String,
-    val exception: Throwable? = null,
-  ) : SaveDailyMemoResult
-}
 
 /**
  * Atomically saves a daily habit memo, preventing race conditions when

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.domain.model.SaveDailyMemoResult
 import space.be1ski.vibits.feature.main.test.FakeMemosRepository
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
@@ -4,8 +4,8 @@ import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
 import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.feature.habits.domain.model.SaveDailyMemoResult
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
-import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyMemoResult
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.memos.domain.model.isConfigTag
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository


### PR DESCRIPTION
## Summary
- Move `SaveDailyMemoResult` sealed interface from inline definition in `SaveDailyHabitMemoUseCase` to `domain/model` package
- Update imports in `HabitsMemoEffectHandler` and test file

## Changes
- Created `SaveDailyMemoResult.kt` in `domain/model/`
- Removed inline definition from `SaveDailyHabitMemoUseCase.kt`
- Updated import paths in presentation and test layers

## Test plan
- [x] Build passes
- [x] Existing tests pass