### PR TITLE
Remove meaningless suffixes from habits domain models

### DIFF
--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummary.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummary.kt
@@ -6,7 +6,7 @@ import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 /**
  * Fully prepared dataset for activity charts.
  */
-data class ActivityWeekData(
+data class ActivitySummary(
   /** Ordered list of week entries. */
   val weeks: List<ActivityWeek>,
   /** Maximum posts for a single day in range. */
@@ -18,7 +18,7 @@ data class ActivityWeekData(
 /**
  * Returns the last 7 in-range days.
  */
-fun ActivityWeekData.lastSevenDays(): List<ContributionDay> {
+fun ActivitySummary.lastSevenDays(): List<ContributionDay> {
   val days = weeks.flatMap { it.days }.filter { it.inRange }
   return days.takeLast(DAYS_IN_WEEK)
 }
@@ -26,7 +26,7 @@ fun ActivityWeekData.lastSevenDays(): List<ContributionDay> {
 /**
  * Finds a contribution day by date.
  */
-fun ActivityWeekData.findDayByDate(date: LocalDate): ContributionDay? =
+fun ActivitySummary.findDayByDate(date: LocalDate): ContributionDay? =
   weeks.firstNotNullOfOrNull { week ->
     week.days.firstOrNull { it.date == date }
   }
@@ -34,7 +34,7 @@ fun ActivityWeekData.findDayByDate(date: LocalDate): ContributionDay? =
 /**
  * Filters activity data for a single habit.
  */
-fun ActivityWeekData.forHabit(habit: HabitConfig): ActivityWeekData {
+fun ActivitySummary.forHabit(habit: HabitConfig): ActivitySummary {
   val filteredWeeks =
     weeks.map { week ->
       val days =
@@ -66,5 +66,5 @@ fun ActivityWeekData.forHabit(habit: HabitConfig): ActivityWeekData {
     }
   val newMaxDaily = filteredWeeks.maxOfOrNull { week -> week.days.maxOfOrNull { it.count } ?: 0 } ?: 0
   val newMaxWeekly = filteredWeeks.maxOfOrNull { it.weeklyCount } ?: 0
-  return ActivityWeekData(weeks = filteredWeeks, maxDaily = newMaxDaily, maxWeekly = newMaxWeekly)
+  return ActivitySummary(weeks = filteredWeeks, maxDaily = newMaxDaily, maxWeekly = newMaxWeekly)
 }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/CachedActivity.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/CachedActivity.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.habits.domain.model
 /**
  * Cached activity data for a specific range and mode.
  */
-data class CachedActivityData(
-  val weekData: ActivityWeekData,
+data class CachedActivity(
+  val weekData: ActivitySummary,
   val configTimeline: List<HabitsConfigEntry>,
-  val successRate: SuccessRateData?,
+  val successRate: SuccessRate?,
 )

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ContributionDay.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ContributionDay.kt
@@ -17,7 +17,7 @@ data class ContributionDay(
   /** Parsed habit status list for the day. */
   val habitStatuses: List<HabitStatus>,
   /** Daily memo information when available. */
-  val dailyMemo: DailyMemoInfo?,
+  val dailyMemo: DailyMemo?,
   /** True if the day is within the requested range. */
   val inRange: Boolean,
   /** True if the day can be clicked to toggle habits (not future, not before config). */

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DailyMemo.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DailyMemo.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.domain.model
 /**
  * Daily memo metadata for editing.
  */
-data class DailyMemoInfo(
+data class DailyMemo(
   /** Memo resource name. */
   val name: String,
   /** Memo content. */

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DayBuildContext.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DayBuildContext.kt
@@ -11,7 +11,7 @@ data class DayBuildContext(
   val bounds: RangeBounds,
   val mode: ActivityMode,
   val configTimeline: List<HabitsConfigEntry>,
-  val dailyMemos: Map<LocalDate, DailyMemoInfo>,
+  val dailyMemos: Map<LocalDate, DailyMemo>,
   val counts: Map<LocalDate, Int>,
   val today: LocalDate,
 )

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/PrewarmResult.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/PrewarmResult.kt
@@ -9,7 +9,7 @@ data class PrewarmResult(
   val range: ActivityRange,
   val mode: ActivityMode,
   val appMode: AppMode,
-  val weekData: ActivityWeekData,
+  val weekData: ActivitySummary,
   val configTimeline: List<HabitsConfigEntry>,
-  val successRate: SuccessRateData?,
+  val successRate: SuccessRate?,
 )

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SuccessRate.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SuccessRate.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.domain.model
 /**
  * Success rate calculation result.
  */
-data class SuccessRateData(
+data class SuccessRate(
   val completed: Int,
   val total: Int,
   val rate: Float,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -9,9 +9,9 @@ import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -24,18 +24,18 @@ class BuildActivityDataUseCase(
   private val buildDayDataUseCase: BuildDayDataUseCase,
 ) {
   /**
-   * Builds ActivityWeekData for a given range.
+   * Builds ActivitySummary for a given range.
    */
   @Suppress("LongParameterList")
   fun buildWeekData(
     configTimeline: List<HabitsConfigEntry>,
-    dailyMemos: Map<LocalDate, DailyMemoInfo>,
+    dailyMemos: Map<LocalDate, DailyMemo>,
     timeZone: TimeZone,
     memos: List<Memo>,
     range: ActivityRange,
     mode: ActivityMode,
     today: LocalDate,
-  ): ActivityWeekData {
+  ): ActivitySummary {
     val bounds = GetRangeBoundsUseCase(range)
     val effectiveConfigTimeline = if (mode == ActivityMode.HABITS) configTimeline else emptyList()
     val counts =
@@ -70,6 +70,6 @@ class BuildActivityDataUseCase(
     }
     val maxDaily = weeks.maxOfOrNull { week -> week.days.maxOfOrNull { it.count } ?: 0 } ?: 0
     val maxWeekly = weeks.maxOfOrNull { it.weeklyCount } ?: 0
-    return ActivityWeekData(weeks = weeks, maxDaily = maxDaily, maxWeekly = maxWeekly)
+    return ActivitySummary(weeks = weeks, maxDaily = maxDaily, maxWeekly = maxWeekly)
   }
 }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
@@ -5,7 +5,7 @@ import space.be1ski.vibits.feature.habits.domain.buildHabitStatuses
 import space.be1ski.vibits.feature.habits.domain.extractHabitTagsFromContent
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
@@ -47,7 +47,7 @@ class BuildDayDataUseCase {
 
   private fun buildHabitSelectionState(
     context: DayBuildContext,
-    dailyMemo: DailyMemoInfo?,
+    dailyMemo: DailyMemo?,
     habitsForDay: List<HabitConfig>,
   ): HabitSelectionState {
     val useHabits = context.mode == ActivityMode.HABITS && habitsForDay.isNotEmpty()

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCase.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.buildHabitStatuses
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 
 /**
@@ -13,7 +13,7 @@ object BuildHabitDayUseCase {
   operator fun invoke(
     date: LocalDate,
     habitsConfig: List<HabitConfig>,
-    dailyMemo: DailyMemoInfo?,
+    dailyMemo: DailyMemo?,
   ): ContributionDay? {
     if (habitsConfig.isEmpty()) {
       return null

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityDataUseCase.kt
@@ -5,7 +5,7 @@ import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 @Inject
@@ -16,7 +16,7 @@ class CalculateActivityDataUseCase(
     range: ActivityRange,
     mode: ActivityMode,
     memos: List<Memo>,
-  ): CachedActivityData {
+  ): CachedActivity {
     val timeZone = TimeZone.currentSystemDefault()
     val today = currentLocalDate()
     val configTimeline = ExtractHabitsConfigUseCase(memos, timeZone)
@@ -39,7 +39,7 @@ class CalculateActivityDataUseCase(
         null
       }
 
-    return CachedActivityData(
+    return CachedActivity(
       weekData = weekData,
       configTimeline = configTimeline,
       successRate = successRate,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
@@ -2,19 +2,19 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
+import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
 
 /**
  * Calculates success rate for habits within a given time range.
  */
 object CalculateSuccessRateUseCase {
   operator fun invoke(
-    weekData: ActivityWeekData,
+    weekData: ActivitySummary,
     range: ActivityRange,
     today: LocalDate,
     configStartDate: LocalDate? = null,
-  ): SuccessRateData {
+  ): SuccessRate {
     val bounds = GetRangeBoundsUseCase(range)
     val effectiveStart =
       if (configStartDate != null && configStartDate > bounds.start) {
@@ -33,6 +33,6 @@ object CalculateSuccessRateUseCase {
     val total = days.sumOf { it.totalHabits }
     val rate = if (total > 0) completed.toFloat() / total else 0f
 
-    return SuccessRateData(completed, total, rate)
+    return SuccessRate(completed, total, rate)
   }
 }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.model.isDailyMemo
 
@@ -14,7 +14,7 @@ object ExtractDailyMemosUseCase {
   operator fun invoke(
     memos: List<Memo>,
     timeZone: TimeZone,
-  ): Map<LocalDate, DailyMemoInfo> {
+  ): Map<LocalDate, DailyMemo> {
     val dailyMemos =
       memos.filter { memo ->
         memo.content.isDailyMemo()
@@ -26,7 +26,7 @@ object ExtractDailyMemosUseCase {
             ?: parseMemoDate(memo, timeZone)
             ?: return@mapNotNull null
         date to
-          DailyMemoInfo(
+          DailyMemo(
             name = memo.name,
             content = memo.content,
           )
@@ -40,5 +40,5 @@ object ExtractDailyMemosUseCase {
     memos: List<Memo>,
     timeZone: TimeZone,
     date: LocalDate,
-  ): DailyMemoInfo? = invoke(memos, timeZone)[date]
+  ): DailyMemo? = invoke(memos, timeZone)[date]
 }

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummaryTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummaryTest.kt
@@ -6,8 +6,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
-class ActivityWeekDataTest {
-  private fun createTestData(): ActivityWeekData {
+class ActivitySummaryTest {
+  private fun createTestData(): ActivitySummary {
     val days =
       listOf(
         ContributionDay(
@@ -48,7 +48,7 @@ class ActivityWeekDataTest {
         ),
       )
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days, weeklyCount = 10)
-    return ActivityWeekData(weeks = listOf(week), maxDaily = 5, maxWeekly = 10)
+    return ActivitySummary(weeks = listOf(week), maxDaily = 5, maxWeekly = 10)
   }
 
   @Test
@@ -78,7 +78,7 @@ class ActivityWeekDataTest {
         )
       }
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days, weeklyCount = 10)
-    val data = ActivityWeekData(weeks = listOf(week), maxDaily = 1, maxWeekly = 10)
+    val data = ActivitySummary(weeks = listOf(week), maxDaily = 1, maxWeekly = 10)
 
     val result = data.lastSevenDays()
 
@@ -128,7 +128,7 @@ class ActivityWeekDataTest {
         ),
       )
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days, weeklyCount = 2)
-    val data = ActivityWeekData(weeks = listOf(week), maxDaily = 2, maxWeekly = 2)
+    val data = ActivitySummary(weeks = listOf(week), maxDaily = 2, maxWeekly = 2)
 
     val result = data.forHabit(habit)
 
@@ -162,7 +162,7 @@ class ActivityWeekDataTest {
         ),
       )
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days, weeklyCount = 1)
-    val data = ActivityWeekData(weeks = listOf(week), maxDaily = 1, maxWeekly = 1)
+    val data = ActivitySummary(weeks = listOf(week), maxDaily = 1, maxWeekly = 1)
 
     val result = data.forHabit(habit)
 
@@ -189,7 +189,7 @@ class ActivityWeekDataTest {
         ),
       )
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days, weeklyCount = 0)
-    val data = ActivityWeekData(weeks = listOf(week), maxDaily = 0, maxWeekly = 0)
+    val data = ActivitySummary(weeks = listOf(week), maxDaily = 0, maxWeekly = 0)
 
     val result = data.forHabit(habit)
 
@@ -233,7 +233,7 @@ class ActivityWeekDataTest {
         ),
       )
     val week = ActivityWeek(startDate = LocalDate(2024, 1, 1), days = days1, weeklyCount = 4)
-    val data = ActivityWeekData(weeks = listOf(week), maxDaily = 2, maxWeekly = 4)
+    val data = ActivitySummary(weeks = listOf(week), maxDaily = 2, maxWeekly = 4)
 
     val result = data.forHabit(habit)
 

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCaseTest.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
@@ -226,7 +226,7 @@ class BuildDayDataUseCaseTest {
 
   @Test
   fun `when habit is completed in dailyMemo then count is 1`() {
-    val dailyMemo = DailyMemoInfo(name = "daily", content = "#habits/test done!")
+    val dailyMemo = DailyMemo(name = "daily", content = "#habits/test done!")
     val context =
       DayBuildContext(
         date = LocalDate(2024, 1, 12),
@@ -265,7 +265,7 @@ class BuildDayDataUseCaseTest {
 
   @Test
   fun `when habit tag not in dailyMemo then count is 0`() {
-    val dailyMemo = DailyMemoInfo(name = "daily", content = "just some text without habits")
+    val dailyMemo = DailyMemo(name = "daily", content = "just some text without habits")
     val context =
       DayBuildContext(
         date = LocalDate(2024, 1, 12),
@@ -304,7 +304,7 @@ class BuildDayDataUseCaseTest {
                 "Meditation | #habits/meditation",
           ),
       )
-    val dailyMemo = DailyMemoInfo(name = "daily", content = "#habits/exercise #habits/reading")
+    val dailyMemo = DailyMemo(name = "daily", content = "#habits/exercise #habits/reading")
     val context =
       DayBuildContext(
         date = LocalDate(2024, 1, 12),

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildHabitDayUseCaseTest.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -15,7 +15,7 @@ class BuildHabitDayUseCaseTest {
   @Test
   fun `when habitsConfig is empty then returns null`() {
     val date = LocalDate(2024, 1, 15)
-    val dailyMemo = DailyMemoInfo(name = "test", content = "content")
+    val dailyMemo = DailyMemo(name = "test", content = "content")
 
     val result = useCase(date, emptyList(), dailyMemo)
 
@@ -31,7 +31,7 @@ class BuildHabitDayUseCaseTest {
         HabitConfig(tag = "#habits/reading", label = "Reading"),
       )
     val dailyMemo =
-      DailyMemoInfo(
+      DailyMemo(
         name = "test",
         content = "#daily 2024-01-15\n#habits/exercise\n#habits/reading",
       )
@@ -56,7 +56,7 @@ class BuildHabitDayUseCaseTest {
         HabitConfig(tag = "#habits/meditation", label = "Meditation"),
       )
     val dailyMemo =
-      DailyMemoInfo(
+      DailyMemo(
         name = "test",
         content = "#daily 2024-01-15\n#habits/exercise",
       )
@@ -77,7 +77,7 @@ class BuildHabitDayUseCaseTest {
         HabitConfig(tag = "#habits/exercise", label = "Exercise"),
       )
     val dailyMemo =
-      DailyMemoInfo(
+      DailyMemo(
         name = "test",
         content = "#daily 2024-01-15",
       )
@@ -116,7 +116,7 @@ class BuildHabitDayUseCaseTest {
         HabitConfig(tag = "#habits/reading", label = "Reading"),
       )
     val dailyMemo =
-      DailyMemoInfo(
+      DailyMemo(
         name = "test",
         content = "#daily\n#habits/exercise",
       )
@@ -143,7 +143,7 @@ class BuildHabitDayUseCaseTest {
         HabitConfig(tag = "#habits/exercise", label = "Exercise"),
       )
     val dailyMemo =
-      DailyMemoInfo(
+      DailyMemo(
         name = "test",
         content = "#habits/exercise",
       )

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCaseTest.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -188,7 +188,7 @@ class CalculateSuccessRateUseCaseTest {
       inRange = inRange,
     )
 
-  private fun createWeekData(vararg days: Pair<LocalDate, ContributionDay>): ActivityWeekData {
+  private fun createWeekData(vararg days: Pair<LocalDate, ContributionDay>): ActivitySummary {
     val sortedDays = days.sortedBy { it.first }
     val weeks =
       sortedDays.chunked(7).map { chunk ->
@@ -200,6 +200,6 @@ class CalculateSuccessRateUseCaseTest {
       }
     val maxDaily = days.maxOfOrNull { it.second.count } ?: 0
     val maxWeekly = weeks.maxOfOrNull { it.weeklyCount } ?: 0
-    return ActivityWeekData(weeks = weeks, maxDaily = maxDaily, maxWeekly = maxWeekly)
+    return ActivitySummary(weeks = weeks, maxDaily = maxDaily, maxWeekly = maxWeekly)
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/action/HabitsAction.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/action/HabitsAction.kt
@@ -4,12 +4,12 @@ import space.be1ski.vibits.core.elm.Action
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
-import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
+import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 /**
@@ -160,9 +160,9 @@ sealed interface HabitsAction : Action {
       val range: ActivityRange,
       val mode: ActivityMode,
       val appMode: AppMode,
-      val weekData: ActivityWeekData,
+      val weekData: ActivitySummary,
       val configTimeline: List<HabitsConfigEntry>,
-      val successRate: SuccessRateData?,
+      val successRate: SuccessRate?,
     ) : Cache
 
     data object PrewarmCompleted : Cache

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsCacheReducer.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsCacheReducer.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.habits.presentation.reducer
 
 import space.be1ski.vibits.core.elm.Reducer
 import space.be1ski.vibits.core.elm.reducer
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.effect.HabitsEffect
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
@@ -30,7 +30,7 @@ internal val cacheReducer: Reducer<HabitsAction.Cache, HabitsState, HabitsEffect
           state.copy(
             activityDataCache =
               state.activityDataCache +
-                (key to CachedActivityData(action.weekData, action.configTimeline, action.successRate)),
+                (key to CachedActivity(action.weekData, action.configTimeline, action.successRate)),
             isRecalculating = state.isRecalculating - key,
           )
         }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/HabitsEditorReducer.kt
@@ -7,7 +7,7 @@ import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.buildHabitStatuses
 import space.be1ski.vibits.feature.habits.domain.buildHabitsEditorSelections
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.usecase.parseDailyDateFromContent
 import space.be1ski.vibits.feature.habits.domain.usecase.parseMemoDate
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
@@ -38,7 +38,7 @@ internal val editorReducer: Reducer<HabitsAction.Editor, HabitsState, HabitsEffe
                 totalHabits = action.config.size,
                 completionRatio = if (action.config.isNotEmpty()) completedCount.toFloat() / action.config.size else 0f,
                 habitStatuses = habitStatuses,
-                dailyMemo = DailyMemoInfo(name = action.memo.name, content = action.memo.content),
+                dailyMemo = DailyMemo(name = action.memo.name, content = action.memo.content),
                 inRange = true,
                 isClickable = true,
               )

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.feature.habits.presentation.state
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitTag
 import space.be1ski.vibits.feature.habits.domain.model.IsSelected
@@ -47,7 +47,7 @@ data class HabitsState(
   val editorDay: ContributionDay? = null,
   val editorConfig: List<HabitConfig> = emptyList(),
   val editorSelections: Map<HabitTag, IsSelected> = emptyMap(),
-  val editorExisting: DailyMemoInfo? = null,
+  val editorExisting: DailyMemo? = null,
   val editorError: String? = null,
   // Delete confirmation
   val showDeleteConfirm: Boolean = false,
@@ -72,7 +72,7 @@ data class HabitsState(
   // Loading state
   val isLoading: Boolean = false,
   // Cache state
-  val activityDataCache: Map<ActivityCacheKey, CachedActivityData> = emptyMap(),
+  val activityDataCache: Map<ActivityCacheKey, CachedActivity> = emptyMap(),
   val isRecalculating: Set<ActivityCacheKey> = emptySet(),
   val needsCacheRefresh: Boolean = false,
   val isInitialLoading: Boolean = false,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsStateExtensions.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsStateExtensions.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.presentation.state
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 
 /**
  * Checks if data for the given key is currently being loaded or recalculated.
@@ -18,4 +18,4 @@ fun HabitsState.getActivityData(
   range: ActivityRange,
   mode: ActivityMode,
   appMode: AppMode,
-): CachedActivityData? = activityDataCache[ActivityCacheKey(range, mode, appMode)]
+): CachedActivity? = activityDataCache[ActivityCacheKey(range, mode, appMode)]

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -16,7 +16,7 @@ import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.findDayByDate
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractDailyMemosUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
@@ -67,7 +67,7 @@ private fun rememberStatsScreenDerived(
   // Read from TEA cache
   val emptyWeekData =
     remember {
-      ActivityWeekData(
+      ActivitySummary(
         weeks = emptyList(),
         maxDaily = 0,
         maxWeekly = 0,
@@ -75,7 +75,7 @@ private fun rememberStatsScreenDerived(
     }
   val weekData = cachedData?.weekData ?: emptyWeekData
   val habitsConfigTimeline = cachedData?.configTimeline.orEmpty()
-  val successRateData = cachedData?.successRate
+  val successRate = cachedData?.successRate
 
   val currentHabitsConfig =
     remember(habitsConfigTimeline) {
@@ -121,8 +121,7 @@ private fun rememberStatsScreenDerived(
     remember(habitsConfigTimeline) {
       habitsConfigTimeline.firstOrNull()?.date
     }
-  // Success rate comes from TEA cache
-  val finalSuccessRateData = successRateData
+  val finalSuccessRate = successRate
   val periodPosts =
     remember(memos, range, timeZone) {
       GetPeriodPostsUseCase(memos, range, timeZone)
@@ -144,7 +143,7 @@ private fun rememberStatsScreenDerived(
     todayDay = todayDay,
     today = today,
     timeZone = timeZone,
-    successRateData = finalSuccessRateData,
+    successRate = finalSuccessRate,
     periodPosts = periodPosts,
     dateFormatter = dateFormatter,
     configStartDate = configStartDate,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenHelpers.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenHelpers.kt
@@ -2,12 +2,12 @@ package space.be1ski.vibits.feature.habits.presentation.view
 
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.usecase.BuildHabitDayUseCase
 
 fun buildHabitDay(
   date: LocalDate,
   habitsConfig: List<HabitConfig>,
-  dailyMemo: DailyMemoInfo?,
+  dailyMemo: DailyMemo?,
 ): ContributionDay? = BuildHabitDayUseCase(date, habitsConfig, dailyMemo)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenModels.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenModels.kt
@@ -4,11 +4,11 @@ import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
-import space.be1ski.vibits.feature.habits.domain.model.SuccessRateData
+import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
@@ -28,7 +28,7 @@ data class StatsScreenState(
 
 internal data class HabitActivitySectionState(
   val habit: HabitConfig,
-  val baseWeekData: ActivityWeekData,
+  val baseWeekData: ActivitySummary,
   val selectedDate: LocalDate?,
   val isActiveSelection: Boolean,
   val showWeekdayLegend: Boolean,
@@ -45,7 +45,7 @@ internal data class StatsScreenDerivedState(
   val habitsState: HabitsState,
   val habitsConfigTimeline: List<HabitsConfigEntry>,
   val currentHabitsConfig: List<HabitConfig>,
-  val weekData: ActivityWeekData,
+  val weekData: ActivitySummary,
   val isLoadingWeekData: Boolean,
   val showWeekdayLegend: Boolean,
   val useCompactHeight: Boolean,
@@ -57,7 +57,7 @@ internal data class StatsScreenDerivedState(
   val todayDay: ContributionDay?,
   val today: LocalDate,
   val timeZone: TimeZone,
-  val successRateData: SuccessRateData?,
+  val successRate: SuccessRate?,
   val periodPosts: List<Memo>,
   val dateFormatter: DateFormatter,
   /** Date when habits were first configured (null if no config). */

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridState.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridState.kt
@@ -4,15 +4,15 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.Dp
 import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 
 /**
  * UI state for rendering the contribution grid.
  */
 data class ContributionGridState(
-  val weekData: ActivityWeekData,
+  val weekData: ActivitySummary,
   val range: ActivityRange,
   val selectedDay: ContributionDay?,
   val selectedWeekStart: LocalDate?,
@@ -41,7 +41,7 @@ private val DEFAULT_WEEKEND_DAYS =
  * UI state for rendering a weekly bar chart.
  */
 data class WeeklyBarChartState(
-  val weekData: ActivityWeekData,
+  val weekData: ActivitySummary,
   val selectedWeek: ActivityWeek?,
   val scrollState: ScrollState,
   val showWeekdayLegend: Boolean,

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsCacheTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsCacheTest.kt
@@ -3,9 +3,9 @@ import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.effect.HabitsEffect
 import space.be1ski.vibits.feature.habits.presentation.reducer.habitsReducer
@@ -28,9 +28,9 @@ class HabitsCacheTest {
     val week1Range = ActivityRange.Week(LocalDate(2026, 1, 20))
     val demoKey = ActivityCacheKey(week1Range, ActivityMode.HABITS, AppMode.DEMO)
     val demoData =
-      CachedActivityData(
+      CachedActivity(
         weekData =
-          ActivityWeekData(
+          ActivitySummary(
             weeks = listOf(ActivityWeek(startDate = week1Range.startDate, days = emptyList(), weeklyCount = 0)),
             maxDaily = 0,
             maxWeekly = 0,
@@ -60,8 +60,8 @@ class HabitsCacheTest {
     val week2Range = ActivityRange.Week(LocalDate(2026, 1, 20))
     val week1Key = ActivityCacheKey(week1Range, ActivityMode.HABITS, appMode)
     val cachedData1 =
-      CachedActivityData(
-        weekData = ActivityWeekData(weeks = emptyList(), maxDaily = 0, maxWeekly = 0),
+      CachedActivity(
+        weekData = ActivitySummary(weeks = emptyList(), maxDaily = 0, maxWeekly = 0),
         configTimeline = emptyList(),
         successRate = null,
       )
@@ -118,8 +118,8 @@ class HabitsCacheTest {
     val week1Key = ActivityCacheKey(week1Range, ActivityMode.HABITS, appMode)
     val week2Key = ActivityCacheKey(week2Range, ActivityMode.HABITS, appMode)
     val cachedData =
-      CachedActivityData(
-        weekData = ActivityWeekData(weeks = emptyList(), maxDaily = 0, maxWeekly = 0),
+      CachedActivity(
+        weekData = ActivitySummary(weeks = emptyList(), maxDaily = 0, maxWeekly = 0),
         configTimeline = emptyList(),
         successRate = null,
       )

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsReducerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsReducerTest.kt
@@ -4,11 +4,11 @@ import space.be1ski.vibits.core.elm.test.test
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
-import space.be1ski.vibits.feature.habits.domain.model.DailyMemoInfo
+import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
@@ -68,7 +68,7 @@ class HabitsReducerTest {
   @Test
   fun `when OpenEditor with existing memo then sets editorExisting`() =
     habitsReducer.test(HabitsState()) {
-      val dayWithMemo = testDay.copy(dailyMemo = DailyMemoInfo("memos/1", "content"))
+      val dayWithMemo = testDay.copy(dailyMemo = DailyMemo("memos/1", "content"))
 
       send(HabitsAction.Editor.OpenEditor(day = dayWithMemo, config = testConfig))
 
@@ -141,7 +141,7 @@ class HabitsReducerTest {
         editorDay = testDay,
         editorConfig = testConfig,
         editorSelections = mapOf("#habits/exercise" to false),
-        editorExisting = DailyMemoInfo("memos/1", "content"),
+        editorExisting = DailyMemo("memos/1", "content"),
       ),
     ) {
       send(HabitsAction.Editor.ConfirmEditor)
@@ -188,7 +188,7 @@ class HabitsReducerTest {
         editorDay = testDay,
         editorConfig = testConfig,
         editorSelections = mapOf("#habits/exercise" to true),
-        editorExisting = DailyMemoInfo("memos/1", "old content"),
+        editorExisting = DailyMemo("memos/1", "old content"),
       ),
     ) {
       send(HabitsAction.Editor.ConfirmEditor)
@@ -223,7 +223,7 @@ class HabitsReducerTest {
 
   @Test
   fun `when ConfirmDelete then emits DeleteMemo effect`() =
-    habitsReducer.test(HabitsState(editorExisting = DailyMemoInfo("memos/1", "content"))) {
+    habitsReducer.test(HabitsState(editorExisting = DailyMemo("memos/1", "content"))) {
       send(HabitsAction.Editor.ConfirmDelete)
 
       assertState { isLoading }
@@ -520,7 +520,7 @@ class HabitsReducerTest {
   fun `when ConfirmSingleHabitToggle then emits ToggleDailyHabit with correct params`() =
     habitsReducer.test(
       HabitsState(
-        singleToggleDay = testDay.copy(dailyMemo = DailyMemoInfo("memos/1", "content")),
+        singleToggleDay = testDay.copy(dailyMemo = DailyMemo("memos/1", "content")),
         singleToggleHabitTag = "#habits/exercise",
         singleToggleConfig = testConfig,
       ),
@@ -789,7 +789,7 @@ class HabitsReducerTest {
         isRecalculating = setOf(ActivityCacheKey(ActivityRange.Week(LocalDate(2024, 1, 1)), ActivityMode.HABITS, AppMode.ONLINE)),
       ),
     ) {
-      val weekData = ActivityWeekData(weeks = emptyList(), maxDaily = 5, maxWeekly = 10)
+      val weekData = ActivitySummary(weeks = emptyList(), maxDaily = 5, maxWeekly = 10)
       send(
         HabitsAction.Cache.UpdateActivityData(
           range = ActivityRange.Week(LocalDate(2024, 1, 1)),
@@ -816,7 +816,7 @@ class HabitsReducerTest {
         activityDataCache =
           mapOf(
             ActivityCacheKey(ActivityRange.Week(LocalDate(2024, 1, 1)), ActivityMode.HABITS, AppMode.ONLINE) to
-              CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null),
+              CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null),
           ),
         isRecalculating = setOf(ActivityCacheKey(ActivityRange.Week(LocalDate(2024, 1, 1)), ActivityMode.HABITS, AppMode.ONLINE)),
         needsCacheRefresh = false,
@@ -841,7 +841,7 @@ class HabitsReducerTest {
         activityDataCache =
           mapOf(
             ActivityCacheKey(ActivityRange.Week(LocalDate(2024, 1, 1)), ActivityMode.HABITS, AppMode.ONLINE) to
-              CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null),
+              CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null),
           ),
         isRecalculating = emptySet(),
         needsCacheRefresh = true,

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsStateExtensionsTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsStateExtensionsTest.kt
@@ -3,8 +3,8 @@ import kotlinx.datetime.LocalDate
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
-import space.be1ski.vibits.feature.habits.domain.model.ActivityWeekData
-import space.be1ski.vibits.feature.habits.domain.model.CachedActivityData
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
@@ -36,7 +36,7 @@ class HabitsStateExtensionsTest {
   @Test
   fun `when isInitialLoading but key is in cache then isDataLoading returns false`() {
     val key = ActivityCacheKey(ActivityRange.Week(LocalDate(2026, 1, 20)), ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(isInitialLoading = true, activityDataCache = mapOf(key to data))
 
     assertFalse(state.isDataLoading(key))
@@ -53,7 +53,7 @@ class HabitsStateExtensionsTest {
   @Test
   fun `when needsCacheRefresh but key is in cache then isDataLoading returns false`() {
     val key = ActivityCacheKey(ActivityRange.Week(LocalDate(2026, 1, 20)), ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(needsCacheRefresh = true, activityDataCache = mapOf(key to data))
 
     assertFalse(state.isDataLoading(key))
@@ -62,7 +62,7 @@ class HabitsStateExtensionsTest {
   @Test
   fun `when not loading and key in cache then isDataLoading returns false`() {
     val key = ActivityCacheKey(ActivityRange.Week(LocalDate(2026, 1, 20)), ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(isInitialLoading = false, activityDataCache = mapOf(key to data))
 
     assertFalse(state.isDataLoading(key))
@@ -74,7 +74,7 @@ class HabitsStateExtensionsTest {
     val mode = ActivityMode.HABITS
     val appMode = AppMode.ONLINE
     val key = ActivityCacheKey(range, mode, appMode)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(activityDataCache = mapOf(key to data))
 
     val result = state.getActivityData(range, mode, appMode)
@@ -97,7 +97,7 @@ class HabitsStateExtensionsTest {
     val range1 = ActivityRange.Week(LocalDate(2026, 1, 20))
     val range2 = ActivityRange.Week(LocalDate(2026, 1, 27))
     val key = ActivityCacheKey(range1, ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(activityDataCache = mapOf(key to data))
 
     val result = state.getActivityData(range2, ActivityMode.HABITS, AppMode.ONLINE)
@@ -109,7 +109,7 @@ class HabitsStateExtensionsTest {
   fun `when different mode then getActivityData returns null`() {
     val range = ActivityRange.Week(LocalDate(2026, 1, 20))
     val key = ActivityCacheKey(range, ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(activityDataCache = mapOf(key to data))
 
     val result = state.getActivityData(range, ActivityMode.POSTS, AppMode.ONLINE)
@@ -121,7 +121,7 @@ class HabitsStateExtensionsTest {
   fun `when different app mode then getActivityData returns null`() {
     val range = ActivityRange.Week(LocalDate(2026, 1, 20))
     val key = ActivityCacheKey(range, ActivityMode.HABITS, AppMode.ONLINE)
-    val data = CachedActivityData(ActivityWeekData(emptyList(), 0, 0), emptyList(), null)
+    val data = CachedActivity(ActivitySummary(emptyList(), 0, 0), emptyList(), null)
     val state = HabitsState(activityDataCache = mapOf(key to data))
 
     val result = state.getActivityData(range, ActivityMode.HABITS, AppMode.DEMO)


### PR DESCRIPTION
## Summary
- Renamed domain model classes to remove meaningless `Data` and `Info` suffixes per CLAUDE.md naming conventions
- `ActivityWeekData` -> `ActivitySummary` (not just suffix drop since `ActivityWeek` already exists)
- `CachedActivityData` -> `CachedActivity`
- `DailyMemoInfo` -> `DailyMemo`
- `SuccessRateData` -> `SuccessRate`

## Changes
- Renamed 4 model files and 1 test file
- Updated all references across domain use cases, presentation layer (actions, reducers, state, views), and tests (29 files total)

## Test plan
- [x] `./gradlew checkAll` passes (ktlint, detekt, compile, tests)
- [x] No remaining references to old class names