### PR TITLE
Remove redundant KDoc comments across the codebase

### DIFF
--- a/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
+++ b/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
@@ -12,17 +12,11 @@ import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 
 private const val TAG = "Credentials"
 
-/**
- * Repository implementation backed by platform credential storage.
- */
 @Inject
 @SingleIn(AppScope::class)
 class CredentialsRepositoryImpl(
   private val credentialsStore: CredentialsStore,
 ) : CredentialsRepository {
-  /**
-   * Loads stored credentials from the platform store.
-   */
   override fun load(): Credentials {
     val local = credentialsStore.load()
     val hasToken = local.token.isNotBlank()
@@ -30,9 +24,6 @@ class CredentialsRepositoryImpl(
     return Credentials(baseUrl = local.baseUrl, token = local.token)
   }
 
-  /**
-   * Persists credentials to the platform store.
-   */
   override fun save(credentials: Credentials) {
     val trimmed = credentials.trimmed()
     Log.i(TAG, "save() baseUrl='${trimmed.baseUrl.maskUrl()}'")

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/Credentials.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/Credentials.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.auth.domain.model
 
-/**
- * Domain model for stored server credentials.
- */
 data class Credentials(
   val baseUrl: String,
   val token: String,

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
@@ -2,17 +2,8 @@ package space.be1ski.vibits.feature.auth.domain.repository
 
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 
-/**
- * Repository for reading and persisting user credentials.
- */
 interface CredentialsRepository {
-  /**
-   * Loads stored credentials or empty values.
-   */
   fun load(): Credentials
 
-  /**
-   * Persists credentials locally.
-   */
   fun save(credentials: Credentials)
 }

--- a/feature/memos/data/src/androidMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/AndroidDatabaseHolder.kt
+++ b/feature/memos/data/src/androidMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/AndroidDatabaseHolder.kt
@@ -5,9 +5,6 @@ import space.be1ski.vibits.core.platform.app.AndroidContextHolder
 import space.be1ski.vibits.feature.memos.data.room.MIGRATION_1_2
 import space.be1ski.vibits.feature.memos.data.room.MemoDatabase
 
-/**
- * Singleton holder for the shared database instance on Android.
- */
 object AndroidDatabaseHolder {
   private var database: MemoDatabase? = null
 

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
@@ -16,9 +16,6 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 
 private const val TAG = "MemosRepository"
 
-/**
- * Repository implementation that loads memos from the network and caches them locally.
- */
 @Inject
 @SingleIn(AppScope::class)
 class OnlineMemosRepository(
@@ -26,9 +23,6 @@ class OnlineMemosRepository(
   private val credentialsRepository: CredentialsRepository,
   private val memoCache: MemoCache,
 ) : MemosRepository {
-  /**
-   * Loads memos from the server using stored credentials and paginated API calls.
-   */
   override suspend fun listMemos(): List<Memo> {
     val (baseUrl, token) = credentialsRepository.load().requireFilled()
     val allMemos = mutableListOf<Memo>()
@@ -61,18 +55,12 @@ class OnlineMemosRepository(
     return allMemos
   }
 
-  /**
-   * Loads cached memos from local storage.
-   */
   override suspend fun cachedMemos(): List<Memo> {
     val memos = memoCache.readMemos()
     Log.d(TAG, "Read ${memos.size} memos from cache")
     return memos
   }
 
-  /**
-   * Updates memo content in the API.
-   */
   override suspend fun updateMemo(
     name: String,
     content: String,
@@ -91,9 +79,6 @@ class OnlineMemosRepository(
     return updated
   }
 
-  /**
-   * Creates a new memo in the API.
-   */
   override suspend fun createMemo(content: String): Memo {
     Log.d(TAG, "Creating memo...")
     val (baseUrl, token) = credentialsRepository.load().requireFilled()
@@ -109,9 +94,6 @@ class OnlineMemosRepository(
     return created
   }
 
-  /**
-   * Deletes a memo in the API.
-   */
   override suspend fun deleteMemo(name: String) {
     Log.d(TAG, "Deleting memo: $name")
     val (baseUrl, token) = credentialsRepository.load().requireFilled()

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/mapper/MemoMapper.kt
@@ -3,13 +3,7 @@ package space.be1ski.vibits.feature.memos.data.mapper
 import space.be1ski.vibits.feature.memos.data.remote.dto.MemoDto
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
-/**
- * Maps network memo DTOs into domain models.
- */
 object MemoMapper {
-  /**
-   * Converts a [MemoDto] into a domain [Memo].
-   */
   fun toDomain(dto: MemoDto): Memo =
     Memo(
       name = dto.name,
@@ -18,8 +12,5 @@ object MemoMapper {
       updateTime = parseInstant(dto.updateTime),
     )
 
-  /**
-   * Converts a list of [MemoDto] into domain [Memo] models.
-   */
   fun toDomainList(dtos: List<MemoDto>): List<Memo> = dtos.map(::toDomain)
 }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemoDto.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemoDto.kt
@@ -3,10 +3,6 @@ package space.be1ski.vibits.feature.memos.data.offline
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * DTO for a single memo stored offline.
- * Format matches Memos API for future export/import compatibility.
- */
 @Serializable
 data class OfflineMemoDto(
   val name: String = "",
@@ -15,9 +11,6 @@ data class OfflineMemoDto(
   @SerialName("updateTime") val updateTime: String? = null,
 )
 
-/**
- * Root DTO for the offline memos JSON file.
- */
 @Serializable
 data class OfflineMemosFileDto(
   val memos: List<OfflineMemoDto> = emptyList(),

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/offline/OfflineMemosRepository.kt
@@ -11,10 +11,6 @@ import kotlin.time.Clock
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
-/**
- * Repository implementation for offline mode.
- * Stores memos in local JSON file.
- */
 @Inject
 @SingleIn(AppScope::class)
 class OfflineMemosRepository(

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/platform/MemoCache.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/platform/MemoCache.kt
@@ -2,10 +2,6 @@ package space.be1ski.vibits.feature.memos.data.platform
 
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
-/**
- * Platform-specific memo cache.
- * Uses Room database (Android, Desktop, iOS) or no-op (WASM).
- */
 interface MemoCache {
   suspend fun readMemos(): List<Memo>
 

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/platform/OfflineMemoStorage.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/platform/OfflineMemoStorage.kt
@@ -2,10 +2,6 @@ package space.be1ski.vibits.feature.memos.data.platform
 
 import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
 
-/**
- * Platform-specific offline memo storage.
- * Stored in Documents/memos.json (Android, Desktop, iOS) or localStorage (WASM).
- */
 interface OfflineMemoStorage {
   fun load(): OfflineMemosFileDto
 

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/CreateMemoRequestDto.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/CreateMemoRequestDto.kt
@@ -2,13 +2,7 @@ package space.be1ski.vibits.feature.memos.data.remote.dto
 
 import kotlinx.serialization.Serializable
 
-/**
- * Request payload for creating a memo.
- */
 @Serializable
 data class CreateMemoRequestDto(
-  /**
-   * Memo content.
-   */
   val content: String,
 )

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/ListMemosResponseDto.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/ListMemosResponseDto.kt
@@ -3,17 +3,8 @@ package space.be1ski.vibits.feature.memos.data.remote.dto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * Response payload for the memos list API.
- */
 @Serializable
 data class ListMemosResponseDto(
-  /**
-   * Returned memos.
-   */
   val memos: List<MemoDto> = emptyList(),
-  /**
-   * Token for the next page, if available.
-   */
   @SerialName("nextPageToken") val nextPageToken: String? = null,
 )

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/MemoDto.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/MemoDto.kt
@@ -3,25 +3,10 @@ package space.be1ski.vibits.feature.memos.data.remote.dto
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
-/**
- * Network DTO describing a memo as returned by the Memos API.
- */
 @Serializable
 data class MemoDto(
-  /**
-   * API resource name.
-   */
   val name: String = "",
-  /**
-   * Memo content.
-   */
   val content: String = "",
-  /**
-   * ISO timestamp when memo was created.
-   */
   @SerialName("createTime") val createTime: String? = null,
-  /**
-   * ISO timestamp when memo was last updated.
-   */
   @SerialName("updateTime") val updateTime: String? = null,
 )

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/UpdateMemoRequestDto.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/dto/UpdateMemoRequestDto.kt
@@ -2,13 +2,7 @@ package space.be1ski.vibits.feature.memos.data.remote.dto
 
 import kotlinx.serialization.Serializable
 
-/**
- * Request payload for updating memo content.
- */
 @Serializable
 data class UpdateMemoRequestDto(
-  /**
-   * Updated memo content.
-   */
   val content: String,
 )

--- a/feature/memos/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/DesktopDatabaseHolder.kt
+++ b/feature/memos/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/DesktopDatabaseHolder.kt
@@ -7,9 +7,6 @@ import space.be1ski.vibits.feature.memos.data.room.MIGRATION_1_2
 import space.be1ski.vibits.feature.memos.data.room.MemoDatabase
 import space.be1ski.vibits.feature.memos.data.room.MemoDatabaseConstructor
 
-/**
- * Singleton holder for the shared database instance on Desktop.
- */
 object DesktopDatabaseHolder {
   val database: MemoDatabase by lazy {
     Room

--- a/feature/memos/data/src/iosMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/IosDatabaseHolder.kt
+++ b/feature/memos/data/src/iosMain/kotlin/space/be1ski/vibits/feature/memos/data/internal/IosDatabaseHolder.kt
@@ -10,9 +10,6 @@ import space.be1ski.vibits.feature.memos.data.room.MIGRATION_1_2
 import space.be1ski.vibits.feature.memos.data.room.MemoDatabase
 import space.be1ski.vibits.feature.memos.data.room.MemoDatabaseConstructor
 
-/**
- * Singleton holder for the shared database instance on iOS.
- */
 object IosDatabaseHolder {
   val database: MemoDatabase by lazy { createDatabase() }
 

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDao.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDao.kt
@@ -5,38 +5,20 @@ import androidx.room.Insert
 import androidx.room.OnConflictStrategy
 import androidx.room.Query
 
-/**
- * Room DAO for cached memos.
- */
 @Dao
 interface MemoDao {
-  /**
-   * Returns all cached memos ordered by update time.
-   */
   @Query("SELECT * FROM memos ORDER BY updateTimeMillis DESC")
   suspend fun loadAll(): List<MemoEntity>
 
-  /**
-   * Inserts or replaces memo entities.
-   */
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun upsertAll(entities: List<MemoEntity>)
 
-  /**
-   * Inserts or replaces a memo entity.
-   */
   @Insert(onConflict = OnConflictStrategy.REPLACE)
   suspend fun upsert(entity: MemoEntity)
 
-  /**
-   * Deletes a memo by its name.
-   */
   @Query("DELETE FROM memos WHERE name = :name")
   suspend fun deleteByName(name: String)
 
-  /**
-   * Clears all cached memos.
-   */
   @Query("DELETE FROM memos")
   suspend fun clearAll()
 }

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDatabase.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDatabase.kt
@@ -6,9 +6,6 @@ import androidx.room.RoomDatabase
 import space.be1ski.vibits.feature.memos.data.room.sync.SyncOperationDao
 import space.be1ski.vibits.feature.memos.data.room.sync.SyncOperationEntity
 
-/**
- * Room database that stores cached memos and sync operations.
- */
 @Database(
   entities = [MemoEntity::class, SyncOperationEntity::class],
   version = 2,
@@ -16,13 +13,7 @@ import space.be1ski.vibits.feature.memos.data.room.sync.SyncOperationEntity
 )
 @ConstructedBy(MemoDatabaseConstructor::class)
 abstract class MemoDatabase : RoomDatabase() {
-  /**
-   * Returns DAO for memo cache.
-   */
   abstract fun memoDao(): MemoDao
 
-  /**
-   * Returns DAO for sync operations.
-   */
   abstract fun syncOperationDao(): SyncOperationDao
 }

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDatabaseConstructor.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoDatabaseConstructor.kt
@@ -2,7 +2,4 @@ package space.be1ski.vibits.feature.memos.data.room
 
 import androidx.room.RoomDatabaseConstructor
 
-/**
- * Room constructor placeholder for platform implementations.
- */
 expect object MemoDatabaseConstructor : RoomDatabaseConstructor<MemoDatabase>

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoEntity.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoEntity.kt
@@ -3,9 +3,6 @@ package space.be1ski.vibits.feature.memos.data.room
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-/**
- * Room entity that stores memo content for offline cache.
- */
 @Entity(tableName = "memos")
 data class MemoEntity(
   @PrimaryKey val name: String,

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoEntityMapper.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/MemoEntityMapper.kt
@@ -3,13 +3,7 @@ package space.be1ski.vibits.feature.memos.data.room
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.time.Instant
 
-/**
- * Maps memo entities to domain models and back.
- */
 object MemoEntityMapper {
-  /**
-   * Converts a cached entity into a domain memo.
-   */
   fun toDomain(entity: MemoEntity): Memo =
     Memo(
       name = entity.name,
@@ -18,9 +12,6 @@ object MemoEntityMapper {
       updateTime = entity.updateTimeMillis?.let(Instant::fromEpochMilliseconds),
     )
 
-  /**
-   * Converts a domain memo into a cached entity.
-   */
   fun toEntity(memo: Memo): MemoEntity =
     MemoEntity(
       name = memo.name,

--- a/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/sync/SyncOperationEntity.kt
+++ b/feature/memos/data/src/nonWasmMain/kotlin/space/be1ski/vibits/feature/memos/data/room/sync/SyncOperationEntity.kt
@@ -3,9 +3,6 @@ package space.be1ski.vibits.feature.memos.data.room.sync
 import androidx.room.Entity
 import androidx.room.PrimaryKey
 
-/**
- * Room entity for pending sync operations.
- */
 @Entity(tableName = "sync_operations")
 data class SyncOperationEntity(
   @PrimaryKey val id: String,

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/config/MemosDefaults.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/config/MemosDefaults.kt
@@ -1,11 +1,5 @@
 package space.be1ski.vibits.feature.memos.domain.config
 
-/**
- * Defaults for memo loading use cases.
- */
 object MemosDefaults {
-  /**
-   * Default page size for Memos list requests.
-   */
   const val DEFAULT_PAGE_SIZE: Int = 200
 }

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/Memo.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/model/Memo.kt
@@ -9,32 +9,19 @@ data class Memo(
   val updateTime: kotlin.time.Instant? = null,
 )
 
-/**
- * Computed property that classifies the memo's post type.
- */
 val Memo.postType: PostFilter
   get() = ClassifyPostTypeUseCase(this)
 
-/**
- * Returns true if this is a habits config post.
- */
 val Memo.isConfigPost: Boolean
   get() = postType == PostFilter.CONFIG
 
-/**
- * Returns true if this is a habit tracking post.
- */
 val Memo.isTrackingPost: Boolean
   get() = postType == PostFilter.HABIT_TRACKING
 
-/**
- * Returns true if this is a regular post (not config or tracking).
- */
 val Memo.isRegularPost: Boolean
   get() = postType == PostFilter.REGULAR
 
 /**
- * Returns true if this post can be deleted from the feed.
  * Config and tracking posts should be deleted from their edit dialogs, not from the feed.
  */
 val Memo.canDeleteFromFeed: Boolean

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
@@ -1,11 +1,5 @@
 package space.be1ski.vibits.feature.memos.domain.repository
 
-/**
- * Manages offline memo storage operations.
- */
 interface MemoStorageManager {
-  /**
-   * Clears all memos from offline storage.
-   */
   fun clearAll()
 }

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemosRepository.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemosRepository.kt
@@ -2,35 +2,17 @@ package space.be1ski.vibits.feature.memos.domain.repository
 
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
-/**
- * Domain repository for loading memos.
- */
 interface MemosRepository {
-  /**
-   * Returns all memos from the server using paginated requests.
-   */
   suspend fun listMemos(): List<Memo>
 
-  /**
-   * Returns cached memos stored locally.
-   */
   suspend fun cachedMemos(): List<Memo>
 
-  /**
-   * Updates memo content and returns the updated memo.
-   */
   suspend fun updateMemo(
     name: String,
     content: String,
   ): Memo
 
-  /**
-   * Creates a new memo and returns it.
-   */
   suspend fun createMemo(content: String): Memo
 
-  /**
-   * Deletes a memo by name.
-   */
   suspend fun deleteMemo(name: String)
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/action/MemosAction.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/action/MemosAction.kt
@@ -7,13 +7,7 @@ import space.be1ski.vibits.feature.memos.domain.model.PostFilter
 import space.be1ski.vibits.feature.sync.domain.model.SyncConflict
 import space.be1ski.vibits.feature.sync.domain.model.SyncStatus
 
-/**
- * Actions for the Memos feature.
- */
 sealed interface MemosAction : Action {
-  /**
-   * Credentials input.
-   */
   sealed interface Credentials : MemosAction {
     data class UpdateBaseUrl(
       val value: String,
@@ -31,9 +25,6 @@ sealed interface MemosAction : Action {
     ) : Credentials
   }
 
-  /**
-   * Loading and filtering.
-   */
   sealed interface Loading : MemosAction {
     data object LoadMemos : Loading
 
@@ -59,9 +50,6 @@ sealed interface MemosAction : Action {
     ) : Loading
   }
 
-  /**
-   * CRUD operations.
-   */
   sealed interface Crud : MemosAction {
     data class CreateMemo(
       val content: String,
@@ -93,9 +81,6 @@ sealed interface MemosAction : Action {
     ) : Crud
   }
 
-  /**
-   * Create dialog.
-   */
   sealed interface CreateDialog : MemosAction {
     data object ShowCreateDialog : CreateDialog
 
@@ -108,9 +93,6 @@ sealed interface MemosAction : Action {
     data object ConfirmCreateDialog : CreateDialog
   }
 
-  /**
-   * Edit dialog.
-   */
   sealed interface EditDialog : MemosAction {
     data class ShowEditDialog(
       val memo: Memo,
@@ -125,29 +107,21 @@ sealed interface MemosAction : Action {
     data object ConfirmEditDialog : EditDialog
   }
 
-  /**
-   * Sync operations.
-   */
   sealed interface Sync : MemosAction {
-    /** User requested sync. */
     data object StartSync : Sync
 
-    /** Sync completed successfully. */
     data class SyncCompleted(
       val memos: List<Memo>,
     ) : Sync
 
-    /** Sync detected conflicts. */
     data class SyncConflictDetected(
       val conflicts: List<SyncConflict>,
     ) : Sync
 
-    /** Sync failed. */
     data class SyncFailed(
       val error: String,
     ) : Sync
 
-    /** Update sync status from queue. */
     data class SyncStatusUpdated(
       val status: SyncStatus,
     ) : Sync
@@ -158,13 +132,10 @@ sealed interface MemosAction : Action {
     /** User chose to keep server data. */
     data object ResolveKeepServer : Sync
 
-    /** Dismiss conflict dialog. */
     data object DismissConflictDialog : Sync
 
-    /** Show sync log dialog. */
     data object ShowSyncLogDialog : Sync
 
-    /** Dismiss sync log dialog. */
     data object DismissSyncLogDialog : Sync
   }
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosEffect.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosEffect.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.memos.presentation.effect
 
-/**
- * Side effects for the Memos feature.
- */
 sealed interface MemosEffect {
   sealed interface Credentials : MemosEffect
 
@@ -39,7 +36,6 @@ sealed interface MemosEffect {
     val name: String,
   ) : Write
 
-  /** Perform sync with server. */
   data object PerformSync : Sync
 
   /** Force sync with local changes overwriting server. */
@@ -48,9 +44,7 @@ sealed interface MemosEffect {
   /** Force sync with server data overwriting local. */
   data object ForceServerSync : Sync
 
-  /** Load current sync status. */
   data object LoadSyncStatus : Sync
 
-  /** Observe sync status changes. */
   data object ObserveSyncStatus : Sync
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/state/MemosState.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/state/MemosState.kt
@@ -5,9 +5,6 @@ import space.be1ski.vibits.feature.memos.domain.model.PostFilter
 import space.be1ski.vibits.feature.sync.domain.model.SyncConflict
 import space.be1ski.vibits.feature.sync.domain.model.SyncStatus
 
-/**
- * State for the Memos feature.
- */
 data class MemosState(
   val memos: List<Memo> = emptyList(),
   val memosRevision: Int = 0,

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
@@ -12,9 +12,6 @@ import space.be1ski.vibits.feature.settings.domain.repository.PreferencesReposit
 
 private const val TAG = "Preferences"
 
-/**
- * Repository implementation backed by platform preferences storage.
- */
 @Inject
 @SingleIn(AppScope::class)
 class PreferencesRepositoryImpl(

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/AppLanguage.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/AppLanguage.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.settings.domain.model
 
-/**
- * Supported app languages.
- */
 enum class AppLanguage(
   val localeCode: String?,
 ) {

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/AppTheme.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/AppTheme.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.settings.domain.model
 
-/**
- * Supported app themes.
- */
 enum class AppTheme {
   SYSTEM,
   LIGHT,

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/TimeRangeTab.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/TimeRangeTab.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.settings.domain.model
 
-/**
- * Time range interval types for viewing activity.
- */
 enum class TimeRangeTab {
   WEEKS,
   MONTHS,

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/UserPreferences.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/UserPreferences.kt
@@ -2,9 +2,6 @@ package space.be1ski.vibits.feature.settings.domain.model
 
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 
-/**
- * Domain model for user UI preferences.
- */
 data class UserPreferences(
   val habitsTimeRangeTab: TimeRangeTab,
   val postsTimeRangeTab: TimeRangeTab,

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/repository/PreferencesRepository.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/repository/PreferencesRepository.kt
@@ -2,17 +2,8 @@ package space.be1ski.vibits.feature.settings.domain.repository
 
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
 
-/**
- * Repository for reading and persisting user preferences.
- */
 interface PreferencesRepository {
-  /**
-   * Loads stored preferences or default values.
-   */
   fun load(): UserPreferences
 
-  /**
-   * Persists user preferences locally.
-   */
   fun save(preferences: UserPreferences)
 }

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/SyncEngine.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/SyncEngine.kt
@@ -2,14 +2,9 @@ package space.be1ski.vibits.feature.sync.domain
 
 import space.be1ski.vibits.feature.sync.domain.model.SyncResult
 
-/**
- * Sync engine interface for processing pending operations and syncing with the server.
- */
 interface SyncEngine {
-  /** Whether a sync is currently in progress. */
   val isSyncing: Boolean
 
-  /** Performs a full sync. */
   suspend fun performSync(): SyncResult
 
   /** Forces server data to overwrite local data. */


### PR DESCRIPTION
## Summary
- Removed KDoc comments that restate class/method/property names without adding semantic value
- Kept comments that explain non-obvious behavior (sync direction, deletion constraints, migration details)
- Follows CLAUDE.md guideline: "Self-documenting code over comments"

## Changes
- **36 files** across auth, memos, settings, and sync modules
- Removed redundant class-level KDoc (e.g., "Repository implementation backed by..." on `*RepositoryImpl`)
- Removed redundant method-level KDoc (e.g., "Loads stored credentials" on `load()`)
- Removed redundant property-level KDoc (e.g., "Returns true if this is a config post" on `isConfigPost`)
- Removed redundant DTO field-level KDoc (e.g., "Memo content." on `content`)
- Preserved comments that add value:
  - `canDeleteFromFeed` — explains why the restriction exists
  - `forceServerSync`/`forceLocalSync` — clarifies sync direction
  - `RefreshMemos` — clarifies behavior difference from other load effects
  - `MIGRATION_1_2` — describes what the migration does

## Test plan
- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, all tests)