### PR TITLE
Move DemoHabitStringKeys to core/utils for single source of truth

### DIFF
--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/habits/DemoHabitStrings.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/habits/DemoHabitStrings.kt
@@ -11,18 +11,19 @@ import space.be1ski.vibits.core.strings.generated.demo_habit_no_sugar
 import space.be1ski.vibits.core.strings.generated.demo_habit_reading
 import space.be1ski.vibits.core.strings.generated.demo_habit_walking
 import space.be1ski.vibits.core.strings.generated.demo_habit_water
+import space.be1ski.vibits.core.utils.habits.DemoHabitStringKeys
 
 @Composable
 fun localizedDemoHabitName(nameKey: String): String =
   when (nameKey) {
-    "demo_habit_exercise" -> stringResource(Res.string.demo_habit_exercise)
-    "demo_habit_water" -> stringResource(Res.string.demo_habit_water)
-    "demo_habit_reading" -> stringResource(Res.string.demo_habit_reading)
-    "demo_habit_meditation" -> stringResource(Res.string.demo_habit_meditation)
-    "demo_habit_walking" -> stringResource(Res.string.demo_habit_walking)
-    "demo_habit_learning" -> stringResource(Res.string.demo_habit_learning)
-    "demo_habit_no_sugar" -> stringResource(Res.string.demo_habit_no_sugar)
-    "demo_habit_early_sleep" -> stringResource(Res.string.demo_habit_early_sleep)
+    DemoHabitStringKeys.EXERCISE -> stringResource(Res.string.demo_habit_exercise)
+    DemoHabitStringKeys.WATER -> stringResource(Res.string.demo_habit_water)
+    DemoHabitStringKeys.READING -> stringResource(Res.string.demo_habit_reading)
+    DemoHabitStringKeys.MEDITATION -> stringResource(Res.string.demo_habit_meditation)
+    DemoHabitStringKeys.WALKING -> stringResource(Res.string.demo_habit_walking)
+    DemoHabitStringKeys.LEARNING -> stringResource(Res.string.demo_habit_learning)
+    DemoHabitStringKeys.NO_SUGAR -> stringResource(Res.string.demo_habit_no_sugar)
+    DemoHabitStringKeys.EARLY_SLEEP -> stringResource(Res.string.demo_habit_early_sleep)
     else -> nameKey
   }
 

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitStringKeys.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitStringKeys.kt
@@ -1,0 +1,12 @@
+package space.be1ski.vibits.core.utils.habits
+
+object DemoHabitStringKeys {
+  const val EXERCISE = "demo_habit_exercise"
+  const val READING = "demo_habit_reading"
+  const val MEDITATION = "demo_habit_meditation"
+  const val WATER = "demo_habit_water"
+  const val LEARNING = "demo_habit_learning"
+  const val WALKING = "demo_habit_walking"
+  const val NO_SUGAR = "demo_habit_no_sugar"
+  const val EARLY_SLEEP = "demo_habit_early_sleep"
+}

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabits.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabits.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
+import space.be1ski.vibits.core.utils.habits.DemoHabitStringKeys
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
 /**
@@ -26,20 +27,6 @@ object DemoHabits {
       "${PostTags.HABITS_PREFIX}$NO_SUGAR",
       "${PostTags.HABITS_PREFIX}$EARLY_SLEEP",
     )
-}
-
-/**
- * String resource keys for demo habits.
- */
-object DemoHabitStringKeys {
-  const val EXERCISE = "demo_habit_exercise"
-  const val READING = "demo_habit_reading"
-  const val MEDITATION = "demo_habit_meditation"
-  const val WATER = "demo_habit_water"
-  const val LEARNING = "demo_habit_learning"
-  const val WALKING = "demo_habit_walking"
-  const val NO_SUGAR = "demo_habit_no_sugar"
-  const val EARLY_SLEEP = "demo_habit_early_sleep"
 }
 
 /**

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabitsTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabitsTest.kt
@@ -1,0 +1,74 @@
+package space.be1ski.vibits.feature.habits.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class DemoHabitsTest {
+  @Test
+  fun `when tag is demo exercise then demoLabelKey returns exercise key`() {
+    val habit = HabitConfig(tag = "#habits/exercise", label = "Exercise")
+    assertEquals("demo_habit_exercise", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo water then demoLabelKey returns water key`() {
+    val habit = HabitConfig(tag = "#habits/water", label = "Water")
+    assertEquals("demo_habit_water", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo reading then demoLabelKey returns reading key`() {
+    val habit = HabitConfig(tag = "#habits/reading", label = "Reading")
+    assertEquals("demo_habit_reading", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo meditation then demoLabelKey returns meditation key`() {
+    val habit = HabitConfig(tag = "#habits/meditation", label = "Meditation")
+    assertEquals("demo_habit_meditation", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo walking then demoLabelKey returns walking key`() {
+    val habit = HabitConfig(tag = "#habits/walking", label = "Walking")
+    assertEquals("demo_habit_walking", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo learning then demoLabelKey returns learning key`() {
+    val habit = HabitConfig(tag = "#habits/learning", label = "Learning")
+    assertEquals("demo_habit_learning", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo no_sugar then demoLabelKey returns no_sugar key`() {
+    val habit = HabitConfig(tag = "#habits/no_sugar", label = "No Sugar")
+    assertEquals("demo_habit_no_sugar", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is demo early_sleep then demoLabelKey returns early_sleep key`() {
+    val habit = HabitConfig(tag = "#habits/early_sleep", label = "Early Sleep")
+    assertEquals("demo_habit_early_sleep", habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is not a demo habit then demoLabelKey returns null`() {
+    val habit = HabitConfig(tag = "#habits/custom", label = "Custom")
+    assertNull(habit.demoLabelKey())
+  }
+
+  @Test
+  fun `when tag is a demo habit then isDemoHabit returns true`() {
+    val habit = HabitConfig(tag = "#habits/exercise", label = "Exercise")
+    assertTrue(habit.isDemoHabit())
+  }
+
+  @Test
+  fun `when tag is not a demo habit then isDemoHabit returns false`() {
+    val habit = HabitConfig(tag = "#habits/custom", label = "Custom")
+    assertEquals(false, habit.isDemoHabit())
+  }
+}

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -3,7 +3,7 @@ package space.be1ski.vibits.feature.onboarding.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
-import space.be1ski.vibits.feature.habits.domain.model.DemoHabitStringKeys
+import space.be1ski.vibits.core.utils.habits.DemoHabitStringKeys
 import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset


### PR DESCRIPTION
## Summary

- Moved `DemoHabitStringKeys` from `feature/habits/domain` to `core/utils/habits/` — eliminates hardcoded string duplication between `habits/domain` and `core/ui`
- `localizedDemoHabitName()` in `core/ui` now matches on constants instead of raw strings
- Added tests for `demoLabelKey()` and `isDemoHabit()` (were untested, caused codecov/patch failure on #245)

## Test plan

- [x] `checkAll` passes via pre-commit hook
- [x] New `DemoHabitsTest` covers all demo habits + non-demo fallback