### PR TITLE
Decompose AppRoot into focused files

### DIFF
--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -1,0 +1,124 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.homescreen.di.AppDependencies
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.mode.presentation.view.ModeSelectionScreen
+import space.be1ski.vibits.feature.onboarding.presentation.view.OnboardingScreen
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+
+@Composable
+internal fun SyncAppMode(
+  featuresState: FeaturesState,
+  currentAppMode: AppMode,
+  onModeUpdated: (AppMode) -> Unit,
+) {
+  val appState by featuresState.app.app.state
+    .collectAsState()
+  LaunchedEffect(appState.appMode) {
+    if (appState.appMode != AppMode.NOT_SELECTED && appState.appMode != currentAppMode) {
+      onModeUpdated(appState.appMode)
+    }
+  }
+}
+
+@Composable
+internal fun ObserveOnboardingCheck(
+  appMode: AppMode,
+  dependencies: AppDependencies,
+  onShowOnboarding: (Boolean) -> Unit,
+) {
+  LaunchedEffect(appMode) {
+    if (appMode == AppMode.OFFLINE) {
+      onShowOnboarding(dependencies.shouldShowOnboarding())
+    } else {
+      onShowOnboarding(false)
+    }
+  }
+}
+
+@Suppress("LongParameterList")
+@Composable
+internal fun AppContent(
+  appMode: AppMode,
+  showOnboarding: Boolean,
+  featuresState: FeaturesState,
+  appTheme: AppTheme,
+  appLanguage: AppLanguage,
+  onResetApp: () -> Unit,
+  onThemeChanged: (AppTheme) -> Unit,
+  onLanguageChanged: (AppLanguage) -> Unit,
+) {
+  when {
+    appMode == AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = featuresState.modeSelection)
+    appMode == AppMode.OFFLINE && showOnboarding -> {
+      val onboardingState by featuresState.onboarding.state.collectAsState()
+      OnboardingScreen(
+        state = onboardingState,
+        onAction = featuresState.onboarding::send,
+      )
+    }
+    appMode == AppMode.ONLINE || appMode == AppMode.OFFLINE || appMode == AppMode.DEMO -> {
+      AppWithLoadingScreen(
+        features = featuresState.app,
+        appTheme = appTheme,
+        appLanguage = appLanguage,
+        onResetApp = onResetApp,
+        onThemeChanged = onThemeChanged,
+        onLanguageChanged = onLanguageChanged,
+      )
+    }
+  }
+}
+
+@Composable
+private fun AppWithLoadingScreen(
+  features: AppFeatures,
+  appTheme: AppTheme,
+  appLanguage: AppLanguage,
+  onResetApp: () -> Unit,
+  onThemeChanged: (AppTheme) -> Unit,
+  onLanguageChanged: (AppLanguage) -> Unit,
+) {
+  val memosState by features.memos.state.collectAsState()
+
+  if (!memosState.initialDataLoaded) {
+    LoadingScreen()
+  } else {
+    VibitsApp(
+      features = features,
+      currentTheme = appTheme,
+      currentLanguage = appLanguage,
+      onResetApp = onResetApp,
+      onThemeChanged = onThemeChanged,
+      onLanguageChanged = onLanguageChanged,
+    )
+  }
+}
+
+@Composable
+private fun LoadingScreen() {
+  Surface(
+    modifier = Modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background,
+  ) {
+    Box(
+      modifier = Modifier.fillMaxSize(),
+      contentAlignment = Alignment.Center,
+    ) {
+      CircularProgressIndicator()
+    }
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -1,43 +1,18 @@
-@file:Suppress("TooManyFunctions")
-
 package space.be1ski.vibits.feature.homescreen.presentation.view
 
-import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.CircularProgressIndicator
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
-import androidx.compose.ui.Modifier
-import space.be1ski.vibits.core.elm.Feature
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
 import space.be1ski.vibits.core.ui.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
-import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
-import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
-import space.be1ski.vibits.feature.mode.di.createModeSelectionFeature
-import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
-import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
-import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
-import space.be1ski.vibits.feature.mode.presentation.view.ModeSelectionScreen
-import space.be1ski.vibits.feature.onboarding.di.createOnboardingFeature
-import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction
-import space.be1ski.vibits.feature.onboarding.presentation.effect.OnboardingEffect
-import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
-import space.be1ski.vibits.feature.onboarding.presentation.view.OnboardingScreen
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 @Composable
@@ -75,14 +50,14 @@ fun AppRoot(dependencies: AppDependencies) {
         appTheme = appTheme,
         appLanguage = appLanguage,
         onResetApp = {
-          createResetAppCallback(
+          resetApp(
             dependencies = dependencies,
             onThemeReset = { appTheme = AppTheme.SYSTEM },
             onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
             onVersionIncrement = { featuresVersion++ },
             onModeReset = { appMode = AppMode.NOT_SELECTED },
             onOnboardingReset = { showOnboarding = false },
-          )()
+          )
         },
         onThemeChanged = { appTheme = it },
         onLanguageChanged = {
@@ -95,133 +70,6 @@ fun AppRoot(dependencies: AppDependencies) {
 }
 
 @Composable
-private fun SyncAppMode(
-  featuresState: FeaturesState,
-  currentAppMode: AppMode,
-  onModeUpdated: (AppMode) -> Unit,
-) {
-  val appState by featuresState.app.app.state
-    .collectAsState()
-  LaunchedEffect(appState.appMode) {
-    if (appState.appMode != AppMode.NOT_SELECTED && appState.appMode != currentAppMode) {
-      onModeUpdated(appState.appMode)
-    }
-  }
-}
-
-@Composable
-private fun ObserveOnboardingCheck(
-  appMode: AppMode,
-  dependencies: AppDependencies,
-  onShowOnboarding: (Boolean) -> Unit,
-) {
-  LaunchedEffect(appMode) {
-    if (appMode == AppMode.OFFLINE) {
-      onShowOnboarding(dependencies.shouldShowOnboarding())
-    } else {
-      onShowOnboarding(false)
-    }
-  }
-}
-
-@Composable
-private fun AppWithLoadingScreen(
-  features: AppFeatures,
-  appTheme: AppTheme,
-  appLanguage: AppLanguage,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
-) {
-  val memosState by features.memos.state.collectAsState()
-
-  if (!memosState.initialDataLoaded) {
-    // Show loading screen while initial data is loading
-    LoadingScreen()
-  } else {
-    VibitsApp(
-      features = features,
-      currentTheme = appTheme,
-      currentLanguage = appLanguage,
-      onResetApp = onResetApp,
-      onThemeChanged = onThemeChanged,
-      onLanguageChanged = onLanguageChanged,
-    )
-  }
-}
-
-@Composable
-private fun LoadingScreen() {
-  Surface(
-    modifier = Modifier.fillMaxSize(),
-    color = MaterialTheme.colorScheme.background,
-  ) {
-    Box(
-      modifier = Modifier.fillMaxSize(),
-      contentAlignment = Alignment.Center,
-    ) {
-      CircularProgressIndicator()
-    }
-  }
-}
-
-@Composable
-private fun rememberAppFeatures(version: Int): AppFeatures =
-  remember(version) {
-    val factory = AppGraph.getFeaturesFactory()
-    val scope = AppGraph.getAppScope()
-    factory.create(scope)
-  }
-
-@Composable
-private fun rememberModeSelectionFeature(
-  dependencies: AppDependencies,
-  onModeSelected: (AppMode) -> Unit,
-): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> {
-  val feature =
-    remember {
-      createModeSelectionFeature(dependencies = dependencies.modeSelectionDependencies)
-    }
-  val scope = rememberCoroutineScope()
-  LaunchedEffect(feature) { feature.launchIn(scope) }
-  LaunchedEffect(feature) {
-    feature.notifications.collect { notification ->
-      when (notification) {
-        is ModeSelectionEffect.Notification.ModeSelected -> onModeSelected(notification.mode)
-      }
-    }
-  }
-  return feature
-}
-
-@Composable
-private fun rememberOnboardingFeature(
-  dependencies: AppDependencies,
-  features: AppFeatures,
-  onOnboardingCompleted: () -> Unit,
-): Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification> {
-  val feature =
-    remember {
-      createOnboardingFeature(dependencies = dependencies.onboardingDependencies)
-    }
-  val scope = rememberCoroutineScope()
-  LaunchedEffect(feature) { feature.launchIn(scope) }
-  LaunchedEffect(feature) {
-    feature.notifications.collect { notification ->
-      when (notification) {
-        is OnboardingEffect.Notification.Completed,
-        is OnboardingEffect.Notification.Skipped,
-        -> onOnboardingCompleted()
-        is OnboardingEffect.Notification.FirstCheckInCreated -> {
-          features.memos.send(MemosAction.Loading.LoadMemos)
-        }
-      }
-    }
-  }
-  return feature
-}
-
-@Composable
 private fun resolveDarkTheme(theme: AppTheme): Boolean {
   val systemDarkTheme = rememberSystemDarkTheme()
   return when (theme) {
@@ -231,81 +79,20 @@ private fun resolveDarkTheme(theme: AppTheme): Boolean {
   }
 }
 
-private data class FeaturesState(
-  val modeSelection: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification>,
-  val onboarding: Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification>,
-  val app: AppFeatures,
-)
-
-@Composable
-private fun rememberFeaturesState(
-  dependencies: AppDependencies,
-  featuresVersion: Int,
-  onModeSelected: (AppMode) -> Unit,
-  onOnboardingCompleted: () -> Unit,
-): FeaturesState {
-  val modeSelectionFeature =
-    key(featuresVersion) {
-      rememberModeSelectionFeature(dependencies, onModeSelected)
-    }
-  val appFeatures = rememberAppFeatures(featuresVersion)
-  val onboardingFeature =
-    key(featuresVersion) {
-      rememberOnboardingFeature(dependencies, appFeatures, onOnboardingCompleted)
-    }
-
-  return FeaturesState(modeSelectionFeature, onboardingFeature, appFeatures)
-}
-
 @Suppress("LongParameterList")
-@Composable
-private fun AppContent(
-  appMode: AppMode,
-  showOnboarding: Boolean,
-  featuresState: FeaturesState,
-  appTheme: AppTheme,
-  appLanguage: AppLanguage,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
-) {
-  when {
-    appMode == AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = featuresState.modeSelection)
-    appMode == AppMode.OFFLINE && showOnboarding -> {
-      val onboardingState by featuresState.onboarding.state.collectAsState()
-      OnboardingScreen(
-        state = onboardingState,
-        onAction = featuresState.onboarding::send,
-      )
-    }
-    appMode == AppMode.ONLINE || appMode == AppMode.OFFLINE || appMode == AppMode.DEMO -> {
-      AppWithLoadingScreen(
-        features = featuresState.app,
-        appTheme = appTheme,
-        appLanguage = appLanguage,
-        onResetApp = onResetApp,
-        onThemeChanged = onThemeChanged,
-        onLanguageChanged = onLanguageChanged,
-      )
-    }
-  }
-}
-
-@Suppress("LongParameterList")
-private fun createResetAppCallback(
+private fun resetApp(
   dependencies: AppDependencies,
   onThemeReset: () -> Unit,
   onLanguageReset: () -> Unit,
   onVersionIncrement: () -> Unit,
   onModeReset: () -> Unit,
   onOnboardingReset: () -> Unit,
-): () -> Unit =
-  {
-    onThemeReset()
-    onLanguageReset()
-    dependencies.localeProvider.configureLocale(AppLanguage.SYSTEM)
-    AppGraph.resetGraph()
-    onVersionIncrement()
-    onModeReset()
-    onOnboardingReset()
-  }
+) {
+  onThemeReset()
+  onLanguageReset()
+  dependencies.localeProvider.configureLocale(AppLanguage.SYSTEM)
+  AppGraph.resetGraph()
+  onVersionIncrement()
+  onModeReset()
+  onOnboardingReset()
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeaturesState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeaturesState.kt
@@ -1,0 +1,103 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import space.be1ski.vibits.core.elm.Feature
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.homescreen.di.AppDependencies
+import space.be1ski.vibits.feature.homescreen.di.AppGraph
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.mode.di.createModeSelectionFeature
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+import space.be1ski.vibits.feature.onboarding.di.createOnboardingFeature
+import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction
+import space.be1ski.vibits.feature.onboarding.presentation.effect.OnboardingEffect
+import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
+
+internal data class FeaturesState(
+  val modeSelection: Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification>,
+  val onboarding: Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification>,
+  val app: AppFeatures,
+)
+
+@Composable
+internal fun rememberFeaturesState(
+  dependencies: AppDependencies,
+  featuresVersion: Int,
+  onModeSelected: (AppMode) -> Unit,
+  onOnboardingCompleted: () -> Unit,
+): FeaturesState {
+  val modeSelectionFeature =
+    key(featuresVersion) {
+      rememberModeSelectionFeature(dependencies, onModeSelected)
+    }
+  val appFeatures = rememberAppFeatures(featuresVersion)
+  val onboardingFeature =
+    key(featuresVersion) {
+      rememberOnboardingFeature(dependencies, appFeatures, onOnboardingCompleted)
+    }
+
+  return FeaturesState(modeSelectionFeature, onboardingFeature, appFeatures)
+}
+
+@Composable
+private fun rememberAppFeatures(version: Int): AppFeatures =
+  remember(version) {
+    val factory = AppGraph.getFeaturesFactory()
+    val scope = AppGraph.getAppScope()
+    factory.create(scope)
+  }
+
+@Composable
+private fun rememberModeSelectionFeature(
+  dependencies: AppDependencies,
+  onModeSelected: (AppMode) -> Unit,
+): Feature<ModeSelectionAction, ModeSelectionState, ModeSelectionEffect.Command, ModeSelectionEffect.Notification> {
+  val feature =
+    remember {
+      createModeSelectionFeature(dependencies = dependencies.modeSelectionDependencies)
+    }
+  val scope = rememberCoroutineScope()
+  LaunchedEffect(feature) { feature.launchIn(scope) }
+  LaunchedEffect(feature) {
+    feature.notifications.collect { notification ->
+      when (notification) {
+        is ModeSelectionEffect.Notification.ModeSelected -> onModeSelected(notification.mode)
+      }
+    }
+  }
+  return feature
+}
+
+@Composable
+private fun rememberOnboardingFeature(
+  dependencies: AppDependencies,
+  features: AppFeatures,
+  onOnboardingCompleted: () -> Unit,
+): Feature<OnboardingAction, OnboardingState, OnboardingEffect.Command, OnboardingEffect.Notification> {
+  val feature =
+    remember {
+      createOnboardingFeature(dependencies = dependencies.onboardingDependencies)
+    }
+  val scope = rememberCoroutineScope()
+  LaunchedEffect(feature) { feature.launchIn(scope) }
+  LaunchedEffect(feature) {
+    feature.notifications.collect { notification ->
+      when (notification) {
+        is OnboardingEffect.Notification.Completed,
+        is OnboardingEffect.Notification.Skipped,
+        -> onOnboardingCompleted()
+        is OnboardingEffect.Notification.FirstCheckInCreated -> {
+          features.memos.send(MemosAction.Loading.LoadMemos)
+        }
+      }
+    }
+  }
+  return feature
+}


### PR DESCRIPTION
## Summary
- Split monolithic `AppRoot.kt` (312 lines, 10+ functions) into three focused files
- Removes `@file:Suppress("TooManyFunctions")` suppression

## Changes
- **`AppRoot.kt`** (97 lines): Entry point composable + theme resolution and reset helpers
- **`AppContent.kt`**: Content routing (`AppContent`, `AppWithLoadingScreen`, `LoadingScreen`), mode sync (`SyncAppMode`), onboarding check (`ObserveOnboardingCheck`)
- **`FeaturesState.kt`**: Feature lifecycle management (`FeaturesState`, `rememberFeaturesState`, `rememberAppFeatures`, `rememberModeSelectionFeature`, `rememberOnboardingFeature`)
- Simplified `createResetAppCallback` (returned a lambda) into direct `resetApp` function

## Test plan
- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, tests)
- [x] No behavioral changes — pure file decomposition

🤖 Generated with [Claude Code](https://claude.com/claude-code)