### PR TITLE
Add checkConventions Gradle task to enforce architecture rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,7 @@ The project follows strict package organization to maintain clean architecture a
 
 - **`core.ui.*`** — UI layer with Compose code:
   - `core.ui.theme.*` — Theming, colors, typography
+  - `core.ui.platform.*` — UI-specific expect/actual declarations (`hoverAware`, `ConfigureSystemBars`, `rememberSystemDarkTheme`)
   - `core.ui.date.DateFormatter` — UI helpers with @Composable functions
   - Any code containing @Composable functions
   - **Excluded from coverage** (@Composable cannot be unit tested)
@@ -72,6 +73,7 @@ Within `feature/<name>/data/`:
 
 - **`data/room/`** — Room database implementations (platform-specific):
   - DAO interfaces, entities, database classes
+  - **Exception:** `MemoDatabaseConstructor` expect/actual lives here (not in `data/platform/`) because Room KMP requires `@ConstructedBy` object to be in the same package as the `@Database` class
   - Excluded from coverage (platform-specific, tested via integration tests)
 
 - **`data/platform/`** — **ONLY expect/actual declarations**:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,9 +63,51 @@ subprojects {
   }
 }
 
+tasks.register("checkConventions") {
+  group = "verification"
+  description = "Checks architecture conventions across source files"
+  doLast {
+    val violations = mutableListOf<String>()
+    val sourceSets = listOf("commonMain", "androidMain", "desktopMain", "iosMain", "wasmJsMain")
+
+    subprojects.forEach { sub ->
+      sourceSets.forEach { sourceSet ->
+        val srcDir = sub.file("src/$sourceSet/kotlin")
+        if (!srcDir.exists()) return@forEach
+        srcDir.walkTopDown().filter { it.extension == "kt" }.forEach { file ->
+          val relativePath = file.relativeTo(rootDir).path
+          val pkg = file.readLines().firstOrNull { it.startsWith("package ") }?.removePrefix("package ")?.trim() ?: ""
+          val content = file.readText()
+          val inUiOrView = pkg.contains(".ui.") || pkg.contains(".view.") || pkg.endsWith(".ui") || pkg.endsWith(".view")
+          val inPlatformOrRoom = pkg.contains(".platform.") || pkg.contains(".room.") || pkg.endsWith(".platform") || pkg.endsWith(".room")
+          val inTest = pkg.contains(".test.") || pkg.contains(".testing.") || pkg.endsWith(".test") || pkg.endsWith(".testing")
+
+          if (!inUiOrView && content.contains("@Composable")) {
+            violations += "$relativePath: @Composable found outside ui/view package ($pkg)"
+          }
+          if (!inPlatformOrRoom && content.contains(Regex("\\bexpect\\s+(fun|class|interface|object|val|var|abstract|annotation)\\b"))) {
+            violations += "$relativePath: expect declaration found outside platform/room package ($pkg)"
+          }
+          if (sourceSet == "commonMain" && !inTest && file.name.startsWith("Fake")) {
+            violations += "$relativePath: Fake class in production code, should be in testing/ module ($pkg)"
+          }
+        }
+      }
+    }
+
+    if (violations.isNotEmpty()) {
+      violations.forEach { logger.error(it) }
+      throw GradleException("Found ${violations.size} convention violation(s):\n${violations.joinToString("\n")}")
+    } else {
+      logger.lifecycle("Convention check passed — no violations found.")
+    }
+  }
+}
+
 tasks.register("checkJvm") {
   group = "verification"
   description = "Runs JVM checks: detekt, compile, and tests (Linux-safe)"
+  dependsOn("checkConventions")
   subprojects {
     plugins.withId("org.jetbrains.kotlin.multiplatform") {
       tasks.findByName("detekt")?.let { dependsOn(it) }

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on iOS; return the modifier unchanged.
+ * Hover events are not available on Android; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import android.app.Activity
 import androidx.activity.ComponentActivity

--- a/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/androidMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
@@ -6,6 +6,8 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import space.be1ski.vibits.core.ui.platform.theme.ConfigureSystemBars
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 
 /**
  * CompositionLocal for the current dark theme state.

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,8 +1,8 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 
 /**
- * Hover events are not available on Android; return the modifier unchanged.
+ * Hover events are not available on iOS; return the modifier unchanged.
  */
 actual fun Modifier.hoverAware(onHoverChange: (Boolean) -> Unit): Modifier = this

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/iosMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/HoverAware.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui
+package space.be1ski.vibits.core.ui.platform
 
 import androidx.compose.ui.Modifier
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemBars.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.runtime.Composable
 

--- a/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
+++ b/core/ui/src/wasmJsMain/kotlin/space/be1ski/vibits/core/ui/platform/theme/SystemTheme.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.core.ui.theme
+package space.be1ski.vibits.core.ui.platform.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/di/HabitsFeatureFactory.kt
@@ -36,18 +36,18 @@ fun createHabitsFeature(
             onRefresh = onRefresh,
           ),
         activityHandler =
-          HabitsActivityEffectHandler(
-            calculateActivityDataUseCase =
+          run {
+            val calculateActivityData =
               CalculateActivityDataUseCase(
                 buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-              ),
-            prewarmActivityDataUseCase =
-              PrewarmActivityDataUseCase(
-                calculateActivityDataUseCase =
-                  CalculateActivityDataUseCase(
-                    buildActivityDataUseCase = dependencies.buildActivityDataUseCase,
-                  ),
-              ),
-          ),
+              )
+            HabitsActivityEffectHandler(
+              calculateActivityDataUseCase = calculateActivityData,
+              prewarmActivityDataUseCase =
+                PrewarmActivityDataUseCase(
+                  calculateActivityDataUseCase = calculateActivityData,
+                ),
+            )
+          },
       ),
   )

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -61,7 +61,7 @@ import space.be1ski.vibits.core.strings.generated.title_create_day
 import space.be1ski.vibits.core.strings.generated.title_edit_day
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
-import space.be1ski.vibits.core.ui.hoverAware
+import space.be1ski.vibits.core.ui.platform.hoverAware
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
 import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
-import space.be1ski.vibits.core.ui.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemoStorageManagerImplTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/MemoStorageManagerImplTest.kt
@@ -1,0 +1,47 @@
+package space.be1ski.vibits.feature.memos.data
+
+import space.be1ski.vibits.feature.memos.data.offline.OfflineMemoDto
+import space.be1ski.vibits.feature.memos.data.offline.OfflineMemosFileDto
+import space.be1ski.vibits.feature.memos.data.platform.OfflineMemoStorage
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class MemoStorageManagerImplTest {
+  @Test
+  fun `when clearAll then saves empty memo list to storage`() {
+    val storage =
+      RecordingOfflineMemoStorage(
+        initial =
+          OfflineMemosFileDto(
+            memos =
+              listOf(
+                OfflineMemoDto(name = "memos/1", content = "test"),
+                OfflineMemoDto(name = "memos/2", content = "test2"),
+              ),
+          ),
+      )
+    val manager = MemoStorageManagerImpl(storage)
+
+    manager.clearAll()
+
+    assertEquals(1, storage.saveCalls)
+    assertTrue(storage.stored.memos.isEmpty())
+  }
+}
+
+private class RecordingOfflineMemoStorage(
+  initial: OfflineMemosFileDto = OfflineMemosFileDto(),
+) : OfflineMemoStorage {
+  var stored: OfflineMemosFileDto = initial
+    private set
+  var saveCalls: Int = 0
+    private set
+
+  override fun load(): OfflineMemosFileDto = stored
+
+  override fun save(data: OfflineMemosFileDto) {
+    stored = data
+    saveCalls += 1
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `checkConventions` Gradle task that scans all source sets for architecture violations
- Wired into `checkJvm` so it runs automatically with existing checks

## Checks enforced
- `@Composable` only in `*.ui.*` / `*.view.*` packages
- `expect` declarations only in `*.platform.*` / `*.room.*` packages
- No `Fake*` classes in production `commonMain` (belong in `testing/` modules)

## Test plan
- [x] `./gradlew checkConventions` passes on current codebase
- [x] Pre-commit hook passes (includes `checkAll` → `checkJvm` → `checkConventions`)