### PR TITLE
Move CredentialValidationError to core/ui for type-safe error display

### DIFF
--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialFields.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialFields.kt
@@ -44,9 +44,8 @@ fun ColumnScope.CredentialFields(
 }
 
 @Composable
-fun credentialValidationErrorMessage(errorName: String): String =
-  when (errorName) {
-    "FILL_ALL_FIELDS" -> stringResource(Res.string.msg_fill_all_fields)
-    "CONNECTION_FAILED" -> stringResource(Res.string.msg_connection_failed)
-    else -> errorName
+fun credentialValidationErrorMessage(error: CredentialValidationError): String =
+  when (error) {
+    CredentialValidationError.FILL_ALL_FIELDS -> stringResource(Res.string.msg_fill_all_fields)
+    CredentialValidationError.CONNECTION_FAILED -> stringResource(Res.string.msg_connection_failed)
   }

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialValidationError.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialValidationError.kt
@@ -1,4 +1,4 @@
-package space.be1ski.vibits.feature.auth.domain.model
+package space.be1ski.vibits.core.ui.form
 
 enum class CredentialValidationError {
   FILL_ALL_FIELDS,

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeValidationReducer.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.mode.presentation.reducer
 import space.be1ski.vibits.core.elm.Reducer
 import space.be1ski.vibits.core.elm.reducer
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
@@ -1,6 +1,6 @@
 package space.be1ski.vibits.feature.mode.presentation.state
 
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 
 data class ModeSelectionState(
   val showCredentialsDialog: Boolean = false,

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -172,7 +172,7 @@ private fun CredentialsSetupDialog(
         )
         state.error?.let { error ->
           Text(
-            text = credentialValidationErrorMessage(error.name),
+            text = credentialValidationErrorMessage(error),
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodySmall,
           )

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -2,7 +2,7 @@ package space.be1ski.vibits.feature.mode.presentation
 
 import space.be1ski.vibits.core.elm.test.test
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.action
 import space.be1ski.vibits.core.elm.Action
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 sealed interface SettingsAction : Action {

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsCredentialsEffectHandler.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.settings.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.core.utils.logging.Log
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.reducer
 import space.be1ski.vibits.core.elm.Reducer
 import space.be1ski.vibits.core.elm.reducer
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation.state
 import space.be1ski.vibits.core.platform.app.AppDetails
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 data class SettingsState(

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -166,7 +166,7 @@ private fun SettingsDialogBody(
     )
     state.validationError?.let { error ->
       Text(
-        credentialValidationErrorMessage(error.name),
+        credentialValidationErrorMessage(error),
         color = MaterialTheme.colorScheme.error,
         style = MaterialTheme.typography.bodySmall,
       )

--- a/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
+++ b/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.settings.presentation
 import space.be1ski.vibits.core.elm.test.test
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.feature.auth.domain.model.CredentialValidationError
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsEffect


### PR DESCRIPTION
## Summary

- Moved `CredentialValidationError` from `feature/auth/domain` to `core/ui/form/` so `credentialValidationErrorMessage` can accept the enum directly instead of a fragile `String`
- Eliminates hardcoded string matching (`"FILL_ALL_FIELDS"`, `"CONNECTION_FAILED"`) — enum renames are now caught at compile time
- Updated imports in 10 files (settings/presentation, mode/presentation + tests)

## Test plan

- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, tests)