### PR TITLE
Replace hardcoded UI strings with localized resources

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The project follows strict package organization to maintain clean architecture a
 
 - **`core.ui.*`** — UI layer with Compose code:
   - `core.ui.theme.*` — Theming, colors, typography
+  - `core.ui.platform.*` — UI-specific expect/actual declarations (`hoverAware`, `ConfigureSystemBars`, `rememberSystemDarkTheme`)
   - `core.ui.date.DateFormatter` — UI helpers with @Composable functions
   - Any code containing @Composable functions
   - **Excluded from coverage** (@Composable cannot be unit tested)
@@ -72,6 +73,7 @@ Within `feature/<name>/data/`:
 
 - **`data/room/`** — Room database implementations (platform-specific):
   - DAO interfaces, entities, database classes
+  - **Exception:** `MemoDatabaseConstructor` expect/actual lives here (not in `data/platform/`) because Room KMP requires `@ConstructedBy` object to be in the same package as the `@Database` class
   - Excluded from coverage (platform-specific, tested via integration tests)
 
 - **`data/platform/`** — **ONLY expect/actual declarations**:

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">رجوع</string>
     <string name="action_cancel">إلغاء</string>
     <string name="action_create_new_config">إنشاء تكوين جديد (موصى به)</string>
     <string name="action_edit_anyway">تحرير على أي حال</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d من %2$d عادات مكتملة</string>
     <string name="format_memos_db">قاعدة بيانات المذكرات: %1$s</string>
     <string name="format_offline_storage">غير متصل: %1$s</string>
+    <string name="format_quarter_label">الربع %1$d %2$d</string>
     <string name="format_memos_count">%1$d مذكرة</string>
     <string name="format_memos_today">%1$d مذكرة اليوم</string>
     <string name="format_memos_this_week">%1$d مذكرة هذا الأسبوع</string>
@@ -104,6 +106,7 @@
     <string name="label_language">اللغة</string>
     <string name="label_memos_db">قاعدة بيانات المذكرات</string>
     <string name="label_post_filter">تصفية</string>
+    <string name="label_selected">محدد</string>
     <string name="label_storage">التخزين</string>
     <string name="label_success_rate">معدل النجاح</string>
     <string name="label_theme">السمة</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">عادي</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">تم اكتشاف %1$d تعارض</string>
     <string name="format_active_since">نشط منذ %1$s</string>
     <string name="msg_connection_failed">فشل الاتصال</string>
     <string name="msg_edit_config_warning">أنت على وشك تعديل تكوين موجود. سيؤثر ذلك على جميع البيانات التاريخية.
@@ -135,6 +139,7 @@
     <string name="msg_fill_all_fields">يرجى ملء جميع الحقول</string>
     <string name="msg_habit_name_required">اسم العادة مطلوب</string>
     <string name="msg_habit_setup">اختر اسماً ذا معنى لعادتك.</string>
+    <string name="msg_no_habits_tracked">لم يتم تتبع أي عادات</string>
     <string name="msg_no_habits_yet">لم يتم تكوين عادات بعد.</string>
     <string name="msg_no_logs">لا توجد سجلات بعد</string>
     <string name="msg_no_memos_yet">لا توجد مذكرات في هذه الفترة.</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Geri</string>
     <string name="action_cancel">Ləğv et</string>
     <string name="action_create_new_config">Yeni konfiqurasiya yarat (tövsiyə olunur)</string>
     <string name="action_edit_anyway">Yenə də redaktə et</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d vərdişdən %1$d tamamlandı</string>
     <string name="format_memos_db">Qeydlər bazası: %1$s</string>
     <string name="format_offline_storage">Oflayn: %1$s</string>
+    <string name="format_quarter_label">R%1$d %2$d</string>
     <string name="format_memos_count">%1$d qeyd</string>
     <string name="format_memos_today">Bu gün %1$d qeyd</string>
     <string name="format_memos_this_week">Bu həftə %1$d qeyd</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Dil</string>
     <string name="label_memos_db">Qeydlər bazası</string>
     <string name="label_post_filter">Filtr</string>
+    <string name="label_selected">Seçilmiş</string>
     <string name="label_storage">Yaddaş</string>
     <string name="label_success_rate">Uğur dərəcəsi</string>
     <string name="label_theme">Tema</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Adi</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d münaqişə aşkarlandı</string>
     <string name="format_active_since">%1$s-dən aktiv</string>
     <string name="msg_connection_failed">Əlaqə xətası</string>
     <string name="msg_edit_config_warning">Mövcud konfiqurasiyanı redaktə etmək üzrəsiniz. Bu, bütün tarixi məlumatlara təsir edəcək.
@@ -135,6 +139,7 @@ Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlk
     <string name="msg_fill_all_fields">Bütün sahələri doldurun</string>
     <string name="msg_habit_name_required">Vərdiş adı tələb olunur</string>
     <string name="msg_habit_setup">Vərdişiniz üçün mənalı ad düşünün.</string>
+    <string name="msg_no_habits_tracked">Heç bir vərdiş izlənməyib</string>
     <string name="msg_no_habits_yet">Vərdişlər hələ tənzimlənməyib.</string>
     <string name="msg_no_logs">Loglar hələ yoxdur</string>
     <string name="msg_no_memos_yet">Bu dövrdə qeyd yoxdur.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Назад</string>
     <string name="action_cancel">Скасаваць</string>
     <string name="action_create_new_config">Стварыць новую канфігурацыю (рэкамендавана)</string>
     <string name="action_edit_anyway">Рэдагаваць усё адно</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">Выканана %1$d з %2$d звычак</string>
     <string name="format_memos_db">База нататак: %1$s</string>
     <string name="format_offline_storage">Афлайн: %1$s</string>
+    <string name="format_quarter_label">К%1$d %2$d</string>
     <string name="format_memos_count">%1$d нататак</string>
     <string name="format_memos_today">%1$d нататак сёння</string>
     <string name="format_memos_this_week">%1$d нататак за тыдзень</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Мова</string>
     <string name="label_memos_db">База нататак</string>
     <string name="label_post_filter">Фільтр</string>
+    <string name="label_selected">Выбрана</string>
     <string name="label_storage">Сховішча</string>
     <string name="label_success_rate">Паспяховасць</string>
     <string name="label_time_day">Дзень</string>
@@ -120,6 +123,7 @@
     <string name="filter_regular">Звычайныя</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">Выяўлена канфліктаў: %1$d</string>
     <string name="format_active_since">Актыўна з %1$s</string>
     <string name="msg_connection_failed">Памылка падключэння</string>
     <string name="msg_edit_config_warning">Вы збіраецеся рэдагаваць існуючую канфігурацыю. Гэта паўплывае на ўсе гістарычныя даныя.
@@ -134,6 +138,7 @@
     <string name="msg_fill_all_fields">Запоўніце ўсе палі</string>
     <string name="msg_habit_name_required">Назва звычкі абавязковая</string>
     <string name="msg_habit_setup">Прыдумайце значную назву для вашай звычкі.</string>
+    <string name="msg_no_habits_tracked">Звычкі не адсочаны</string>
     <string name="msg_no_habits_yet">Звычкі яшчэ не наладжаны.</string>
     <string name="msg_no_logs">Логаў пакуль няма</string>
     <string name="msg_no_memos_yet">Няма нататак за гэты перыяд.</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Zurück</string>
     <string name="action_cancel">Abbrechen</string>
     <string name="action_create_new_config">Neue Konfiguration erstellen (empfohlen)</string>
     <string name="action_edit_anyway">Trotzdem bearbeiten</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d von %2$d Gewohnheiten erledigt</string>
     <string name="format_memos_db">Notizen-DB: %1$s</string>
     <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_quarter_label">Q%1$d %2$d</string>
     <string name="format_memos_count">%1$d Notizen</string>
     <string name="format_memos_today">%1$d Notizen heute</string>
     <string name="format_memos_this_week">%1$d Notizen diese Woche</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Sprache</string>
     <string name="label_memos_db">Notizen-DB</string>
     <string name="label_post_filter">Filter</string>
+    <string name="label_selected">Ausgewählt</string>
     <string name="label_storage">Speicher</string>
     <string name="label_success_rate">Erfolgsrate</string>
     <string name="label_theme">Design</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Normal</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d Konflikt(e) erkannt</string>
     <string name="format_active_since">Aktiv seit %1$s</string>
     <string name="msg_connection_failed">Verbindung fehlgeschlagen</string>
     <string name="msg_edit_config_warning">Du bist dabei, eine bestehende Konfiguration zu bearbeiten. Das wirkt sich auf alle historischen Daten aus.
@@ -135,6 +139,7 @@ Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Dat
     <string name="msg_fill_all_fields">Bitte füllen Sie alle Felder aus</string>
     <string name="msg_habit_name_required">Gewohnheitsname ist erforderlich</string>
     <string name="msg_habit_setup">Geben Sie Ihrer Gewohnheit einen aussagekräftigen Namen.</string>
+    <string name="msg_no_habits_tracked">Keine Gewohnheiten erfasst</string>
     <string name="msg_no_habits_yet">Noch keine Gewohnheiten konfiguriert.</string>
     <string name="msg_no_logs">Noch keine Protokolle</string>
     <string name="msg_no_memos_yet">Keine Notizen in diesem Zeitraum.</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Atrás</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_create_new_config">Crear Nueva Configuración (Recomendado)</string>
     <string name="action_edit_anyway">Editar De Todos Modos</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d de %2$d hábitos completados</string>
     <string name="format_memos_db">Base de datos: %1$s</string>
     <string name="format_offline_storage">Sin conexión: %1$s</string>
+    <string name="format_quarter_label">T%1$d %2$d</string>
     <string name="format_memos_count">%1$d notas</string>
     <string name="format_memos_today">%1$d notas hoy</string>
     <string name="format_memos_this_week">%1$d notas esta semana</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Idioma</string>
     <string name="label_memos_db">Base de notas</string>
     <string name="label_post_filter">Filtro</string>
+    <string name="label_selected">Seleccionado</string>
     <string name="label_storage">Almacenamiento</string>
     <string name="label_success_rate">Tasa de éxito</string>
     <string name="label_theme">Tema</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Normales</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d conflicto(s) detectado(s)</string>
     <string name="format_active_since">Activo desde %1$s</string>
     <string name="msg_connection_failed">Error de conexión</string>
     <string name="msg_edit_config_warning">Está a punto de editar una configuración existente. Esto afectará a todos los datos históricos.\n\nNo se recomienda editar una configuración antigua porque cambia la apariencia de sus datos pasados. Por ejemplo, si agrega un nuevo hábito, todos los días pasados lo mostrarán como "no completado" aunque no existiera en ese momento.\n\nMejor práctica: Cree una nueva configuración en su lugar. Sus datos históricos mantendrán la configuración antigua, y los nuevos datos usarán la nueva configuración.</string>
@@ -131,6 +135,7 @@
     <string name="msg_fill_all_fields">Por favor, complete todos los campos</string>
     <string name="msg_habit_name_required">El nombre del hábito es obligatorio</string>
     <string name="msg_habit_setup">Dale a tu hábito un nombre significativo.</string>
+    <string name="msg_no_habits_tracked">Sin hábitos registrados</string>
     <string name="msg_no_habits_yet">Aún no hay hábitos configurados.</string>
     <string name="msg_no_logs">Aún no hay registros</string>
     <string name="msg_no_memos_yet">No hay notas en este período.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Retour</string>
     <string name="action_cancel">Annuler</string>
     <string name="action_create_new_config">Créer une nouvelle configuration (recommandé)</string>
     <string name="action_edit_anyway">Modifier quand même</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d sur %2$d habitudes accomplies</string>
     <string name="format_memos_db">Base de données : %1$s</string>
     <string name="format_offline_storage">Hors ligne : %1$s</string>
+    <string name="format_quarter_label">T%1$d %2$d</string>
     <string name="format_memos_count">%1$d notes</string>
     <string name="format_memos_today">%1$d notes aujourd\'hui</string>
     <string name="format_memos_this_week">%1$d notes cette semaine</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Langue</string>
     <string name="label_memos_db">Base de notes</string>
     <string name="label_post_filter">Filtre</string>
+    <string name="label_selected">Sélectionné</string>
     <string name="label_storage">Stockage</string>
     <string name="label_success_rate">Taux de réussite</string>
     <string name="label_theme">Thème</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Normaux</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d conflit(s) détecté(s)</string>
     <string name="format_active_since">Actif depuis %1$s</string>
     <string name="msg_connection_failed">Échec de la connexion</string>
     <string name="msg_edit_config_warning">Vous êtes sur le point de modifier une configuration existante. Cela affectera toutes les données historiques.
@@ -135,6 +139,7 @@ Bonne pratique : créez une nouvelle configuration. Vos données historiques con
     <string name="msg_fill_all_fields">Veuillez remplir tous les champs</string>
     <string name="msg_habit_name_required">Le nom de l\'habitude est requis</string>
     <string name="msg_habit_setup">Donnez un nom significatif à votre habitude.</string>
+    <string name="msg_no_habits_tracked">Aucune habitude suivie</string>
     <string name="msg_no_habits_yet">Aucune habitude configurée pour l\'instant.</string>
     <string name="msg_no_logs">Aucun journal pour l\'instant</string>
     <string name="msg_no_memos_yet">Aucune note pour cette période.</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">पीछे</string>
     <string name="action_cancel">रद्द करें</string>
     <string name="action_create_new_config">नई कॉन्फ़िगरेशन बनाएँ (अनुशंसित)</string>
     <string name="action_edit_anyway">फिर भी संपादित करें</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d में से %1$d आदतें पूरी</string>
     <string name="format_memos_db">मेमो DB: %1$s</string>
     <string name="format_offline_storage">ऑफ़लाइन: %1$s</string>
+    <string name="format_quarter_label">Q%1$d %2$d</string>
     <string name="format_memos_count">%1$d मेमो</string>
     <string name="format_memos_today">आज %1$d मेमो</string>
     <string name="format_memos_this_week">इस सप्ताह %1$d मेमो</string>
@@ -104,6 +106,7 @@
     <string name="label_language">भाषा</string>
     <string name="label_memos_db">मेमो DB</string>
     <string name="label_post_filter">फ़िल्टर</string>
+    <string name="label_selected">चयनित</string>
     <string name="label_storage">स्टोरेज</string>
     <string name="label_success_rate">सफलता दर</string>
     <string name="label_theme">थीम</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">सामान्य</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d विरोध पाया गया</string>
     <string name="format_active_since">%1$s से सक्रिय</string>
     <string name="msg_connection_failed">कनेक्शन विफल</string>
     <string name="msg_edit_config_warning">आप एक मौजूदा कॉन्फ़िगरेशन संपादित करने वाले हैं। इससे सभी ऐतिहासिक डेटा प्रभावित होगा।
@@ -135,6 +139,7 @@
     <string name="msg_fill_all_fields">कृपया सभी फ़ील्ड भरें</string>
     <string name="msg_habit_name_required">आदत का नाम आवश्यक है</string>
     <string name="msg_habit_setup">अपनी आदत के लिए एक सार्थक नाम सोचें।</string>
+    <string name="msg_no_habits_tracked">कोई आदत ट्रैक नहीं की गई</string>
     <string name="msg_no_habits_yet">अभी तक कोई आदत कॉन्फ़िगर नहीं।</string>
     <string name="msg_no_logs">अभी कोई लॉग नहीं</string>
     <string name="msg_no_memos_yet">इस अवधि में कोई मेमो नहीं।</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">戻る</string>
     <string name="action_cancel">キャンセル</string>
     <string name="action_create_new_config">新しい設定を作成（推奨）</string>
     <string name="action_edit_anyway">それでも編集</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d個中%1$d個の習慣完了</string>
     <string name="format_memos_db">メモDB: %1$s</string>
     <string name="format_offline_storage">オフライン: %1$s</string>
+    <string name="format_quarter_label">%2$d年Q%1$d</string>
     <string name="format_memos_count">%1$d件のメモ</string>
     <string name="format_memos_today">今日%1$d件のメモ</string>
     <string name="format_memos_this_week">今週%1$d件のメモ</string>
@@ -104,6 +106,7 @@
     <string name="label_language">言語</string>
     <string name="label_memos_db">メモDB</string>
     <string name="label_post_filter">フィルター</string>
+    <string name="label_selected">選択済み</string>
     <string name="label_storage">ストレージ</string>
     <string name="label_success_rate">成功率</string>
     <string name="label_theme">テーマ</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">通常</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d 件の競合を検出</string>
     <string name="format_active_since">%1$s からアクティブ</string>
     <string name="msg_connection_failed">接続に失敗しました</string>
     <string name="msg_edit_config_warning">既存の設定を編集しようとしています。これは過去のすべてのデータに影響します。
@@ -135,6 +139,7 @@
     <string name="msg_fill_all_fields">すべての項目を入力してください</string>
     <string name="msg_habit_name_required">習慣名は必須です</string>
     <string name="msg_habit_setup">習慣にわかりやすい名前を付けてください。</string>
+    <string name="msg_no_habits_tracked">習慣の記録なし</string>
     <string name="msg_no_habits_yet">まだ習慣が設定されていません。</string>
     <string name="msg_no_logs">ログがありません</string>
     <string name="msg_no_memos_yet">この期間にメモがありません。</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">უკან</string>
     <string name="action_cancel">გაუქმება</string>
     <string name="action_create_new_config">ახალი კონფიგურაციის შექმნა (რეკომენდებულია)</string>
     <string name="action_edit_anyway">მაინც რედაქტირება</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d ჩვევიდან %1$d შესრულებულია</string>
     <string name="format_memos_db">ჩანაწერების ბაზა: %1$s</string>
     <string name="format_offline_storage">ოფლაინ: %1$s</string>
+    <string name="format_quarter_label">Q%1$d %2$d</string>
     <string name="format_memos_count">%1$d ჩანაწერი</string>
     <string name="format_memos_today">დღეს %1$d ჩანაწერი</string>
     <string name="format_memos_this_week">ამ კვირაში %1$d ჩანაწერი</string>
@@ -104,6 +106,7 @@
     <string name="label_language">ენა</string>
     <string name="label_memos_db">ჩანაწერების ბაზა</string>
     <string name="label_post_filter">ფილტრი</string>
+    <string name="label_selected">არჩეული</string>
     <string name="label_storage">საცავი</string>
     <string name="label_success_rate">წარმატების მაჩვენებელი</string>
     <string name="label_theme">თემა</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">ჩვეულებრივი</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">აღმოჩენილია %1$d კონფლიქტი</string>
     <string name="format_active_since">აქტიური %1$s-დან</string>
     <string name="msg_connection_failed">კავშირის შეცდომა</string>
     <string name="msg_edit_config_warning">თქვენ აპირებთ არსებული კონფიგურაციის რედაქტირებას. ეს ყველა ისტორიულ მონაცემზე იმოქმედებს.
@@ -135,6 +139,7 @@
     <string name="msg_fill_all_fields">შეავსეთ ყველა ველი</string>
     <string name="msg_habit_name_required">ჩვევის სახელი აუცილებელია</string>
     <string name="msg_habit_setup">გამოიგონეთ მნიშვნელოვანი სახელი თქვენი ჩვევისთვის.</string>
+    <string name="msg_no_habits_tracked">ჩვევები არ არის აღრიცხული</string>
     <string name="msg_no_habits_yet">ჩვევები ჯერ არ არის კონფიგურირებული.</string>
     <string name="msg_no_logs">ლოგები ჯერ არ არის</string>
     <string name="msg_no_memos_yet">ამ პერიოდში ჩანაწერები არ არის.</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Артқа</string>
     <string name="action_cancel">Болдырмау</string>
     <string name="action_create_new_config">Жаңа конфигурация жасау (ұсынылады)</string>
     <string name="action_edit_anyway">Бәрібір өңдеу</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d әдеттің %1$d орындалды</string>
     <string name="format_memos_db">Жазбалар базасы: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
+    <string name="format_quarter_label">Т%1$d %2$d</string>
     <string name="format_memos_count">%1$d жазба</string>
     <string name="format_memos_today">Бүгін %1$d жазба</string>
     <string name="format_memos_this_week">Осы аптада %1$d жазба</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Тіл</string>
     <string name="label_memos_db">Жазбалар базасы</string>
     <string name="label_post_filter">Сүзгі</string>
+    <string name="label_selected">Таңдалған</string>
     <string name="label_storage">Сақтау орны</string>
     <string name="label_success_rate">Сәттілік деңгейі</string>
     <string name="label_time_day">Күн</string>
@@ -120,6 +123,7 @@
     <string name="filter_regular">Қарапайым</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d қақтығыс анықталды</string>
     <string name="format_active_since">%1$s бастап белсенді</string>
     <string name="msg_connection_failed">Қосылу қатесі</string>
     <string name="msg_edit_config_warning">Сіз қолданыстағы конфигурацияны өңдемекшісіз. Бұл барлық тарихи деректерге әсер етеді.
@@ -134,6 +138,7 @@
     <string name="msg_fill_all_fields">Барлық өрістерді толтырыңыз</string>
     <string name="msg_habit_name_required">Әдет атауы міндетті</string>
     <string name="msg_habit_setup">Әдетіңізге мағыналы атау ойлап табыңыз.</string>
+    <string name="msg_no_habits_tracked">Әдеттер бақыланбаған</string>
     <string name="msg_no_habits_yet">Әдеттер әлі бапталмаған.</string>
     <string name="msg_no_logs">Логтар әлі жоқ</string>
     <string name="msg_no_memos_yet">Бұл кезеңде жазбалар жоқ.</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Actions -->
     <string name="action_add_first_habit">Биринчи адатты кошуу</string>
+    <string name="action_back">Артка</string>
     <string name="action_cancel">Жокко чыгаруу</string>
     <string name="action_clear">Тазалоо</string>
     <string name="action_continue">Улантуу</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d адаттан %1$d аткарылды</string>
     <string name="format_memos_db">Жазуулар базасы: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
+    <string name="format_quarter_label">Ч%1$d %2$d</string>
     <string name="format_memos_count">%1$d жазуу</string>
     <string name="format_memos_today">Бүгүн %1$d жазуу</string>
     <string name="format_memos_this_week">Бул жумада %1$d жазуу</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Тил</string>
     <string name="label_memos_db">Жазуулар базасы</string>
     <string name="label_post_filter">Чыпка</string>
+    <string name="label_selected">Тандалган</string>
     <string name="label_storage">Сактагыч</string>
     <string name="label_success_rate">Ийгилик деңгээли</string>
     <string name="label_theme">Тема</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Кадимки</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d чыр-чатак аныкталды</string>
     <string name="format_active_since">%1$sдөн бери активдүү</string>
     <string name="msg_connection_failed">Байланыш катасы</string>
     <string name="msg_edit_config_warning">Сиз бар болгон конфигурацияны түзөтүүгө баратасыз. Бул бардык тарыхый маалыматтарга таасир этет.
@@ -135,6 +139,7 @@
     <string name="msg_fill_all_fields">Бардык талааларды толтуруңуз</string>
     <string name="msg_habit_name_required">Адаттын аты милдеттүү</string>
     <string name="msg_habit_setup">Адатыңызга маанилүү ат ойлоп табыңыз.</string>
+    <string name="msg_no_habits_tracked">Адаттар көзөмөлдөнгөн жок</string>
     <string name="msg_no_habits_yet">Адаттар али тууралangan эмес.</string>
     <string name="msg_no_logs">Логдор али жок</string>
     <string name="msg_no_memos_yet">Бул мезгилде жазуулар жок.</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Voltar</string>
     <string name="action_cancel">Cancelar</string>
     <string name="action_create_new_config">Criar nova configuração (recomendado)</string>
     <string name="action_edit_anyway">Editar mesmo assim</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d de %2$d hábitos concluídos</string>
     <string name="format_memos_db">Banco de dados: %1$s</string>
     <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_quarter_label">T%1$d %2$d</string>
     <string name="format_memos_count">%1$d notas</string>
     <string name="format_memos_today">%1$d notas hoje</string>
     <string name="format_memos_this_week">%1$d notas esta semana</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Idioma</string>
     <string name="label_memos_db">Banco de notas</string>
     <string name="label_post_filter">Filtro</string>
+    <string name="label_selected">Selecionado</string>
     <string name="label_storage">Armazenamento</string>
     <string name="label_success_rate">Taxa de sucesso</string>
     <string name="label_theme">Tema</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Normais</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d conflito(s) detectado(s)</string>
     <string name="format_active_since">Ativo desde %1$s</string>
     <string name="msg_connection_failed">Falha na conexão</string>
     <string name="msg_edit_config_warning">Você está prestes a editar uma configuração existente. Isso afetará todos os dados históricos.
@@ -135,6 +139,7 @@ Melhor prática: crie uma nova configuração. Seus dados históricos manterão 
     <string name="msg_fill_all_fields">Por favor, preencha todos os campos</string>
     <string name="msg_habit_name_required">O nome do hábito é obrigatório</string>
     <string name="msg_habit_setup">Dê um nome significativo ao seu hábito.</string>
+    <string name="msg_no_habits_tracked">Nenhum hábito registrado</string>
     <string name="msg_no_habits_yet">Nenhum hábito configurado ainda.</string>
     <string name="msg_no_logs">Sem logs ainda</string>
     <string name="msg_no_memos_yet">Sem notas neste período.</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Actions -->
     <string name="action_add_first_habit">Adaugă primul tău obicei</string>
+    <string name="action_back">Înapoi</string>
     <string name="action_cancel">Anulare</string>
     <string name="action_clear">Curăță</string>
     <string name="action_continue">Continuă</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%1$d din %2$d obiceiuri finalizate</string>
     <string name="format_memos_db">Baza de date note: %1$s</string>
     <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_quarter_label">T%1$d %2$d</string>
     <string name="format_memos_count">%1$d note</string>
     <string name="format_memos_today">%1$d note astăzi</string>
     <string name="format_memos_this_week">%1$d note săptămâna aceasta</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Limbă</string>
     <string name="label_memos_db">Baza de date note</string>
     <string name="label_post_filter">Filtru</string>
+    <string name="label_selected">Selectat</string>
     <string name="label_storage">Stocare</string>
     <string name="label_success_rate">Rată de succes</string>
     <string name="label_theme">Temă</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Obișnuite</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d conflict(e) detectat(e)</string>
     <string name="format_active_since">Activ din %1$s</string>
     <string name="msg_connection_failed">Conexiune eșuată</string>
     <string name="msg_edit_config_warning">Ești pe cale să editezi o configurație existentă. Acest lucru va afecta toate datele istorice.
@@ -135,6 +139,7 @@ Cea mai bună practică: creează o configurație nouă. Datele tale istorice vo
     <string name="msg_empty_state_no_habits">Creează unul pentru a începe urmărirea offline.</string>
     <string name="msg_habit_name_required">Numele obiceiului este obligatoriu</string>
     <string name="msg_habit_setup">Dă-i obiceiului tău un nume semnificativ.</string>
+    <string name="msg_no_habits_tracked">Niciun obicei urmărit</string>
     <string name="msg_no_habits_yet">Niciun obicei configurat încă.</string>
     <string name="msg_no_logs">Niciun log încă</string>
     <string name="msg_no_memos_yet">Nicio notă în această perioadă.</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Назад</string>
     <string name="action_cancel">Отмена</string>
     <string name="action_clear">Очистить</string>
     <string name="action_close">Закрыть</string>
@@ -64,6 +65,7 @@
     <string name="month_dec">Дек</string>
 
     <!-- Format strings -->
+    <string name="format_conflicts_detected">Обнаружено конфликтов: %1$d</string>
     <string name="format_active_since">Активно с %1$s</string>
     <string name="format_app_version">Версия: %1$s</string>
     <string name="format_credentials">Данные для входа: %1$s</string>
@@ -73,6 +75,7 @@
     <string name="format_offline_storage">Офлайн: %1$s</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d привычек</string>
     <string name="format_tooltip_memos">%1$s: %2$d воспоминаний</string>
+    <string name="format_quarter_label">К%1$d %2$d</string>
     <string name="format_memos_count">%1$d воспоминаний</string>
     <string name="format_memos_today">%1$d воспоминаний сегодня</string>
     <string name="format_memos_this_week">%1$d воспоминаний за неделю</string>
@@ -105,6 +108,7 @@
     <string name="label_language">Язык</string>
     <string name="label_memos_db">База Memos</string>
     <string name="label_post_filter">Фильтр записей</string>
+    <string name="label_selected">Выбрано</string>
     <string name="label_storage">Хранилище</string>
     <string name="label_success_rate">Процент выполнения</string>
     <string name="label_time_day">День</string>
@@ -130,6 +134,7 @@
     <string name="msg_fill_all_fields">Заполни все поля</string>
     <string name="msg_habit_name_required">Нужно название привычки</string>
     <string name="msg_habit_setup">Придумай осмысленное название для своей привычки.</string>
+    <string name="msg_no_habits_tracked">Привычки не отслежены</string>
     <string name="msg_no_habits_yet">Пока нет привычек.</string>
     <string name="msg_no_logs">Логов пока нет</string>
     <string name="msg_no_memos_yet">За этот период воспоминаний нет.</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Actions -->
     <string name="action_add_first_habit">Одати аввалро илова кунед</string>
+    <string name="action_back">Бозгашт</string>
     <string name="action_cancel">Бекор кардан</string>
     <string name="action_clear">Тоза кардан</string>
     <string name="action_continue">Идома додан</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d одатҳо аз %1$d иҷро шуд</string>
     <string name="format_memos_db">Базаи ёддоштҳо: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
+    <string name="format_quarter_label">С%1$d %2$d</string>
     <string name="format_memos_count">%1$d ёддошт</string>
     <string name="format_memos_today">Имрӯз %1$d ёддошт</string>
     <string name="format_memos_this_week">Ин ҳафта %1$d ёддошт</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Забон</string>
     <string name="label_memos_db">Базаи ёддоштҳо</string>
     <string name="label_post_filter">Филтр</string>
+    <string name="label_selected">Интихобшуда</string>
     <string name="label_storage">Анбор</string>
     <string name="label_success_rate">Дараҷаи муваффақият</string>
     <string name="label_theme">Мавзуъ</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Оддӣ</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d мухолифат ошкор шуд</string>
     <string name="format_active_since">Фаъол аз %1$s</string>
     <string name="msg_connection_failed">Хатои пайвастшавӣ</string>
     <string name="msg_edit_config_warning">Шумо мехоҳед конфигуратсияи мавҷударо таҳрир кунед. Ин ба ҳамаи маълумоти таърихӣ таъсир мерасонад.
@@ -135,6 +139,7 @@
     <string name="msg_empty_state_no_habits">Барои оғози назорат дар реҷаи офлайн одат эҷод кунед.</string>
     <string name="msg_habit_name_required">Номи одат зарур аст</string>
     <string name="msg_habit_setup">Барои одати худ номи маънидор интихоб кунед.</string>
+    <string name="msg_no_habits_tracked">Одатҳо пайгирӣ нашуданд</string>
     <string name="msg_no_habits_yet">Одатҳо ҳанӯз танзим нашудаанд.</string>
     <string name="msg_no_logs">Логҳо ҳанӯз нестанд</string>
     <string name="msg_no_memos_yet">Дар ин давра ёддоштҳо нестанд.</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -1,6 +1,7 @@
 <resources>
     <!-- Actions -->
     <string name="action_add_first_habit">Ilkinji endigi goş</string>
+    <string name="action_back">Yza</string>
     <string name="action_cancel">Ýatyr</string>
     <string name="action_clear">Arassala</string>
     <string name="action_continue">Dowam et</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d endikden %1$d ýerine ýetirildi</string>
     <string name="format_memos_db">Bellikler bazasy: %1$s</string>
     <string name="format_offline_storage">Oflaýn: %1$s</string>
+    <string name="format_quarter_label">Ç%1$d %2$d</string>
     <string name="format_memos_count">%1$d bellik</string>
     <string name="format_memos_today">Şu gün %1$d bellik</string>
     <string name="format_memos_this_week">Bu hepde %1$d bellik</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Dil</string>
     <string name="label_memos_db">Bellikler bazasy</string>
     <string name="label_post_filter">Filtr</string>
+    <string name="label_selected">Saýlanan</string>
     <string name="label_storage">Ammar</string>
     <string name="label_success_rate">Üstünlik derejesi</string>
     <string name="label_theme">Tema</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Adaty</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d gapma-garşylyk ýüze çykaryldy</string>
     <string name="format_active_since">%1$s-den bäri işjeň</string>
     <string name="msg_connection_failed">Baglanşyk ýalňyşlygy</string>
     <string name="msg_edit_config_warning">Bar bolan konfigurasiýany redaktirlemekçi bolýarsyňyz. Bu ähli taryhy maglumatlara täsir eder.
@@ -135,6 +139,7 @@ Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigur
     <string name="msg_empty_state_no_habits">Awtonom režimde yzarlamagy başlamak üçin endik dörediň.</string>
     <string name="msg_habit_name_required">Endik ady hökmany</string>
     <string name="msg_habit_setup">Endikiňiz üçin many-manyly at oýlap tapyň.</string>
+    <string name="msg_no_habits_tracked">Endikler yzarlanmady</string>
     <string name="msg_no_habits_yet">Endikler heniz düzülmedi.</string>
     <string name="msg_no_logs">Loglar heniz ýok</string>
     <string name="msg_no_memos_yet">Bu döwürde bellik ýok.</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Назад</string>
     <string name="action_cancel">Скасувати</string>
     <string name="action_create_new_config">Створити нову конфігурацію (рекомендовано)</string>
     <string name="action_edit_anyway">Редагувати все одно</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">Виконано %1$d з %2$d звичок</string>
     <string name="format_memos_db">База нотаток: %1$s</string>
     <string name="format_offline_storage">Офлайн: %1$s</string>
+    <string name="format_quarter_label">К%1$d %2$d</string>
     <string name="format_memos_count">%1$d нотаток</string>
     <string name="format_memos_today">%1$d нотаток сьогодні</string>
     <string name="format_memos_this_week">%1$d нотаток цього тижня</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Мова</string>
     <string name="label_memos_db">База нотаток</string>
     <string name="label_post_filter">Фільтр</string>
+    <string name="label_selected">Обрано</string>
     <string name="label_storage">Сховище</string>
     <string name="label_success_rate">Успішність</string>
     <string name="label_time_day">День</string>
@@ -120,6 +123,7 @@
     <string name="filter_regular">Звичайні</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">Виявлено конфліктів: %1$d</string>
     <string name="format_active_since">Активно з %1$s</string>
     <string name="msg_connection_failed">Помилка підключення</string>
     <string name="msg_edit_config_warning">Ви збираєтеся редагувати наявну конфігурацію. Це вплине на всі історичні дані.
@@ -134,6 +138,7 @@
     <string name="msg_fill_all_fields">Заповніть усі поля</string>
     <string name="msg_habit_name_required">Назва звички обов'язкова</string>
     <string name="msg_habit_setup">Придумайте значущу назву для вашої звички.</string>
+    <string name="msg_no_habits_tracked">Звички не відстежені</string>
     <string name="msg_no_habits_yet">Звички ще не налаштовано.</string>
     <string name="msg_no_logs">Логів поки немає</string>
     <string name="msg_no_memos_yet">Немає нотаток за цей період.</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Orqaga</string>
     <string name="action_cancel">Bekor qilish</string>
     <string name="action_create_new_config">Yangi konfiguratsiya yaratish (tavsiya etiladi)</string>
     <string name="action_edit_anyway">Baribir tahrirlash</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">%2$d ta odatdan %1$d bajarildi</string>
     <string name="format_memos_db">Eslatmalar bazasi: %1$s</string>
     <string name="format_offline_storage">Oflayn: %1$s</string>
+    <string name="format_quarter_label">Ch%1$d %2$d</string>
     <string name="format_memos_count">%1$d ta eslatma</string>
     <string name="format_memos_today">Bugun %1$d ta eslatma</string>
     <string name="format_memos_this_week">Bu hafta %1$d ta eslatma</string>
@@ -104,6 +106,7 @@
     <string name="label_language">Til</string>
     <string name="label_memos_db">Eslatmalar bazasi</string>
     <string name="label_post_filter">Filtr</string>
+    <string name="label_selected">Tanlangan</string>
     <string name="label_storage">Saqlash joyi</string>
     <string name="label_success_rate">Muvaffaqiyat darajasi</string>
     <string name="label_theme">Mavzu</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">Oddiy</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">%1$d ziddiyat aniqlandi</string>
     <string name="format_active_since">%1$s dan beri faol</string>
     <string name="msg_connection_failed">Ulanish xatosi</string>
     <string name="msg_edit_config_warning">Siz mavjud konfiguratsiyani tahrirlash arafasidiz. Bu barcha tarixiy ma'lumotlarga ta'sir qiladi.
@@ -135,6 +139,7 @@ Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfi
     <string name="msg_fill_all_fields">Barcha maydonlarni to\'ldiring</string>
     <string name="msg_habit_name_required">Odat nomi majburiy</string>
     <string name="msg_habit_setup">Odatingiz uchun mazmunli nom o\'ylab toping.</string>
+    <string name="msg_no_habits_tracked">Odatlar kuzatilmagan</string>
     <string name="msg_no_habits_yet">Odatlar hali sozlanmagan.</string>
     <string name="msg_no_logs">Loglar hali yo\'q</string>
     <string name="msg_no_memos_yet">Bu davrda eslatmalar yo\'q.</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">返回</string>
     <string name="action_cancel">取消</string>
     <string name="action_create_new_config">创建新配置（推荐）</string>
     <string name="action_edit_anyway">仍然编辑</string>
@@ -70,6 +71,7 @@
     <string name="format_habits_progress">已完成 %1$d / %2$d 个习惯</string>
     <string name="format_memos_db">备忘数据库: %1$s</string>
     <string name="format_offline_storage">离线: %1$s</string>
+    <string name="format_quarter_label">%2$d年第%1$d季度</string>
     <string name="format_memos_count">%1$d 条备忘</string>
     <string name="format_memos_today">今天 %1$d 条备忘</string>
     <string name="format_memos_this_week">本周 %1$d 条备忘</string>
@@ -104,6 +106,7 @@
     <string name="label_language">语言</string>
     <string name="label_memos_db">备忘数据库</string>
     <string name="label_post_filter">筛选</string>
+    <string name="label_selected">已选择</string>
     <string name="label_storage">存储</string>
     <string name="label_success_rate">成功率</string>
     <string name="label_theme">主题</string>
@@ -121,6 +124,7 @@
     <string name="filter_regular">普通</string>
 
     <!-- Messages -->
+    <string name="format_conflicts_detected">检测到 %1$d 个冲突</string>
     <string name="format_active_since">自 %1$s 起生效</string>
     <string name="msg_connection_failed">连接失败</string>
     <string name="msg_edit_config_warning">您即将编辑现有配置。这将影响所有历史数据。\n\n不建议编辑旧配置，因为它会改变过去数据的显示方式。例如，如果您添加新习惯，所有过去的日期都会显示为"未完成"，即使当时它还不存在。\n\n最佳实践：创建新配置。您的历史数据将保留旧配置，新数据将使用新配置。</string>
@@ -131,6 +135,7 @@
     <string name="msg_fill_all_fields">请填写所有字段</string>
     <string name="msg_habit_name_required">习惯名称为必填项</string>
     <string name="msg_habit_setup">为您的习惯起一个有意义的名称。</string>
+    <string name="msg_no_habits_tracked">未记录任何习惯</string>
     <string name="msg_no_habits_yet">尚未配置任何习惯。</string>
     <string name="msg_no_logs">暂无日志</string>
     <string name="msg_no_memos_yet">该时期暂无备忘。</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -1,5 +1,6 @@
 <resources>
     <!-- Actions -->
+    <string name="action_back">Back</string>
     <string name="action_cancel">Cancel</string>
     <string name="action_clear">Clear</string>
     <string name="action_close">Close</string>
@@ -64,6 +65,7 @@
     <string name="month_dec">Dec</string>
 
     <!-- Format strings -->
+    <string name="format_conflicts_detected">%1$d conflict(s) detected</string>
     <string name="format_active_since">Active since %1$s</string>
     <string name="format_app_version">Version: %1$s</string>
     <string name="format_credentials">Credentials: %1$s</string>
@@ -71,6 +73,7 @@
     <string name="format_habits_progress">%1$d of %2$d habits done</string>
     <string name="format_memos_db">Memos DB: %1$s</string>
     <string name="format_offline_storage">Offline: %1$s</string>
+    <string name="format_quarter_label">Q%1$d %2$d</string>
     <string name="format_memos_count">%1$d memos</string>
     <string name="format_memos_today">%1$d memos today</string>
     <string name="format_memos_this_week">%1$d memos this week</string>
@@ -105,6 +108,7 @@
     <string name="label_language">Language</string>
     <string name="label_memos_db">Memos DB</string>
     <string name="label_post_filter">Filter posts</string>
+    <string name="label_selected">Selected</string>
     <string name="label_storage">Storage</string>
     <string name="label_success_rate">Success rate</string>
     <string name="label_time_day">Day</string>
@@ -130,6 +134,7 @@
     <string name="msg_fill_all_fields">Please fill in all fields</string>
     <string name="msg_habit_name_required">Habit name is required</string>
     <string name="msg_habit_setup">Give your habit a meaningful name.</string>
+    <string name="msg_no_habits_tracked">No habits tracked</string>
     <string name="msg_no_habits_yet">No habits configured yet.</string>
     <string name="msg_no_logs">No logs yet</string>
     <string name="msg_no_memos_yet">No memos in this period.</string>

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on iOS; return the modifier unchanged.
+ * Hover events are not available on Android; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import android.app.Activity
 import androidx.activity.ComponentActivity

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import space.be1ski.vibits.core.ui.platform.theme.ConfigureSystemBars
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 
 /**
  * CompositionLocal for the current dark theme state.

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on Android; return the modifier unchanged.
+ * Hover events are not available on iOS; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -61,7 +61,7 @@ import space.be1ski.vibits.core.strings.generated.title_create_day
 import space.be1ski.vibits.core.strings.generated.title_edit_day
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
-import space.be1ski.vibits.core.ui.hoverAware
+import space.be1ski.vibits.core.ui.platform.hoverAware
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
 import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
-import space.be1ski.vibits.core.ui.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/TimeRangeControls.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/TimeRangeControls.kt
@@ -28,6 +28,7 @@ import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_next
 import space.be1ski.vibits.core.strings.generated.action_previous
+import space.be1ski.vibits.core.strings.generated.format_quarter_label
 import space.be1ski.vibits.core.strings.generated.time_months
 import space.be1ski.vibits.core.strings.generated.time_quarters
 import space.be1ski.vibits.core.strings.generated.time_weeks
@@ -126,6 +127,7 @@ private fun TimeRangeNavigator(
   }
 }
 
+@Composable
 internal fun formatRangeLabel(
   range: ActivityRange,
   formatter: DateFormatter,
@@ -137,7 +139,7 @@ internal fun formatRangeLabel(
       formatter.weekRange(range.startDate, endDate, currentYear)
     }
     is ActivityRange.Month -> "${formatter.monthShort(range.month)} ${range.year}"
-    is ActivityRange.Quarter -> "Q${range.index} ${range.year}"
+    is ActivityRange.Quarter -> stringResource(Res.string.format_quarter_label, range.index, range.year)
     is ActivityRange.Year -> range.year.toString()
   }
 

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/HabitsTrackingCard.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/HabitsTrackingCard.kt
@@ -16,6 +16,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.msg_no_habits_tracked
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.extractCompletedHabits
@@ -90,7 +93,7 @@ internal fun HabitsTrackingCard(
       }
     } else {
       Text(
-        text = "No habits tracked",
+        text = stringResource(Res.string.msg_no_habits_tracked),
         style = MaterialTheme.typography.bodyMedium,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
@@ -20,6 +20,7 @@ import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
 import space.be1ski.vibits.core.strings.generated.action_keep_local
 import space.be1ski.vibits.core.strings.generated.action_keep_server
+import space.be1ski.vibits.core.strings.generated.format_conflicts_detected
 import space.be1ski.vibits.core.strings.generated.msg_sync_conflict
 import space.be1ski.vibits.core.strings.generated.title_sync_conflict
 import space.be1ski.vibits.core.ui.Indent
@@ -47,7 +48,7 @@ fun SyncConflictDialog(
         )
         Spacer(modifier = Modifier.height(Indent.s))
         Text(
-          text = "$conflictCount conflict(s) detected",
+          text = stringResource(Res.string.format_conflicts_detected, conflictCount),
           style = MaterialTheme.typography.bodySmall,
           color = MaterialTheme.colorScheme.onSurfaceVariant,
         )

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
@@ -37,8 +37,10 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.action_back
 import space.be1ski.vibits.core.strings.generated.action_continue
 import space.be1ski.vibits.core.strings.generated.label_habit_preset_custom
+import space.be1ski.vibits.core.strings.generated.label_selected
 import space.be1ski.vibits.core.strings.generated.title_choose_starter_habit
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.theme.AppColors
@@ -76,7 +78,7 @@ fun ChoosePresetScreen(
       modifier = Modifier.fillMaxWidth(),
     ) {
       IconButton(onClick = onBack) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textColor)
+        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.action_back), tint = textColor)
       }
       Text(
         text = stringResource(Res.string.title_choose_starter_habit),
@@ -167,7 +169,7 @@ private fun PresetCard(
       if (isSelected) {
         Icon(
           Icons.Default.Check,
-          contentDescription = "Selected",
+          contentDescription = stringResource(Res.string.label_selected),
           tint = AppColors.habitBlue.resolve(),
         )
       }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/HabitSetupScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/HabitSetupScreen.kt
@@ -34,6 +34,7 @@ import androidx.compose.ui.graphics.luminance
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.action_back
 import space.be1ski.vibits.core.strings.generated.action_start_tracking
 import space.be1ski.vibits.core.strings.generated.hint_habit_name
 import space.be1ski.vibits.core.strings.generated.label_habit_color
@@ -98,7 +99,7 @@ fun HabitSetupScreen(
       modifier = Modifier.fillMaxWidth(),
     ) {
       IconButton(onClick = onBack, enabled = !isCreating) {
-        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = "Back", tint = textColor)
+        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.action_back), tint = textColor)
       }
       Text(
         text = stringResource(Res.string.title_habit_setup),


### PR DESCRIPTION
## Summary
- Replaced 6 hardcoded user-facing strings with localized string resources
- Added translations for all 20 supported locales

## Changes
- Added 5 new string resources: `action_back`, `format_conflicts_detected`, `format_quarter_label`, `label_selected`, `msg_no_habits_tracked`
- Updated `HabitsTrackingCard` — "No habits tracked" → `msg_no_habits_tracked`
- Updated `TimeRangeControls` — "Q1 2024" → `format_quarter_label`
- Updated `SyncConflictDialog` — "N conflict(s) detected" → `format_conflicts_detected`
- Updated `HabitSetupScreen` / `ChoosePresetScreen` — "Back" / "Selected" contentDescriptions → `action_back` / `label_selected`

## Test plan
- [x] `checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)