### PR TITLE
Move expect/actual UI helpers to core.ui.platform subpackage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The project follows strict package organization to maintain clean architecture a
 
 - **`core.ui.*`** — UI layer with Compose code:
   - `core.ui.theme.*` — Theming, colors, typography
+  - `core.ui.platform.*` — UI-specific expect/actual declarations (`hoverAware`, `ConfigureSystemBars`, `rememberSystemDarkTheme`)
   - `core.ui.date.DateFormatter` — UI helpers with @Composable functions
   - Any code containing @Composable functions
   - **Excluded from coverage** (@Composable cannot be unit tested)
@@ -72,6 +73,7 @@ Within `feature/<name>/data/`:
 
 - **`data/room/`** — Room database implementations (platform-specific):
   - DAO interfaces, entities, database classes
+  - **Exception:** `MemoDatabaseConstructor` expect/actual lives here (not in `data/platform/`) because Room KMP requires `@ConstructedBy` object to be in the same package as the `@Database` class
   - Excluded from coverage (platform-specific, tested via integration tests)
 
 - **`data/platform/`** — **ONLY expect/actual declarations**:

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on iOS; return the modifier unchanged.
+ * Hover events are not available on Android; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import android.app.Activity
 import androidx.activity.ComponentActivity

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import space.be1ski.vibits.core.ui.platform.theme.ConfigureSystemBars
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 
 /**
  * CompositionLocal for the current dark theme state.

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on Android; return the modifier unchanged.
+ * Hover events are not available on iOS; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -61,7 +61,7 @@ import space.be1ski.vibits.core.strings.generated.title_create_day
 import space.be1ski.vibits.core.strings.generated.title_edit_day
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
-import space.be1ski.vibits.core.ui.hoverAware
+import space.be1ski.vibits.core.ui.platform.hoverAware
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
 import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
-import space.be1ski.vibits.core.ui.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme


### PR DESCRIPTION
## Summary
- Moved `HoverAware`, `SystemBars`, `SystemTheme` expect/actual declarations from `core.ui`/`core.ui.theme` to `core.ui.platform`/`core.ui.platform.theme` to align with the `*.platform.*` package rule
- Documented Room `MemoDatabaseConstructor` as a same-package exception in CLAUDE.md (Room KMP requires `@ConstructedBy` in same package as `@Database`)

## Changes
- Moved 15 files (3 declarations x 5 source sets) to `platform` subpackage
- Updated imports in `VibitsTheme`, `AppRoot`, `ContributionGrid`
- Updated CLAUDE.md/AGENTS.md with new `core.ui.platform` docs and Room exception note

## Test plan
- [x] `checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)