### PR TITLE
Centralize demo habit IDs in core/utils

### DIFF
--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/habits/DemoHabitStrings.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/habits/DemoHabitStrings.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.core.ui.habits
 
 import androidx.compose.runtime.Composable
+import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.demo_habit_early_sleep
@@ -12,20 +13,25 @@ import space.be1ski.vibits.core.strings.generated.demo_habit_reading
 import space.be1ski.vibits.core.strings.generated.demo_habit_walking
 import space.be1ski.vibits.core.strings.generated.demo_habit_water
 import space.be1ski.vibits.core.utils.habits.DEMO_HABIT_KEY_PREFIX
+import space.be1ski.vibits.core.utils.habits.DemoHabitIds
+
+private val demoHabitResources: Map<String, StringResource> =
+  mapOf(
+    DemoHabitIds.EXERCISE to Res.string.demo_habit_exercise,
+    DemoHabitIds.WATER to Res.string.demo_habit_water,
+    DemoHabitIds.READING to Res.string.demo_habit_reading,
+    DemoHabitIds.MEDITATION to Res.string.demo_habit_meditation,
+    DemoHabitIds.WALKING to Res.string.demo_habit_walking,
+    DemoHabitIds.LEARNING to Res.string.demo_habit_learning,
+    DemoHabitIds.NO_SUGAR to Res.string.demo_habit_no_sugar,
+    DemoHabitIds.EARLY_SLEEP to Res.string.demo_habit_early_sleep,
+  )
 
 @Composable
-fun localizedDemoHabitName(nameKey: String): String =
-  when (nameKey.removePrefix(DEMO_HABIT_KEY_PREFIX)) {
-    "exercise" -> stringResource(Res.string.demo_habit_exercise)
-    "water" -> stringResource(Res.string.demo_habit_water)
-    "reading" -> stringResource(Res.string.demo_habit_reading)
-    "meditation" -> stringResource(Res.string.demo_habit_meditation)
-    "walking" -> stringResource(Res.string.demo_habit_walking)
-    "learning" -> stringResource(Res.string.demo_habit_learning)
-    "no_sugar" -> stringResource(Res.string.demo_habit_no_sugar)
-    "early_sleep" -> stringResource(Res.string.demo_habit_early_sleep)
-    else -> nameKey
-  }
+fun localizedDemoHabitName(nameKey: String): String {
+  val habitId = nameKey.removePrefix(DEMO_HABIT_KEY_PREFIX)
+  return demoHabitResources[habitId]?.let { stringResource(it) } ?: nameKey
+}
 
 @Composable
 fun localizedHabitLabel(

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitIds.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitIds.kt
@@ -1,0 +1,18 @@
+package space.be1ski.vibits.core.utils.habits
+
+object DemoHabitIds {
+  const val EXERCISE = "exercise"
+  const val READING = "reading"
+  const val MEDITATION = "meditation"
+  const val WATER = "water"
+  const val LEARNING = "learning"
+  const val WALKING = "walking"
+  const val NO_SUGAR = "no_sugar"
+  const val EARLY_SLEEP = "early_sleep"
+
+  val ALL = setOf(EXERCISE, READING, MEDITATION, WATER, LEARNING, WALKING, NO_SUGAR, EARLY_SLEEP)
+}
+
+const val DEMO_HABIT_KEY_PREFIX = "demo_habit_"
+
+fun demoHabitNameKey(habitId: String): String = "$DEMO_HABIT_KEY_PREFIX$habitId"

--- a/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitKeys.kt
+++ b/core/utils/src/commonMain/kotlin/space/be1ski/vibits/core/utils/habits/DemoHabitKeys.kt
@@ -1,5 +1,0 @@
-package space.be1ski.vibits.core.utils.habits
-
-const val DEMO_HABIT_KEY_PREFIX = "demo_habit_"
-
-fun demoHabitNameKey(habitId: String): String = "$DEMO_HABIT_KEY_PREFIX$habitId"

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabits.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/model/DemoHabits.kt
@@ -1,32 +1,11 @@
 package space.be1ski.vibits.feature.habits.domain.model
 
+import space.be1ski.vibits.core.utils.habits.DemoHabitIds
 import space.be1ski.vibits.core.utils.habits.demoHabitNameKey
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
 
-/**
- * Predefined demo habits configuration.
- */
 object DemoHabits {
-  const val EXERCISE = "exercise"
-  const val READING = "reading"
-  const val MEDITATION = "meditation"
-  const val WATER = "water"
-  const val LEARNING = "learning"
-  const val WALKING = "walking"
-  const val NO_SUGAR = "no_sugar"
-  const val EARLY_SLEEP = "early_sleep"
-
-  val TAGS =
-    setOf(
-      "${PostTags.HABITS_PREFIX}$EXERCISE",
-      "${PostTags.HABITS_PREFIX}$READING",
-      "${PostTags.HABITS_PREFIX}$MEDITATION",
-      "${PostTags.HABITS_PREFIX}$WATER",
-      "${PostTags.HABITS_PREFIX}$LEARNING",
-      "${PostTags.HABITS_PREFIX}$WALKING",
-      "${PostTags.HABITS_PREFIX}$NO_SUGAR",
-      "${PostTags.HABITS_PREFIX}$EARLY_SLEEP",
-    )
+  val TAGS = DemoHabitIds.ALL.map { "${PostTags.HABITS_PREFIX}$it" }.toSet()
 }
 
 fun HabitConfig.isDemoHabit(): Boolean = DemoHabits.TAGS.contains(tag)

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/demo/DemoDataGenerator.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/demo/DemoDataGenerator.kt
@@ -6,9 +6,9 @@ import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.minus
 import kotlinx.datetime.toLocalDateTime
+import space.be1ski.vibits.core.utils.habits.DemoHabitIds
 import space.be1ski.vibits.feature.habits.domain.formatHexColor
 import space.be1ski.vibits.feature.habits.domain.labelFromTag
-import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
@@ -33,14 +33,14 @@ internal data class DemoHabit(
 internal object DemoDataGenerator {
   private val demoHabits =
     listOf(
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.EXERCISE}", formatHexColor(HabitColor(0xFF4CAF50L)), 0.85f, 0.7f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.READING}", formatHexColor(HabitColor(0xFFFF9800L)), 0.70f, 1.1f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.MEDITATION}", formatHexColor(HabitColor(0xFF9C27B0L)), 0.60f, 1.0f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.WATER}", formatHexColor(HabitColor(0xFF00BCD4L)), 0.90f, 0.95f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.LEARNING}", formatHexColor(HabitColor(0xFFE91E63L)), 0.50f, 0.6f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.WALKING}", formatHexColor(HabitColor(0xFF607D8BL)), 0.65f, 1.2f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.NO_SUGAR}", formatHexColor(HabitColor(0xFFF44336L)), 0.45f, 0.8f),
-      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabits.EARLY_SLEEP}", formatHexColor(HabitColor(0xFF2196F3L)), 0.55f, 0.7f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.EXERCISE}", formatHexColor(HabitColor(0xFF4CAF50L)), 0.85f, 0.7f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.READING}", formatHexColor(HabitColor(0xFFFF9800L)), 0.70f, 1.1f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.MEDITATION}", formatHexColor(HabitColor(0xFF9C27B0L)), 0.60f, 1.0f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.WATER}", formatHexColor(HabitColor(0xFF00BCD4L)), 0.90f, 0.95f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.LEARNING}", formatHexColor(HabitColor(0xFFE91E63L)), 0.50f, 0.6f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.WALKING}", formatHexColor(HabitColor(0xFF607D8BL)), 0.65f, 1.2f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.NO_SUGAR}", formatHexColor(HabitColor(0xFFF44336L)), 0.45f, 0.8f),
+      DemoHabit("${PostTags.HABITS_PREFIX}${DemoHabitIds.EARLY_SLEEP}", formatHexColor(HabitColor(0xFF2196F3L)), 0.55f, 0.7f),
     )
 
   private const val MONTHS_OF_HISTORY = 18

--- a/feature/onboarding/data/build.gradle.kts
+++ b/feature/onboarding/data/build.gradle.kts
@@ -9,7 +9,6 @@ kotlin {
       dependencies {
         implementation(projects.core.platform)
         implementation(projects.core.utils)
-        implementation(projects.feature.habits.domain)
         implementation(projects.feature.memos.domain)
         implementation(projects.feature.onboarding.domain)
         implementation(libs.kotlinx.datetime)

--- a/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
+++ b/feature/onboarding/data/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/data/HabitPresetsDataSource.kt
@@ -3,8 +3,8 @@ package space.be1ski.vibits.feature.onboarding.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.habits.DemoHabitIds
 import space.be1ski.vibits.core.utils.habits.demoHabitNameKey
-import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
@@ -17,14 +17,14 @@ interface HabitPresetsDataSource {
 class HabitPresetsDataSourceImpl : HabitPresetsDataSource {
   override fun getPresets(): List<HabitPreset> =
     listOf(
-      HabitPreset(id = DemoHabits.EXERCISE, nameKey = demoHabitNameKey(DemoHabits.EXERCISE)),
-      HabitPreset(id = DemoHabits.WATER, nameKey = demoHabitNameKey(DemoHabits.WATER)),
-      HabitPreset(id = DemoHabits.READING, nameKey = demoHabitNameKey(DemoHabits.READING)),
-      HabitPreset(id = DemoHabits.MEDITATION, nameKey = demoHabitNameKey(DemoHabits.MEDITATION)),
-      HabitPreset(id = DemoHabits.WALKING, nameKey = demoHabitNameKey(DemoHabits.WALKING)),
-      HabitPreset(id = DemoHabits.LEARNING, nameKey = demoHabitNameKey(DemoHabits.LEARNING)),
-      HabitPreset(id = DemoHabits.NO_SUGAR, nameKey = demoHabitNameKey(DemoHabits.NO_SUGAR)),
-      HabitPreset(id = DemoHabits.EARLY_SLEEP, nameKey = demoHabitNameKey(DemoHabits.EARLY_SLEEP)),
+      HabitPreset(id = DemoHabitIds.EXERCISE, nameKey = demoHabitNameKey(DemoHabitIds.EXERCISE)),
+      HabitPreset(id = DemoHabitIds.WATER, nameKey = demoHabitNameKey(DemoHabitIds.WATER)),
+      HabitPreset(id = DemoHabitIds.READING, nameKey = demoHabitNameKey(DemoHabitIds.READING)),
+      HabitPreset(id = DemoHabitIds.MEDITATION, nameKey = demoHabitNameKey(DemoHabitIds.MEDITATION)),
+      HabitPreset(id = DemoHabitIds.WALKING, nameKey = demoHabitNameKey(DemoHabitIds.WALKING)),
+      HabitPreset(id = DemoHabitIds.LEARNING, nameKey = demoHabitNameKey(DemoHabitIds.LEARNING)),
+      HabitPreset(id = DemoHabitIds.NO_SUGAR, nameKey = demoHabitNameKey(DemoHabitIds.NO_SUGAR)),
+      HabitPreset(id = DemoHabitIds.EARLY_SLEEP, nameKey = demoHabitNameKey(DemoHabitIds.EARLY_SLEEP)),
       HabitPreset(id = CUSTOM_PRESET_ID, nameKey = "label_habit_preset_custom"),
     )
 }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
@@ -46,7 +46,7 @@ import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.habits.localizedDemoHabitName
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
-import space.be1ski.vibits.feature.habits.domain.model.DemoHabits
+import space.be1ski.vibits.core.utils.habits.DemoHabitIds
 import space.be1ski.vibits.feature.onboarding.domain.model.CUSTOM_PRESET_ID
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 
@@ -179,14 +179,14 @@ private fun PresetCard(
 
 private fun HabitPreset.iconVector(): ImageVector? =
   when (id) {
-    DemoHabits.EXERCISE -> Icons.Default.FitnessCenter
-    DemoHabits.WATER -> Icons.Default.WaterDrop
-    DemoHabits.READING -> Icons.AutoMirrored.Filled.MenuBook
-    DemoHabits.MEDITATION -> Icons.Default.SelfImprovement
-    DemoHabits.WALKING -> Icons.AutoMirrored.Filled.DirectionsWalk
-    DemoHabits.LEARNING -> Icons.Default.School
-    DemoHabits.NO_SUGAR -> Icons.Default.NoFood
-    DemoHabits.EARLY_SLEEP -> Icons.Default.Bedtime
+    DemoHabitIds.EXERCISE -> Icons.Default.FitnessCenter
+    DemoHabitIds.WATER -> Icons.Default.WaterDrop
+    DemoHabitIds.READING -> Icons.AutoMirrored.Filled.MenuBook
+    DemoHabitIds.MEDITATION -> Icons.Default.SelfImprovement
+    DemoHabitIds.WALKING -> Icons.AutoMirrored.Filled.DirectionsWalk
+    DemoHabitIds.LEARNING -> Icons.Default.School
+    DemoHabitIds.NO_SUGAR -> Icons.Default.NoFood
+    DemoHabitIds.EARLY_SLEEP -> Icons.Default.Bedtime
     CUSTOM_PRESET_ID -> Icons.Default.AutoAwesome
     else -> null
   }


### PR DESCRIPTION
## Summary

- Introduces `DemoHabitIds` object in `core/utils/habits/` as the single source of truth for all demo habit ID constants
- Replaces the scattered `DemoHabits.*` constants (which lived in `feature/habits/domain`) with `DemoHabitIds.*` from `core/utils`
- `core/ui/DemoHabitStrings.kt` now uses a `Map<String, StringResource>` keyed by `DemoHabitIds.*` instead of a `when` block with hardcoded strings
- `DemoHabits` in `feature/habits/domain` simplified to compute `TAGS` from `DemoHabitIds.ALL`
- Removes `feature/habits/domain` dependency from `feature/onboarding/data`

## Changes

- **Added** `core/utils/.../habits/DemoHabitIds.kt` — single source of truth for habit IDs + `ALL` set
- **Deleted** `core/utils/.../habits/DemoHabitKeys.kt` — replaced by `DemoHabitIds.kt`
- **Updated** `core/ui/.../DemoHabitStrings.kt` — map-based lookup instead of `when` with hardcoded strings
- **Simplified** `feature/habits/domain/.../DemoHabits.kt` — removed individual constants, computes TAGS from `DemoHabitIds.ALL`
- **Updated** `feature/onboarding/data`, `feature/memos/data`, `feature/onboarding/presentation` — use `DemoHabitIds` directly

## Test plan

- [x] `checkAll` passes via pre-commit hook