### PR TITLE
Remove redundant KDoc comments across codebase

### DIFF
--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/Platform.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/Platform.kt
@@ -1,6 +1,3 @@
 package space.be1ski.vibits.core.platform
 
-/**
- * True when running on desktop.
- */
 expect val isDesktop: Boolean

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppDetails.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppDetails.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.core.platform.app
 
-/**
- * Application details for settings and diagnostics.
- */
 data class AppDetails(
   val version: String,
   val environment: String,

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppDetailsProvider.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppDetailsProvider.kt
@@ -1,11 +1,5 @@
 package space.be1ski.vibits.core.platform.app
 
-/**
- * Provides application details for settings and diagnostics.
- */
 expect class AppDetailsProvider() {
-  /**
-   * Returns app details including version, environment, and storage paths.
-   */
   fun load(): AppDetails
 }

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/di/AppScope.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/di/AppScope.kt
@@ -1,7 +1,3 @@
 package space.be1ski.vibits.core.platform.di
 
-/**
- * Scope marker for application-level singletons.
- * Used with @SingleIn(AppScope::class) to scope bindings to the app graph lifecycle.
- */
 object AppScope

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/locale/AppLanguage.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/locale/AppLanguage.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.core.platform.locale
 
-/**
- * Supported app languages.
- */
 enum class AppLanguage(
   val localeCode: String?,
 ) {

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/locale/LocaleProvider.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/locale/LocaleProvider.kt
@@ -1,17 +1,8 @@
 package space.be1ski.vibits.core.platform.locale
 
-/**
- * Platform-specific locale configuration.
- */
 expect class LocaleProvider() {
-  /**
-   * Returns the system locale code (e.g., "en", "ru").
-   */
   fun getSystemLocale(): String
 
-  /**
-   * Configures the app locale based on the selected language.
-   * @return true if a restart is required for the change to take effect
-   */
+  /** @return true if a restart is required for the change to take effect */
   fun configureLocale(language: AppLanguage): Boolean
 }

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/date/DateFormatter.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/date/DateFormatter.kt
@@ -31,10 +31,6 @@ import space.be1ski.vibits.core.strings.generated.month_sep
 private const val MONTH_FALLBACK_LENGTH = 3
 private const val DAY_FALLBACK_LENGTH = 2
 
-/**
- * Date formatter using localized strings from Compose Resources.
- * Create via [rememberDateFormatter] composable.
- */
 class DateFormatter(
   private val months: Map<Month, String>,
   private val days: Map<DayOfWeek, String>,

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
@@ -2,17 +2,8 @@ package space.be1ski.vibits.feature.auth.domain.repository
 
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 
-/**
- * Repository for reading and persisting user credentials.
- */
 interface CredentialsRepository {
-  /**
-   * Loads stored credentials or empty values.
-   */
   fun load(): Credentials
 
-  /**
-   * Persists credentials locally.
-   */
   fun save(credentials: Credentials)
 }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityMode.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivityMode.kt
@@ -1,12 +1,6 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
-/**
- * Activity visualization modes.
- */
 enum class ActivityMode {
-  /** Habit completion based on daily and config post tags. */
   HABITS,
-
-  /** Raw post count per day. */
   POSTS,
 }

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DailyMemo.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DailyMemo.kt
@@ -1,11 +1,6 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
-/**
- * Daily memo metadata for editing.
- */
 data class DailyMemo(
-  /** Memo resource name. */
   val name: String,
-  /** Memo content. */
   val content: String,
 )

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/HabitStatus.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/HabitStatus.kt
@@ -1,13 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
-/**
- * Habit completion status for a single habit tag.
- */
 data class HabitStatus(
-  /** Habit tag, e.g. #habits/зарядка. */
   val tag: String,
-  /** Habit label for display. */
   val label: String,
-  /** True when the habit is marked completed in a daily memo. */
   val done: Boolean,
 )

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SuccessRate.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/SuccessRate.kt
@@ -1,8 +1,5 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
-/**
- * Success rate calculation result.
- */
 data class SuccessRate(
   val completed: Int,
   val total: Int,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -16,16 +16,10 @@ import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
-/**
- * Use case for building activity data.
- */
 @Inject
 class BuildActivityDataUseCase(
   private val buildDayDataUseCase: BuildDayDataUseCase,
 ) {
-  /**
-   * Builds ActivitySummary for a given range.
-   */
   @Suppress("LongParameterList")
   fun buildWeekData(
     configTimeline: List<HabitsConfigEntry>,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildDayDataUseCase.kt
@@ -10,9 +10,6 @@ import space.be1ski.vibits.feature.habits.domain.model.DayBuildContext
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
 
-/**
- * Use case for building a single ContributionDay from context.
- */
 @Inject
 class BuildDayDataUseCase {
   operator fun invoke(context: DayBuildContext): ContributionDay {
@@ -96,9 +93,6 @@ class BuildDayDataUseCase {
     completed: Int,
   ): Float = if (totalHabits > 0) completed.toFloat() / totalHabits.toFloat() else 0f
 
-  /**
-   * Internal state for habit selection computation.
-   */
   private data class HabitSelectionState(
     val useHabits: Boolean,
     val habitStatuses: List<HabitStatus>,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateSuccessRateUseCase.kt
@@ -5,9 +5,6 @@ import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
 import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
 
-/**
- * Calculates success rate for habits within a given time range.
- */
 object CalculateSuccessRateUseCase {
   operator fun invoke(
     weekData: ActivitySummary,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/ExtractDailyMemosUseCase.kt
@@ -6,10 +6,6 @@ import space.be1ski.vibits.feature.habits.domain.model.DailyMemo
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.model.isDailyMemo
 
-/**
- * Extracts daily memos from a list of memos.
- * Daily memos are identified by PostTags.HABITS_DAILY or PostTags.DAILY tags.
- */
 object ExtractDailyMemosUseCase {
   operator fun invoke(
     memos: List<Memo>,
@@ -33,9 +29,6 @@ object ExtractDailyMemosUseCase {
       }.toMap()
   }
 
-  /**
-   * Finds daily memo for a specific date.
-   */
   fun forDate(
     memos: List<Memo>,
     timeZone: TimeZone,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -13,9 +13,6 @@ import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 
-/**
- * Calculates date bounds for an activity range.
- */
 object GetRangeBoundsUseCase {
   operator fun invoke(range: ActivityRange): RangeBounds =
     when (range) {

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetSuccessRateLevelUseCase.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetSuccessRateLevelUseCase.kt
@@ -5,9 +5,6 @@ import space.be1ski.vibits.feature.homescreen.domain.model.SuccessRateLevel
 private const val GOOD_THRESHOLD = 0.8f
 private const val MEDIUM_THRESHOLD = 0.5f
 
-/**
- * Determines the achievement level based on success rate.
- */
 object GetSuccessRateLevelUseCase {
   operator fun invoke(rate: Float): SuccessRateLevel =
     when {

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/LoadAppDetailsUseCase.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/LoadAppDetailsUseCase.kt
@@ -4,9 +4,6 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.core.platform.app.AppDetails
 import space.be1ski.vibits.core.platform.app.AppDetailsProvider
 
-/**
- * Loads app details for settings screen.
- */
 @Inject
 class LoadAppDetailsUseCase(
   private val appDetailsProvider: AppDetailsProvider,

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
@@ -16,9 +16,6 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 
 private const val TAG = "MemosRepository"
 
-/**
- * Repository implementation that loads memos from the network and caches them locally.
- */
 @Inject
 @SingleIn(AppScope::class)
 class OnlineMemosRepository(
@@ -26,9 +23,6 @@ class OnlineMemosRepository(
   private val credentialsRepository: CredentialsRepository,
   private val memoCache: MemoCache,
 ) : MemosRepository {
-  /**
-   * Loads memos from the server using stored credentials and paginated API calls.
-   */
   override suspend fun listMemos(): List<Memo> {
     val (baseUrl, token) = credentialsRepository.load().requireFilled()
     val allMemos = mutableListOf<Memo>()
@@ -61,18 +55,12 @@ class OnlineMemosRepository(
     return allMemos
   }
 
-  /**
-   * Loads cached memos from local storage.
-   */
   override suspend fun cachedMemos(): List<Memo> {
     val memos = memoCache.readMemos()
     Log.d(TAG, "Read ${memos.size} memos from cache")
     return memos
   }
 
-  /**
-   * Updates memo content in the API.
-   */
   override suspend fun updateMemo(
     name: String,
     content: String,
@@ -91,9 +79,6 @@ class OnlineMemosRepository(
     return updated
   }
 
-  /**
-   * Creates a new memo in the API.
-   */
   override suspend fun createMemo(content: String): Memo {
     Log.d(TAG, "Creating memo...")
     val (baseUrl, token) = credentialsRepository.load().requireFilled()
@@ -109,9 +94,6 @@ class OnlineMemosRepository(
     return created
   }
 
-  /**
-   * Deletes a memo in the API.
-   */
   override suspend fun deleteMemo(name: String) {
     Log.d(TAG, "Deleting memo: $name")
     val (baseUrl, token) = credentialsRepository.load().requireFilled()

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/export/Exporter.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/export/Exporter.kt
@@ -8,9 +8,6 @@ import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
 import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
 import kotlin.time.Clock
 
-/**
- * Handles exporting app data to files.
- */
 @Inject
 class Exporter(
   private val fileExporter: FileExporter,
@@ -23,10 +20,6 @@ class Exporter(
       prettyPrint = true
     }
 
-  /**
-   * Export logs to a text file.
-   * @return ExportResult with file name on success or error message on failure
-   */
   fun exportLogs(): ExportResult {
     val fileName = generateFileName("logs", "txt")
     val content = Log.export()
@@ -38,10 +31,6 @@ class Exporter(
     }
   }
 
-  /**
-   * Export offline memos to a JSON file.
-   * @return ExportResult with file name on success or error message on failure
-   */
   fun exportMemos(): ExportResult {
     val fileName = generateFileName("memos", "json")
     val data = offlineMemoStorage.load()

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/config/MemosDefaults.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/config/MemosDefaults.kt
@@ -1,11 +1,5 @@
 package space.be1ski.vibits.feature.memos.domain.config
 
-/**
- * Defaults for memo loading use cases.
- */
 object MemosDefaults {
-  /**
-   * Default page size for Memos list requests.
-   */
   const val DEFAULT_PAGE_SIZE: Int = 200
 }

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemoStorageManager.kt
@@ -1,11 +1,5 @@
 package space.be1ski.vibits.feature.memos.domain.repository
 
-/**
- * Manages offline memo storage operations.
- */
 interface MemoStorageManager {
-  /**
-   * Clears all memos from offline storage.
-   */
   fun clearAll()
 }

--- a/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemosRepository.kt
+++ b/feature/memos/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/domain/repository/MemosRepository.kt
@@ -2,35 +2,17 @@ package space.be1ski.vibits.feature.memos.domain.repository
 
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
-/**
- * Domain repository for loading memos.
- */
 interface MemosRepository {
-  /**
-   * Returns all memos from the server using paginated requests.
-   */
   suspend fun listMemos(): List<Memo>
 
-  /**
-   * Returns cached memos stored locally.
-   */
   suspend fun cachedMemos(): List<Memo>
 
-  /**
-   * Updates memo content and returns the updated memo.
-   */
   suspend fun updateMemo(
     name: String,
     content: String,
   ): Memo
 
-  /**
-   * Creates a new memo and returns it.
-   */
   suspend fun createMemo(content: String): Memo
 
-  /**
-   * Deletes a memo by name.
-   */
   suspend fun deleteMemo(name: String)
 }

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/repository/PreferencesRepository.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/repository/PreferencesRepository.kt
@@ -2,17 +2,8 @@ package space.be1ski.vibits.feature.settings.domain.repository
 
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
 
-/**
- * Repository for reading and persisting user preferences.
- */
 interface PreferencesRepository {
-  /**
-   * Loads stored preferences or default values.
-   */
   fun load(): UserPreferences
 
-  /**
-   * Persists user preferences locally.
-   */
   fun save(preferences: UserPreferences)
 }

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/SyncEngine.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/SyncEngine.kt
@@ -2,19 +2,12 @@ package space.be1ski.vibits.feature.sync.domain
 
 import space.be1ski.vibits.feature.sync.domain.model.SyncResult
 
-/**
- * Sync engine interface for processing pending operations and syncing with the server.
- */
 interface SyncEngine {
-  /** Whether a sync is currently in progress. */
   val isSyncing: Boolean
 
-  /** Performs a full sync. */
   suspend fun performSync(): SyncResult
 
-  /** Forces server data to overwrite local data. */
   suspend fun forceServerSync(): SyncResult
 
-  /** Forces local data to overwrite server data. */
   suspend fun forceLocalSync(): SyncResult
 }

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/repository/SyncQueueRepository.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/repository/SyncQueueRepository.kt
@@ -5,80 +5,45 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncOperation
 import space.be1ski.vibits.feature.sync.domain.model.SyncOperationStatus
 import space.be1ski.vibits.feature.sync.domain.model.SyncStatus
 
-/**
- * Provides sync status observation capabilities.
- */
 interface SyncStatusProvider {
-  /**
-   * Observes the current sync status.
-   */
   fun observeSyncStatus(): Flow<SyncStatus>
 
-  /**
-   * Returns the current sync status.
-   */
   suspend fun getSyncStatus(): SyncStatus
 }
 
-/**
- * Repository for managing the sync operation queue.
- */
 interface SyncQueueRepository : SyncStatusProvider {
-  /**
-   * Adds an operation to the sync queue.
-   */
   suspend fun addOperation(operation: SyncOperation)
 
-  /**
-   * Returns all pending operations.
-   */
   suspend fun getPendingOperations(): List<SyncOperation>
 
-  /**
-   * Returns all operations regardless of status.
-   */
   suspend fun getAllOperations(): List<SyncOperation>
 
-  /**
-   * Updates the status of an operation.
-   */
   suspend fun updateStatus(
     id: String,
     status: SyncOperationStatus,
   )
 
-  /**
-   * Updates the memo name after successful create (server assigns the name).
-   */
   suspend fun updateMemoName(
     id: String,
     memoName: String,
   )
 
   /**
-   * Updates the content of a pending operation.
-   * Used to coalesce updates to temporary memos into the pending CREATE operation.
-   * @return true if the operation was found and updated, false otherwise
+   * Coalesces updates to temporary memos into the pending CREATE operation.
+   * @return true if the operation was found and updated
    */
   suspend fun updateContent(
     id: String,
     content: String,
   ): Boolean
 
-  /**
-   * Removes a synced operation from the queue.
-   */
   suspend fun removeOperation(id: String)
 
   /**
-   * Clears operations from the queue.
-   * @param syncedOnly If true, only clears synced operations. If false, clears all operations.
+   * @param syncedOnly If true, only clears synced operations. If false, clears all.
    */
   suspend fun clearOperations(syncedOnly: Boolean)
 
-  /**
-   * Resets IN_PROGRESS operations back to PENDING.
-   * Called at startup to recover from crashes during sync.
-   */
+  /** Resets IN_PROGRESS operations back to PENDING to recover from crashes during sync. */
   suspend fun resetInProgressToPending()
 }

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
@@ -11,9 +11,6 @@ import space.be1ski.vibits.feature.sync.domain.model.TempMemoName
 
 private val TAG = SyncLogTags.SYNC_ENGINE
 
-/**
- * Detects conflicts between pending sync operations and server state.
- */
 object DetectSyncConflictsUseCase {
   operator fun invoke(
     pendingOperations: List<SyncOperation>,


### PR DESCRIPTION
## Summary
- Remove KDoc comments that merely restate class/interface/function names across 28 files
- Keep only KDoc that provides non-obvious information (e.g., return value semantics, behavioral notes)
- Follows CLAUDE.md guideline: "Self-documenting code over comments"

## Changes
- **core/**: Remove KDoc from `AppScope`, `AppLanguage`, `LocaleProvider`, `Platform`, `AppDetails`, `AppDetailsProvider`, `DateFormatter`
- **feature/habits/domain/**: Remove KDoc from models (`SuccessRate`, `DailyMemo`, `HabitStatus`, `ActivityMode`) and use cases (`BuildDayDataUseCase`, `BuildActivityDataUseCase`, `GetRangeBoundsUseCase`, `CalculateSuccessRateUseCase`, `ExtractDailyMemosUseCase`)
- **feature/memos/**: Remove KDoc from `MemosRepository`, `MemoStorageManager`, `MemosDefaults`, `OnlineMemosRepository`, `Exporter`
- **feature/auth/**: Remove KDoc from `CredentialsRepository`
- **feature/settings/**: Remove KDoc from `PreferencesRepository`
- **feature/sync/**: Remove KDoc from `SyncEngine`, `SyncQueueRepository`, `SyncStatusProvider`, `DetectSyncConflictsUseCase`
- **feature/homescreen/**: Remove KDoc from `LoadAppDetailsUseCase`, `GetSuccessRateLevelUseCase`

## Test plan
- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, tests)