### PR TITLE
Move DesktopStoragePathsTest to core/platform module

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
@@ -4,39 +4,24 @@ import java.nio.file.Files
 import java.nio.file.Path
 import java.nio.file.Paths
 
-/**
- * Desktop paths for preferences and databases.
- */
 object DesktopStoragePaths {
   private const val APP_NAME = "Memos"
   private const val APP_ID = "space.be1ski.vibits"
   private const val ENVIRONMENT_PROPERTY = "memos.env"
   private const val VERSION_PROPERTY = "memos.version"
 
-  /**
-   * Returns the application version.
-   */
   fun appVersion(): String =
     System.getProperty(VERSION_PROPERTY)?.takeIf { it.isNotBlank() }
       ?: DesktopStoragePaths::class.java.`package`?.implementationVersion
       ?: "dev"
 
-  /**
-   * Returns the preferences node name with an optional environment suffix.
-   */
   fun preferencesNode(): String {
     val env = environmentSuffix()
     return if (env.isBlank()) APP_ID else "$APP_ID.$env"
   }
 
-  /**
-   * Returns the full path to the memo database file.
-   */
   fun databasePath(): String = appDataDir().resolve("memos.db").toString()
 
-  /**
-   * Returns the current environment label.
-   */
   fun environmentLabel(): String = environmentSuffix().ifBlank { "prod" }
 
   private fun appDataDir(): Path {

--- a/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
+++ b/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
@@ -1,6 +1,5 @@
-package space.be1ski.vibits.feature.homescreen.data
+package space.be1ski.vibits.core.platform.app
 
-import space.be1ski.vibits.core.platform.app.DesktopStoragePaths
 import kotlin.test.AfterTest
 import kotlin.test.Test
 import kotlin.test.assertEquals


### PR DESCRIPTION
## Summary
- Moved `DesktopStoragePathsTest` from `feature/homescreen` to `core/platform` where the tested code lives
- Removed redundant KDoc from `DesktopStoragePaths`

## Changes
- Moved `DesktopStoragePathsTest.kt` from `feature/homescreen/src/desktopTest/` to `core/platform/src/desktopTest/`
- Updated package from `feature.homescreen.data` to `core.platform.app`
- Removed redundant KDoc comments from `DesktopStoragePaths.kt`

## Test plan
- [x] `checkJvm` passes
- [x] `:core:platform:desktopTest` passes