### PR TITLE
Unify credential validation errors and create auth presentation module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ core/
   ui/            — Compose UI components and theme
   utils/         — Shared utilities (date, logging)
 feature/
-  auth/          — Authentication (domain, domain/testing, data)
+  auth/          — Authentication (domain, domain/testing, data, presentation)
   habits/        — Habits tracking (domain, presentation)
   homescreen/    — App graph, DI wiring, coordinator
   memos/         — Memos API (domain, domain/testing, data, data/testing, presentation)

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/CredentialValidationError.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/model/CredentialValidationError.kt
@@ -1,0 +1,6 @@
+package space.be1ski.vibits.feature.auth.domain.model
+
+enum class CredentialValidationError {
+  FILL_ALL_FIELDS,
+  CONNECTION_FAILED,
+}

--- a/feature/auth/presentation/build.gradle.kts
+++ b/feature/auth/presentation/build.gradle.kts
@@ -1,0 +1,19 @@
+plugins {
+  id("vibits.kmp.compose")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(projects.core.strings)
+        implementation(projects.feature.auth.domain)
+        implementation(libs.compose.foundation)
+        implementation(libs.compose.material3)
+        implementation(libs.compose.resources)
+        implementation(libs.compose.runtime)
+        implementation(libs.compose.ui)
+      }
+    }
+  }
+}

--- a/feature/auth/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/presentation/view/CredentialFields.kt
+++ b/feature/auth/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/presentation/view/CredentialFields.kt
@@ -1,0 +1,56 @@
+package space.be1ski.vibits.feature.auth.presentation.view
+
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.input.PasswordVisualTransformation
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.hint_base_url
+import space.be1ski.vibits.core.strings.generated.label_access_token
+import space.be1ski.vibits.core.strings.generated.label_base_url
+import space.be1ski.vibits.core.strings.generated.msg_connection_failed
+import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+
+/**
+ * Emits two TextFields (base URL + access token) into the calling Column scope.
+ * Does not wrap in its own Column so consumers control spacing and layout.
+ */
+@Composable
+fun ColumnScope.CredentialFields(
+  baseUrl: String,
+  token: String,
+  onBaseUrlChange: (String) -> Unit,
+  onTokenChange: (String) -> Unit,
+  enabled: Boolean = true,
+) {
+  TextField(
+    value = baseUrl,
+    onValueChange = onBaseUrlChange,
+    label = { Text(stringResource(Res.string.label_base_url)) },
+    placeholder = { Text(stringResource(Res.string.hint_base_url)) },
+    enabled = enabled,
+    modifier = Modifier.fillMaxWidth(),
+    singleLine = true,
+  )
+  TextField(
+    value = token,
+    onValueChange = onTokenChange,
+    label = { Text(stringResource(Res.string.label_access_token)) },
+    visualTransformation = PasswordVisualTransformation(),
+    enabled = enabled,
+    modifier = Modifier.fillMaxWidth(),
+    singleLine = true,
+  )
+}
+
+@Composable
+fun credentialValidationErrorMessage(error: CredentialValidationError): String =
+  when (error) {
+    CredentialValidationError.FILL_ALL_FIELDS -> stringResource(Res.string.msg_fill_all_fields)
+    CredentialValidationError.CONNECTION_FAILED -> stringResource(Res.string.msg_connection_failed)
+  }

--- a/feature/mode/presentation/build.gradle.kts
+++ b/feature/mode/presentation/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         implementation(projects.core.ui)
         implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
+        implementation(projects.feature.auth.presentation)
         implementation(projects.feature.memos.domain)
         implementation(projects.feature.mode.domain)
         implementation(libs.compose.resources)

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
@@ -3,10 +3,10 @@ package space.be1ski.vibits.feature.mode.presentation.reducer
 import space.be1ski.vibits.core.elm.Reducer
 import space.be1ski.vibits.core.elm.reducer
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
-import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionError
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
 
 internal val validationReducer: Reducer<ModeSelectionAction.Validation, ModeSelectionState, Command, Notification> =
@@ -16,7 +16,7 @@ internal val validationReducer: Reducer<ModeSelectionAction.Validation, ModeSele
         val baseUrl = state.baseUrl.trim()
         val token = state.token.trim()
         if (baseUrl.isBlank() || token.isBlank()) {
-          state { state.copy(error = ModeSelectionError.FILL_ALL_FIELDS) }
+          state { state.copy(error = CredentialValidationError.FILL_ALL_FIELDS) }
         } else {
           state { state.copy(isValidating = true, error = null) }
           command(Command.ValidateCredentials(baseUrl, token))
@@ -45,7 +45,7 @@ internal val validationReducer: Reducer<ModeSelectionAction.Validation, ModeSele
       }
 
       is ModeSelectionAction.Validation.Failed -> {
-        state { state.copy(isValidating = false, error = ModeSelectionError.CONNECTION_FAILED) }
+        state { state.copy(isValidating = false, error = CredentialValidationError.CONNECTION_FAILED) }
       }
     }
   }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
@@ -1,5 +1,7 @@
 package space.be1ski.vibits.feature.mode.presentation.state
 
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+
 data class ModeSelectionState(
   val showCredentialsDialog: Boolean = false,
   val showQuickOnlineDialog: Boolean = false,
@@ -7,10 +9,5 @@ data class ModeSelectionState(
   val baseUrl: String = "",
   val token: String = "",
   val isValidating: Boolean = false,
-  val error: ModeSelectionError? = null,
+  val error: CredentialValidationError? = null,
 )
-
-enum class ModeSelectionError {
-  FILL_ALL_FIELDS,
-  CONNECTION_FAILED,
-}

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -17,13 +17,11 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.elm.Feature
@@ -32,9 +30,6 @@ import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
 import space.be1ski.vibits.core.strings.generated.action_save
 import space.be1ski.vibits.core.strings.generated.action_use_saved
-import space.be1ski.vibits.core.strings.generated.hint_base_url
-import space.be1ski.vibits.core.strings.generated.label_access_token
-import space.be1ski.vibits.core.strings.generated.label_base_url
 import space.be1ski.vibits.core.strings.generated.mode_demo_desc
 import space.be1ski.vibits.core.strings.generated.mode_demo_title
 import space.be1ski.vibits.core.strings.generated.mode_offline_desc
@@ -45,12 +40,11 @@ import space.be1ski.vibits.core.strings.generated.mode_quick_online_desc
 import space.be1ski.vibits.core.strings.generated.mode_quick_online_title
 import space.be1ski.vibits.core.strings.generated.mode_select_subtitle
 import space.be1ski.vibits.core.strings.generated.mode_select_title
-import space.be1ski.vibits.core.strings.generated.msg_connection_failed
-import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.auth.presentation.view.CredentialFields
+import space.be1ski.vibits.feature.auth.presentation.view.credentialValidationErrorMessage
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
-import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionError
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
 
 @Composable
@@ -159,45 +153,26 @@ private fun QuickOnlineDialog(
   )
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun CredentialsSetupDialog(
   state: ModeSelectionState,
   dispatch: (ModeSelectionAction) -> Unit,
 ) {
-  val errorText =
-    when (state.error) {
-      ModeSelectionError.FILL_ALL_FIELDS -> stringResource(Res.string.msg_fill_all_fields)
-      ModeSelectionError.CONNECTION_FAILED -> stringResource(Res.string.msg_connection_failed)
-      null -> null
-    }
-
   AlertDialog(
     onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.Dialog.Dismiss) },
     title = { Text(stringResource(Res.string.mode_online_title)) },
     text = {
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
-        TextField(
-          value = state.baseUrl,
-          onValueChange = { dispatch(ModeSelectionAction.Input.UpdateBaseUrl(it)) },
-          label = { Text(stringResource(Res.string.label_base_url)) },
-          placeholder = { Text(stringResource(Res.string.hint_base_url)) },
+        CredentialFields(
+          baseUrl = state.baseUrl,
+          token = state.token,
+          onBaseUrlChange = { dispatch(ModeSelectionAction.Input.UpdateBaseUrl(it)) },
+          onTokenChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
           enabled = !state.isValidating,
-          modifier = Modifier.fillMaxWidth(),
-          singleLine = true,
         )
-        TextField(
-          value = state.token,
-          onValueChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
-          label = { Text(stringResource(Res.string.label_access_token)) },
-          visualTransformation = PasswordVisualTransformation(),
-          enabled = !state.isValidating,
-          modifier = Modifier.fillMaxWidth(),
-          singleLine = true,
-        )
-        errorText?.let { error ->
+        state.error?.let { error ->
           Text(
-            text = error,
+            text = credentialValidationErrorMessage(error),
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodySmall,
           )

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -2,11 +2,11 @@ package space.be1ski.vibits.feature.mode.presentation
 
 import space.be1ski.vibits.core.elm.test.test
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
 import space.be1ski.vibits.feature.mode.presentation.reducer.modeSelectionReducer
-import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionError
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -14,7 +14,7 @@ import kotlin.test.assertEquals
 class ModeSelectionReducerTest {
   @Test
   fun `when Dialog Show then shows dialog and clears error`() =
-    modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
+    modeSelectionReducer.test(ModeSelectionState(error = CredentialValidationError.FILL_ALL_FIELDS)) {
       send(ModeSelectionAction.Dialog.Show)
 
       assertState { showCredentialsDialog && error == null }
@@ -29,7 +29,7 @@ class ModeSelectionReducerTest {
         baseUrl = "https://api.com",
         token = "secret",
         isValidating = true,
-        error = ModeSelectionError.CONNECTION_FAILED,
+        error = CredentialValidationError.CONNECTION_FAILED,
       ),
     ) {
       send(ModeSelectionAction.Dialog.Dismiss)
@@ -46,7 +46,7 @@ class ModeSelectionReducerTest {
 
   @Test
   fun `when Input UpdateBaseUrl then updates baseUrl and clears error`() =
-    modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
+    modeSelectionReducer.test(ModeSelectionState(error = CredentialValidationError.FILL_ALL_FIELDS)) {
       send(ModeSelectionAction.Input.UpdateBaseUrl("https://new.api.com"))
 
       assertState { baseUrl == "https://new.api.com" && error == null }
@@ -55,7 +55,7 @@ class ModeSelectionReducerTest {
 
   @Test
   fun `when Input UpdateToken then updates token and clears error`() =
-    modeSelectionReducer.test(ModeSelectionState(error = ModeSelectionError.FILL_ALL_FIELDS)) {
+    modeSelectionReducer.test(ModeSelectionState(error = CredentialValidationError.FILL_ALL_FIELDS)) {
       send(ModeSelectionAction.Input.UpdateToken("new-token"))
 
       assertState { token == "new-token" && error == null }
@@ -67,7 +67,7 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "", token = "")) {
       send(ModeSelectionAction.Validation.Submit)
 
-      assertState { error == ModeSelectionError.FILL_ALL_FIELDS && !isValidating }
+      assertState { error == CredentialValidationError.FILL_ALL_FIELDS && !isValidating }
       assertNoEffects()
     }
 
@@ -76,7 +76,7 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "  ", token = "token123")) {
       send(ModeSelectionAction.Validation.Submit)
 
-      assertState { error == ModeSelectionError.FILL_ALL_FIELDS }
+      assertState { error == CredentialValidationError.FILL_ALL_FIELDS }
       assertNoEffects()
     }
 
@@ -85,7 +85,7 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState(baseUrl = "https://api.com", token = "  ")) {
       send(ModeSelectionAction.Validation.Submit)
 
-      assertState { error == ModeSelectionError.FILL_ALL_FIELDS }
+      assertState { error == CredentialValidationError.FILL_ALL_FIELDS }
       assertNoEffects()
     }
 
@@ -174,7 +174,7 @@ class ModeSelectionReducerTest {
     modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
       send(ModeSelectionAction.Validation.Failed)
 
-      assertState { !isValidating && error == ModeSelectionError.CONNECTION_FAILED }
+      assertState { !isValidating && error == CredentialValidationError.CONNECTION_FAILED }
       assertNoEffects()
     }
 

--- a/feature/settings/presentation/build.gradle.kts
+++ b/feature/settings/presentation/build.gradle.kts
@@ -13,6 +13,7 @@ kotlin {
         implementation(projects.core.ui)
         implementation(projects.core.utils)
         implementation(projects.feature.auth.domain)
+        implementation(projects.feature.auth.presentation)
         implementation(projects.feature.memos.data)
         implementation(projects.feature.memos.domain)
         implementation(projects.feature.mode.domain)

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.action
 import space.be1ski.vibits.core.elm.Action
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 sealed interface SettingsAction : Action {
@@ -57,7 +58,7 @@ sealed interface SettingsAction : Action {
     data object ValidationSucceeded : Validation
 
     data class ValidationFailed(
-      val error: String,
+      val error: CredentialValidationError,
     ) : Validation
   }
 

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
@@ -4,6 +4,7 @@ import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
 import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
@@ -26,7 +27,7 @@ class SettingsCredentialsEffectHandler(
       Log.d(TAG, "Testing connection")
       connectionTester(command.baseUrl, command.token)
         .onSuccess { emit(SettingsAction.Validation.ValidationSucceeded) }
-        .onFailure { emit(SettingsAction.Validation.ValidationFailed("connection_failed")) }
+        .onFailure { emit(SettingsAction.Validation.ValidationFailed(CredentialValidationError.CONNECTION_FAILED)) }
     }
 
   private fun handleSaveCredentials(command: SettingsEffect.Command.SaveCredentials): Flow<SettingsAction> =

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.reducer
 import space.be1ski.vibits.core.elm.Reducer
 import space.be1ski.vibits.core.elm.reducer
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
@@ -23,7 +24,7 @@ internal val saveAndLogsReducer: Reducer<SettingsAction.SaveAndLogs, SettingsSta
           val baseUrl = state.editBaseUrl.trim()
           val token = state.editToken.trim()
           if (baseUrl.isBlank() || token.isBlank()) {
-            state { state.copy(validationError = "fill_all_fields") }
+            state { state.copy(validationError = CredentialValidationError.FILL_ALL_FIELDS) }
           } else {
             state { state.copy(isValidating = true, validationError = null, pendingSave = true) }
             command(SettingsEffect.Command.ValidateCredentials(baseUrl, token, AppMode.ONLINE))

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.state
 import space.be1ski.vibits.core.platform.app.AppDetails
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 data class SettingsState(
@@ -14,7 +15,7 @@ data class SettingsState(
   val languageChanged: Boolean = false,
   val selectedTheme: AppTheme = AppTheme.SYSTEM,
   val isValidating: Boolean = false,
-  val validationError: String? = null,
+  val validationError: CredentialValidationError? = null,
   val showResetConfirmation: Boolean = false,
   val isResetting: Boolean = false,
   val showLogsDialog: Boolean = false,

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -29,7 +29,6 @@ import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
-import androidx.compose.material3.TextField
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -43,7 +42,6 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.delay
@@ -68,10 +66,7 @@ import space.be1ski.vibits.core.strings.generated.action_reset_settings_only
 import space.be1ski.vibits.core.strings.generated.action_reset_with_memos
 import space.be1ski.vibits.core.strings.generated.action_save
 import space.be1ski.vibits.core.strings.generated.action_view_logs
-import space.be1ski.vibits.core.strings.generated.hint_base_url
-import space.be1ski.vibits.core.strings.generated.label_access_token
 import space.be1ski.vibits.core.strings.generated.label_app_mode
-import space.be1ski.vibits.core.strings.generated.label_base_url
 import space.be1ski.vibits.core.strings.generated.label_credentials
 import space.be1ski.vibits.core.strings.generated.label_environment
 import space.be1ski.vibits.core.strings.generated.label_language
@@ -103,10 +98,8 @@ import space.be1ski.vibits.core.strings.generated.language_uzbek
 import space.be1ski.vibits.core.strings.generated.mode_demo_title
 import space.be1ski.vibits.core.strings.generated.mode_offline_title
 import space.be1ski.vibits.core.strings.generated.mode_online_title
-import space.be1ski.vibits.core.strings.generated.msg_connection_failed
 import space.be1ski.vibits.core.strings.generated.msg_export_failed
 import space.be1ski.vibits.core.strings.generated.msg_export_success
-import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 import space.be1ski.vibits.core.strings.generated.msg_no_logs
 import space.be1ski.vibits.core.strings.generated.msg_reset_choose_option
 import space.be1ski.vibits.core.strings.generated.msg_restart_required
@@ -119,6 +112,8 @@ import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.LogViewer
 import space.be1ski.vibits.core.ui.SegmentedSelector
 import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.feature.auth.presentation.view.CredentialFields
+import space.be1ski.vibits.feature.auth.presentation.view.credentialValidationErrorMessage
 import space.be1ski.vibits.feature.memos.data.export.ExportResult
 import space.be1ski.vibits.feature.memos.data.export.Exporter
 import space.be1ski.vibits.feature.memos.data.platform.createOfflineMemoStorage
@@ -163,23 +158,18 @@ private fun SettingsDialogBody(
   state: SettingsState,
   dispatch: (SettingsAction) -> Unit,
 ) {
-  val validationErrorMessage =
-    state.validationError?.let { errorKey ->
-      when (errorKey) {
-        "fill_all_fields" -> stringResource(Res.string.msg_fill_all_fields)
-        "connection_failed" -> stringResource(Res.string.msg_connection_failed)
-        else -> errorKey
-      }
-    }
-
   Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
     AppModeSelector(
       currentMode = state.appMode,
       isValidating = state.isValidating,
       onModeChange = { mode -> dispatch(SettingsAction.Input.SelectMode(mode)) },
     )
-    validationErrorMessage?.let { error ->
-      Text(error, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    state.validationError?.let { error ->
+      Text(
+        credentialValidationErrorMessage(error),
+        color = MaterialTheme.colorScheme.error,
+        style = MaterialTheme.typography.bodySmall,
+      )
     }
     SegmentedSelector(
       label = stringResource(Res.string.label_theme),
@@ -206,21 +196,11 @@ private fun SettingsDialogBody(
       )
     }
     if (state.appMode == AppMode.ONLINE) {
-      TextField(
-        value = state.editBaseUrl,
-        onValueChange = { dispatch(SettingsAction.Input.UpdateBaseUrl(it)) },
-        label = { Text(stringResource(Res.string.label_base_url)) },
-        placeholder = { Text(stringResource(Res.string.hint_base_url)) },
-        singleLine = true,
-        modifier = Modifier.fillMaxWidth(),
-      )
-      TextField(
-        value = state.editToken,
-        onValueChange = { dispatch(SettingsAction.Input.UpdateToken(it)) },
-        label = { Text(stringResource(Res.string.label_access_token)) },
-        visualTransformation = PasswordVisualTransformation(),
-        singleLine = true,
-        modifier = Modifier.fillMaxWidth(),
+      CredentialFields(
+        baseUrl = state.editBaseUrl,
+        token = state.editToken,
+        onBaseUrlChange = { dispatch(SettingsAction.Input.UpdateBaseUrl(it)) },
+        onTokenChange = { dispatch(SettingsAction.Input.UpdateToken(it)) },
       )
     }
     ActionsRow(

--- a/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
+++ b/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation
 import space.be1ski.vibits.core.elm.test.test
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect
@@ -44,7 +45,7 @@ class SettingsReducerTest {
       SettingsState(
         isOpen = true,
         showLogsDialog = true,
-        validationError = "error",
+        validationError = CredentialValidationError.CONNECTION_FAILED,
       ),
     ) {
       send(SettingsAction.Dialog.Close)
@@ -67,7 +68,7 @@ class SettingsReducerTest {
     settingsReducer.test(
       SettingsState(
         editToken = "token123",
-        validationError = "old error",
+        validationError = CredentialValidationError.FILL_ALL_FIELDS,
       ),
     ) {
       send(SettingsAction.Input.UpdateBaseUrl("https://new.api.com"))
@@ -81,7 +82,7 @@ class SettingsReducerTest {
     settingsReducer.test(
       SettingsState(
         editBaseUrl = "https://api.com",
-        validationError = "old error",
+        validationError = CredentialValidationError.FILL_ALL_FIELDS,
       ),
     ) {
       send(SettingsAction.Input.UpdateToken("new-token"))
@@ -95,7 +96,7 @@ class SettingsReducerTest {
     settingsReducer.test(
       SettingsState(
         appMode = AppMode.ONLINE,
-        validationError = "old error",
+        validationError = CredentialValidationError.FILL_ALL_FIELDS,
       ),
     ) {
       send(SettingsAction.Input.SelectMode(AppMode.OFFLINE))
@@ -156,9 +157,9 @@ class SettingsReducerTest {
         pendingSave = true,
       ),
     ) {
-      send(SettingsAction.Validation.ValidationFailed("connection_failed"))
+      send(SettingsAction.Validation.ValidationFailed(CredentialValidationError.CONNECTION_FAILED))
 
-      assertState { !isValidating && !pendingSave && validationError == "connection_failed" }
+      assertState { !isValidating && !pendingSave && validationError == CredentialValidationError.CONNECTION_FAILED }
       assertNoEffects()
     }
 
@@ -271,7 +272,7 @@ class SettingsReducerTest {
     ) {
       send(SettingsAction.SaveAndLogs.Save)
 
-      assertState { isOpen && validationError == "fill_all_fields" }
+      assertState { isOpen && validationError == CredentialValidationError.FILL_ALL_FIELDS }
       assertNoEffects()
     }
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -43,6 +43,7 @@ include(
   ":feature:auth:domain",
   ":feature:auth:domain:testing",
   ":feature:auth:data",
+  ":feature:auth:presentation",
 
   ":feature:memos:domain",
   ":feature:memos:domain:testing",


### PR DESCRIPTION
## Summary
- Create shared `CredentialValidationError` enum in `auth/domain/model/` replacing duplicated error types
- Create `feature/auth/presentation` module with reusable credential input composables
- Replace `ModeSelectionError` enum in mode feature with shared domain type
- Replace stringly-typed `validationError: String?` in settings with type-safe `CredentialValidationError?`

## Changes
- **New**: `CredentialValidationError` enum in `feature/auth/domain/model/`
- **New**: `feature/auth/presentation` module with `CredentialFields` and `credentialValidationErrorMessage` composables
- **Deleted**: `ModeSelectionError` enum from `mode/presentation/state/`
- **Updated**: Mode reducers, UI, and tests to use `CredentialValidationError`
- **Updated**: Settings state, actions, reducers, effect handler, UI, and tests to use `CredentialValidationError` instead of strings
- **Updated**: Both features now use shared `CredentialFields` composable instead of duplicated TextFields

## Test plan
- [x] `./gradlew checkJvm` passes (ktlint + detekt + compile + tests)
- [x] Mode reducer tests updated and passing
- [x] Settings reducer tests updated and passing
- [x] Settings effect handler tests passing (no changes needed)