### PR TITLE
Align core/utils package naming with module structure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,12 +49,12 @@ The project follows strict package organization to maintain clean architecture a
   - Any code containing @Composable functions
   - **Excluded from coverage** (@Composable cannot be unit tested)
 
-- **`core.date.*`** — Date/time utilities (module: `core/utils`):
+- **`core.utils.date.*`** — Date/time utilities (module: `core/utils`):
   - `DateConstants` — Calendar constants (`DAYS_IN_WEEK`, `MONTHS_IN_QUARTER`, etc.)
   - `DateUtils` — Pure functions: `startOfWeek(LocalDate)`, `quarterIndex(LocalDate|Month)`
   - Uses `kotlinx-datetime`; no platform-specific code
 
-- **`core.logging.*`** — In-memory logging (module: `core/utils`):
+- **`core.utils.logging.*`** — In-memory logging (module: `core/utils`):
   - `Log` — Thread-safe singleton log store (max 500 entries), delegates to `platformLog()`
   - `LogEntry` — Data class: timestamp, level, tag, message
   - `String.maskUrl()` — Truncates URLs for safe logging

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
@@ -16,8 +16,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
-import space.be1ski.vibits.core.logging.LogEntry
 import space.be1ski.vibits.core.platform.logging.LogLevel
+import space.be1ski.vibits.core.utils.logging.LogEntry
 
 private const val LOG_TIMESTAMP_LENGTH = 8
 private val MaxHeight = 400.dp

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/date/DateConstants.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/date/DateConstants.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.date
+package space.be1ski.vibits.core.utils.date
 
 const val DAYS_IN_WEEK = 7
 const val MONTHS_IN_QUARTER = 3

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/date/DateUtils.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/date/DateUtils.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.date
+package space.be1ski.vibits.core.utils.date
 
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.DayOfWeek

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/logging/Log.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/logging/Log.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.logging
+package space.be1ski.vibits.core.utils.logging
 
 import kotlinx.atomicfu.locks.SynchronizedObject
 import kotlinx.atomicfu.locks.synchronized

--- a/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/utils/logging/LogTest.kt
+++ b/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/utils/logging/LogTest.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.logging
+package space.be1ski.vibits.core.utils.logging
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.joinAll

--- a/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
+++ b/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.feature.auth.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
-import space.be1ski.vibits.core.logging.maskUrl
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.maskUrl
 import space.be1ski.vibits.feature.auth.data.platform.CredentialsStore
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.model.trimmed

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/usecase/InitializeCredentialsFromEnvUseCase.kt
@@ -1,9 +1,9 @@
 package space.be1ski.vibits.feature.auth.domain.usecase
 
 import dev.zacsweers.metro.Inject
-import space.be1ski.vibits.core.logging.Log
-import space.be1ski.vibits.core.logging.maskUrl
 import space.be1ski.vibits.core.platform.env.LocalConfigProvider
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.maskUrl
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 
 private const val TAG = "InitCredentialsFromConfig"

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummary.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/ActivitySummary.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
 
 /**
  * Fully prepared dataset for activity charts.

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/BuildActivityDataUseCase.kt
@@ -5,8 +5,8 @@ import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.startOfWeek
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
@@ -1,8 +1,8 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
-import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GenerateActivityRangesUseCase.kt
@@ -3,12 +3,12 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
-import space.be1ski.vibits.core.date.quarterIndex
-import space.be1ski.vibits.core.date.startOfWeek
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.utils.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.utils.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.quarterIndex
+import space.be1ski.vibits.core.utils.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GenerateActivityRangesUseCase {

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetPeriodPostsUseCase.kt
@@ -5,12 +5,12 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.date.FIRST_MONTH_OF_YEAR
-import space.be1ski.vibits.core.date.LAST_DAY_OF_DECEMBER
-import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.utils.date.FIRST_MONTH_OF_YEAR
+import space.be1ski.vibits.core.utils.date.LAST_DAY_OF_DECEMBER
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/GetRangeBoundsUseCase.kt
@@ -5,11 +5,11 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.date.FIRST_QUARTER_INDEX
-import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.utils.date.FIRST_QUARTER_INDEX
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.utils.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.RangeBounds
 

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/NavigateActivityRangeUseCase.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.habits.domain.usecase
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.QUARTERS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.QUARTERS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
@@ -6,8 +6,8 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.extractCompletedHabits
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/DateCalculationsUseCaseTest.kt
@@ -4,8 +4,8 @@ import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.date.quarterIndex
-import space.be1ski.vibits.core.date.startOfWeek
+import space.be1ski.vibits.core.utils.date.quarterIndex
+import space.be1ski.vibits.core.utils.date.startOfWeek
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandler.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsActivityEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.usecase.CalculateActivityDataUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.PrewarmActivityDataUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.model.SaveDailyMemoResult
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsRefreshEffectHandler.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsRefreshEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.habits.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.sideEffect
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 
 private const val TAG = "HabitsRefreshEffect"

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -38,7 +38,6 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.plus
 import kotlinx.datetime.toLocalDateTime
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_configure_habits
 import space.be1ski.vibits.core.strings.generated.action_hide_memos
@@ -59,6 +58,7 @@ import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -47,7 +47,6 @@ import androidx.compose.ui.window.PopupPositionProvider
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.day_fri
 import space.be1ski.vibits.core.strings.generated.day_mon
@@ -65,6 +64,7 @@ import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.core.ui.hoverAware
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 
 internal object ChartDimens {

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.habits.presentation.view.components
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.date.quarterIndex
 import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.utils.date.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/AdjustDateForTabChangeUseCase.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/AdjustDateForTabChangeUseCase.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.homescreen.domain.usecase
 
 import kotlinx.datetime.LocalDate
-import space.be1ski.vibits.core.date.quarterIndex
+import space.be1ski.vibits.core.utils.date.quarterIndex
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetActivityRangeEndDateUseCase.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetActivityRangeEndDateUseCase.kt
@@ -5,10 +5,10 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
 import kotlinx.datetime.minus
 import kotlinx.datetime.plus
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
-import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
-import space.be1ski.vibits.core.date.MONTHS_IN_YEAR
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.core.utils.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_YEAR
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 object GetActivityRangeEndDateUseCase {

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetActivityRangeStartDateUseCase.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/usecase/GetActivityRangeStartDateUseCase.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.homescreen.domain.usecase
 
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
-import space.be1ski.vibits.core.date.FIRST_DAY_OF_MONTH
-import space.be1ski.vibits.core.date.MONTHS_IN_QUARTER
+import space.be1ski.vibits.core.utils.date.FIRST_DAY_OF_MONTH
+import space.be1ski.vibits.core.utils.date.MONTHS_IN_QUARTER
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -14,11 +14,11 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.date.quarterIndex
-import space.be1ski.vibits.core.date.startOfWeek
 import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.utils.date.quarterIndex
+import space.be1ski.vibits.core.utils.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.parseConfigFromContent

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/TimeRangeControls.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/TimeRangeControls.kt
@@ -24,7 +24,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.datetime.DatePeriod
 import kotlinx.datetime.plus
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.date.DAYS_IN_WEEK
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_next
@@ -37,6 +36,7 @@ import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
+import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.homescreen.domain.model.SuccessRateLevel
 import space.be1ski.vibits.feature.homescreen.domain.usecase.GetSuccessRateLevelUseCase

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.memos.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
 

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepository.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.feature.memos.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.demo.DemoMemosRepository
 import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosRepository
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.memos.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.requireFilled
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/export/Exporter.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/export/Exporter.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.memos.data.export
 
 import dev.zacsweers.metro.Inject
 import kotlinx.serialization.json.Json
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.export.FileExporter
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
 import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
 import kotlin.time.Clock

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
@@ -14,8 +14,8 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.dto.CreateMemoRequestDto
 import space.be1ski.vibits.feature.memos.data.remote.dto.ListMemosResponseDto
 import space.be1ski.vibits.feature.memos.data.remote.dto.MemoDto

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.memos.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadCachedMemosUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadMemosUseCase
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import space.be1ski.vibits.feature.sync.domain.SyncEngine
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.memos.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.usecase.CreateMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.DeleteMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.UpdateMemoUseCase

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
@@ -9,14 +9,14 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.logging.Log
-import space.be1ski.vibits.core.logging.LogEntry
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_clear
 import space.be1ski.vibits.core.strings.generated.action_close
 import space.be1ski.vibits.core.strings.generated.msg_no_logs
 import space.be1ski.vibits.core.strings.generated.title_sync_logs
 import space.be1ski.vibits.core.ui.LogViewer
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags
 
 /**

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.mode.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
-import space.be1ski.vibits.core.logging.maskUrl
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.maskUrl
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.model.isFilled
 import space.be1ski.vibits.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionModeEffectHandler.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionModeEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.mode.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.mode.domain.usecase.SaveAppModeUseCase
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/OnboardingRepositoryImpl.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/OnboardingRepositoryImpl.kt
@@ -2,8 +2,8 @@ package space.be1ski.vibits.feature.onboarding.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
 import space.be1ski.vibits.feature.memos.domain.model.isConfigMemo
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingCompletionEffectHandler.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingCompletionEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.onboarding.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.onboarding.domain.usecase.MarkOnboardingCompletedUseCase
 import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction
 

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingPresetsEffectHandler.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingPresetsEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.onboarding.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.onboarding.domain.usecase.GetHabitPresetsUseCase
 import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction
 

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingSetupEffectHandler.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/effect/OnboardingSetupEffectHandler.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.onboarding.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.date.currentLocalDate
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.onboarding.domain.usecase.CreateFirstCheckInUseCase
 import space.be1ski.vibits.feature.onboarding.domain.usecase.CreateFirstHabitUseCase
 import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesKeyMigration.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesKeyMigration.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.settings.data
 
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.storage.KeyValueStore
+import space.be1ski.vibits.core.utils.logging.Log
 
 private const val TAG = "PrefsMigration"
 

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
@@ -2,9 +2,9 @@ package space.be1ski.vibits.feature.settings.data
 
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsModeEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsModeEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.mode.domain.usecase.ResetAppUseCase
 import space.be1ski.vibits.feature.mode.domain.usecase.ResetAppWithMemosUseCase
 import space.be1ski.vibits.feature.mode.domain.usecase.SwitchAppModeUseCase

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsPreferencesEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsPreferencesEffectHandler.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.sideEffect
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveLanguageUseCase
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveThemeUseCase
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -49,7 +49,6 @@ import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.app.AppDetails
 import space.be1ski.vibits.core.platform.export.createFileExporter
 import space.be1ski.vibits.core.platform.locale.AppLanguage
@@ -119,6 +118,7 @@ import space.be1ski.vibits.core.strings.generated.title_logs
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.LogViewer
 import space.be1ski.vibits.core.ui.SegmentedSelector
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.export.ExportResult
 import space.be1ski.vibits.feature.memos.data.export.Exporter
 import space.be1ski.vibits.feature.memos.data.platform.createOfflineMemoStorage

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepository.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepository.kt
@@ -4,8 +4,8 @@ import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.platform.MemoCache
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
@@ -5,8 +5,8 @@ import dev.zacsweers.metro.SingleIn
 import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
-import space.be1ski.vibits.core.logging.Log
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.isFilled
 import space.be1ski.vibits.feature.auth.domain.model.trimmed
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.feature.sync.data
 
 import kotlinx.coroutines.delay
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.mapper.MemoMapper
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
@@ -1,6 +1,6 @@
 package space.be1ski.vibits.feature.sync.domain.usecase
 
-import space.be1ski.vibits.core.logging.Log
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags
 import space.be1ski.vibits.feature.sync.domain.model.ConflictType


### PR DESCRIPTION
## Summary

The `core/utils` module had packages `core.date` and `core.logging` instead of `core.utils.date` and `core.utils.logging`. This violated the convention that package structure mirrors module structure.

## Changes
- Renamed `space.be1ski.vibits.core.date` → `space.be1ski.vibits.core.utils.date`
- Renamed `space.be1ski.vibits.core.logging` → `space.be1ski.vibits.core.utils.logging`
- Moved source files to matching directory structure
- Updated all imports across the codebase (53 files)
- Added `core.utils.date.*` and `core.utils.logging.*` package documentation to CLAUDE.md and AGENTS.md

## Test plan
- [x] `checkJvm` passes (compile + ktlint + detekt + tests)
- [x] Pre-commit hook passes
- [x] No old package references remain