### PR TITLE
Reuse CalculateActivityDataUseCase instance and add MemoStorageManagerImpl test

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
@@ -36,18 +36,18 @@ fun createHabitsFeature(
             onRefresh = onRefresh,
           ),
         activityHandler =
-          HabitsActivityEffectHandler(
-            calculateActivityDataUseCase =
+          run {
+            val calculateActivityData =
               CalculateActivityDataUseCase(
                 buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-              ),
-            prewarmActivityDataUseCase =
-              PrewarmActivityDataUseCase(
-                calculateActivityDataUseCase =
-                  CalculateActivityDataUseCase(
-                    buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-                  ),
-              ),
-          ),
+              )
+            HabitsActivityEffectHandler(
+              calculateActivityDataUseCase = calculateActivityData,
+              prewarmActivityDataUseCase =
+                PrewarmActivityDataUseCase(
+                  calculateActivityDataUseCase = calculateActivityData,
+                ),
+            )
+          },
       ),
   )

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemoStorageManagerImplTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemoStorageManagerImplTest.kt
@@ -1,0 +1,47 @@
+package space.be1ski.vibits.feature.memos.data
+
+import space.be1ski.vibits.feature.memos.data.offline.OfflineMemoDto
+import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
+import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MemoStorageManagerImplTest {
+  @Test
+  fun `when clearAll then saves empty memo list to storage`() {
+    val storage =
+      RecordingOfflineMemoStorage(
+        initial =
+          OfflineMemosFileDto(
+            memos =
+              listOf(
+                OfflineMemoDto(name = "memos/1", content = "test"),
+                OfflineMemoDto(name = "memos/2", content = "test2"),
+              ),
+          ),
+      )
+    val manager = MemoStorageManagerImpl(storage)
+
+    manager.clearAll()
+
+    assertEquals(1, storage.saveCalls)
+    assertTrue(storage.stored.memos.isEmpty())
+  }
+}
+
+private class RecordingOfflineMemoStorage(
+  initial: OfflineMemosFileDto = OfflineMemosFileDto(),
+) : OfflineMemoStorage {
+  var stored: OfflineMemosFileDto = initial
+    private set
+  var saveCalls: Int = 0
+    private set
+
+  override fun load(): OfflineMemosFileDto = stored
+
+  override fun save(data: OfflineMemosFileDto) {
+    stored = data
+    saveCalls += 1
+  }
+}


### PR DESCRIPTION
## Summary
- Fixed duplicate `CalculateActivityDataUseCase` instantiation in `HabitsFeatureFactory` — now creates one instance and passes it to both `HabitsActivityEffectHandler` and `PrewarmActivityDataUseCase`
- Added unit test for `MemoStorageManagerImpl.clearAll()`, the only repository implementation without test coverage

## Changes
- **feature/habits/di/HabitsFeatureFactory.kt** — extract `calculateActivityData` val, reuse in both consumers
- **feature/memos/data (test)** — new `MemoStorageManagerImplTest` verifying `clearAll()` delegates to storage correctly

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] New test verifies `MemoStorageManagerImpl.clearAll()` saves empty list to storage