### PR TITLE
Fix inspection warnings across the codebase

### DIFF
--- a/core/elm/src/commonMain/kotlin/space/be1ski/vibits/core/elm/ReducerDsl.kt
+++ b/core/elm/src/commonMain/kotlin/space/be1ski/vibits/core/elm/ReducerDsl.kt
@@ -40,7 +40,7 @@ public object StateUpdateScope
  * }
  * ```
  *
- * Inside [state] block, [command] and [notify] are NOT accessible due to [ReducerDslMarker].
+ * Inside `state` block, `command` and `notify` are NOT accessible due to [ReducerDslMarker].
  */
 public fun <Action, State, Command, Notification> reducer(
   reduce: ReducerContext<State, Command, Notification>.(Action, State) -> Unit,

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialFields.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/form/CredentialFields.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.core.ui.form
 
-import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
@@ -16,7 +15,7 @@ import space.be1ski.vibits.core.strings.generated.msg_connection_failed
 import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 
 @Composable
-fun ColumnScope.CredentialFields(
+fun CredentialFields(
   baseUrl: String,
   token: String,
   onBaseUrlChange: (String) -> Unit,

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitParser.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/HabitParser.kt
@@ -12,7 +12,7 @@ import space.be1ski.vibits.feature.memos.domain.model.stripHabitPrefixes
 /** Regex for matching whitespace sequences (for tag normalization). */
 private val WHITESPACE_REGEX = Regex("\\s+")
 
-/** Regex for matching checkbox format: "- [x] habit" or "* [X] habit". */
+/** Regex for matching checkbox format: "- \[x\] habit" or "* \[X\] habit". */
 private val CHECKBOX_REGEX = Regex("^\\s*[-*]\\s*\\[(x|X)\\]\\s+(.+)$")
 
 /** Regex for extracting habit tags from content. */

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/CalculateActivityRangeDeltaUseCase.kt
@@ -7,7 +7,7 @@ import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 
 /**
  * Calculates the number of periods between two activity ranges.
- * Returns positive if [to] is after [from], negative otherwise.
+ * Returns positive if `to` is after `from`, negative otherwise.
  */
 object CalculateActivityRangeDeltaUseCase {
   operator fun invoke(

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
@@ -122,7 +122,6 @@ class SaveDailyHabitMemoUseCaseTest {
   @Test
   fun `when concurrent calls for same date then does not create duplicates`() =
     runTest {
-      val createdMemo = Memo(name = "memos/1", content = "#habits/daily 2026-01-30\n\nexercise")
       val repository = StatefulFakeMemosRepository()
       val useCase = SaveDailyHabitMemoUseCase(repository)
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/HabitsState.kt
@@ -22,7 +22,7 @@ data class EditableHabit(
   val color: HabitColor,
 ) {
   fun toHabitConfig(): HabitConfig {
-    val finalTag = if (tag.isBlank()) normalizeHabitTag(label) else tag
+    val finalTag = tag.ifBlank { normalizeHabitTag(label) }
     return HabitConfig(tag = finalTag, label = label, color = color)
   }
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -121,7 +121,6 @@ private fun rememberStatsScreenDerived(
     remember(habitsConfigTimeline) {
       habitsConfigTimeline.firstOrNull()?.date
     }
-  val finalSuccessRate = successRate
   val periodPosts =
     remember(memos, range, timeZone) {
       GetPeriodPostsUseCase(memos, range, timeZone)
@@ -143,7 +142,7 @@ private fun rememberStatsScreenDerived(
     todayDay = todayDay,
     today = today,
     timeZone = timeZone,
-    successRate = finalSuccessRate,
+    successRate = successRate,
     periodPosts = periodPosts,
     dateFormatter = dateFormatter,
     configStartDate = configStartDate,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.horizontalScroll
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
-import androidx.compose.foundation.layout.BoxWithConstraintsScope
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
@@ -159,7 +158,7 @@ private fun ContributionGridLayout(
 }
 
 @Composable
-private fun BoxWithConstraintsScope.ContributionGridContent(
+private fun ContributionGridContent(
   state: ContributionGridState,
   dateFormatter: DateFormatter,
   onDaySelected: (ContributionDay) -> Unit,
@@ -216,7 +215,7 @@ private fun BoxWithConstraintsScope.ContributionGridContent(
 }
 
 @Composable
-private fun BoxWithConstraintsScope.CalendarGridLayout(
+private fun CalendarGridLayout(
   state: ContributionGridState,
   onDaySelected: (ContributionDay) -> Unit,
   interaction: ContributionGridInteractionState,

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsCacheTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/HabitsCacheTest.kt
@@ -69,7 +69,7 @@ class HabitsCacheTest {
 
     // When: manually invalidate for week 2
     val memos = emptyList<space.be1ski.vibits.feature.memos.domain.model.Memo>()
-    val (newState, effects) =
+    val (newState, _) =
       reducer.invoke(
         HabitsAction.Cache.InvalidateCache(
           range = week2Range,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -63,16 +63,27 @@ internal fun AppContent(
   onThemeChanged: (AppTheme) -> Unit,
   onLanguageChanged: (AppLanguage) -> Unit,
 ) {
-  when {
-    appMode == AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = featuresState.modeSelection)
-    appMode == AppMode.OFFLINE && showOnboarding -> {
-      val onboardingState by featuresState.onboarding.state.collectAsState()
-      OnboardingScreen(
-        state = onboardingState,
-        onAction = featuresState.onboarding::send,
-      )
-    }
-    appMode == AppMode.ONLINE || appMode == AppMode.OFFLINE || appMode == AppMode.DEMO -> {
+  when (appMode) {
+    AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = featuresState.modeSelection)
+    AppMode.OFFLINE ->
+      if (showOnboarding) {
+        val onboardingState by featuresState.onboarding.state.collectAsState()
+        OnboardingScreen(
+          state = onboardingState,
+          onAction = featuresState.onboarding::send,
+        )
+      } else {
+        AppWithLoadingScreen(
+          features = featuresState.app,
+          appTheme = appTheme,
+          appLanguage = appLanguage,
+          exportService = exportService,
+          onResetApp = onResetApp,
+          onThemeChanged = onThemeChanged,
+          onLanguageChanged = onLanguageChanged,
+        )
+      }
+    AppMode.ONLINE, AppMode.DEMO -> {
       AppWithLoadingScreen(
         features = featuresState.app,
         appTheme = appTheme,

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepository.kt
@@ -14,7 +14,7 @@ import space.be1ski.vibits.feature.mode.domain.repository.AppModeRepository
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags
 import space.be1ski.vibits.feature.sync.domain.repository.OfflineFirstMemoOperations
 
-private val TAG = SyncLogTags.MODE_AWARE_REPO
+private const val TAG = SyncLogTags.MODE_AWARE_REPO
 
 @Inject
 @SingleIn(AppScope::class)

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosRemoteSourceImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosRemoteSourceImpl.kt
@@ -16,7 +16,7 @@ class MemosRemoteSourceImpl(
   private val memosApi: MemosApi,
   private val credentialsRepository: CredentialsRepository,
 ) : MemosRemoteSource {
-  private suspend fun credentials(): Pair<String, String> {
+  private fun credentials(): Pair<String, String> {
     val creds = credentialsRepository.load().requireFilled()
     return creds.baseUrl to creds.token
   }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
@@ -11,7 +11,7 @@ import space.be1ski.vibits.feature.sync.domain.SyncLogTags
 import space.be1ski.vibits.feature.sync.domain.model.SyncResult
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 
-private val TAG = SyncLogTags.MEMOS_SYNC_EFFECT
+private const val TAG = SyncLogTags.MEMOS_SYNC_EFFECT
 
 class MemosSyncEffectHandler(
   private val syncEngine: SyncEngine,

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -4,7 +4,6 @@ import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.auth.domain.test.FakeCredentialsRepository
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
-import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
 import space.be1ski.vibits.feature.mode.domain.test.FakeAppModeRepository
 import space.be1ski.vibits.feature.mode.domain.usecase.SaveAppModeUseCase
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
@@ -176,7 +175,7 @@ class ModeSelectionEffectHandlerTest {
     return ModeSelectionEffectHandler(
       credentialsHandler =
         ModeSelectionCredentialsEffectHandler(
-          connectionTester = ConnectionTester { _, _ -> connectionResult },
+          connectionTester = { _, _ -> connectionResult },
           initializeCredentialsFromEnv =
             space.be1ski.vibits.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase(
               loadCredentials =

--- a/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -6,7 +6,6 @@ import space.be1ski.vibits.core.platform.locale.LocaleProvider
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.auth.domain.test.FakeCredentialsRepository
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
-import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
 import space.be1ski.vibits.feature.memos.domain.test.FakeMemoStorageManager
 import space.be1ski.vibits.feature.mode.domain.test.FakeAppModeRepository
 import space.be1ski.vibits.feature.mode.domain.usecase.ResetAppUseCase
@@ -154,7 +153,7 @@ class SettingsEffectHandlerTest {
     return SettingsEffectHandler(
       credentialsHandler =
         SettingsCredentialsEffectHandler(
-          connectionTester = ConnectionTester { _, _ -> connectionResult },
+          connectionTester = { _, _ -> connectionResult },
           saveCredentials = SaveCredentialsUseCase(credentialsRepository),
         ),
       modeHandler =

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepository.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepository.kt
@@ -17,7 +17,7 @@ import space.be1ski.vibits.feature.sync.domain.repository.OfflineFirstMemoOperat
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 import kotlin.time.Clock
 
-private val TAG = SyncLogTags.OFFLINE_FIRST_MEMOS
+private const val TAG = SyncLogTags.OFFLINE_FIRST_MEMOS
 
 /**
  * Thread-safe offline-first memo operations.

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
@@ -18,7 +18,7 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncResult
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 import space.be1ski.vibits.feature.sync.domain.usecase.DetectSyncConflictsUseCase
 
-private val TAG = SyncLogTags.SYNC_ENGINE
+private const val TAG = SyncLogTags.SYNC_ENGINE
 private const val LOG_CONTENT_PREVIEW_LENGTH = 50
 
 @Inject

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
@@ -13,7 +13,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
 import kotlin.time.Duration.Companion.seconds
 
-private val TAG = SyncLogTags.SYNC_OPERATION_APPLIER
+private const val TAG = SyncLogTags.SYNC_OPERATION_APPLIER
 
 private const val DEFAULT_MAX_RETRIES = 3
 private val DEFAULT_INITIAL_DELAY = 500.milliseconds

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepositoryTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/OfflineFirstMemosRepositoryTest.kt
@@ -167,7 +167,7 @@ class OfflineFirstMemosRepositoryTest {
   @Test
   fun `when updateMemoLocally with temp memo then finds correct CREATE among multiple operations`() =
     runTest {
-      val (repository, cache, queue) = createRepository()
+      val (repository, _, queue) = createRepository()
 
       // Add some unrelated operations to the queue first
       queue.addOperation(
@@ -242,7 +242,7 @@ class OfflineFirstMemosRepositoryTest {
   @Test
   fun `when updateMemoLocally with existing memo among others then finds correct one`() =
     runTest {
-      val (repository, cache, queue) = createRepository()
+      val (repository, cache, _) = createRepository()
       // Add multiple memos, only one matches
       cache.memos.add(Memo(name = "memos/other1", content = "Other 1"))
       cache.memos.add(Memo(name = "memos/target", content = "Original", createTime = Instant.fromEpochMilliseconds(1000L)))

--- a/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
+++ b/feature/sync/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/usecase/DetectSyncConflictsUseCase.kt
@@ -9,7 +9,7 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncOperation
 import space.be1ski.vibits.feature.sync.domain.model.SyncOperationType
 import space.be1ski.vibits.feature.sync.domain.model.TempMemoName
 
-private val TAG = SyncLogTags.SYNC_ENGINE
+private const val TAG = SyncLogTags.SYNC_ENGINE
 
 object DetectSyncConflictsUseCase {
   operator fun invoke(

--- a/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/OperationIdTest.kt
+++ b/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/OperationIdTest.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.sync.domain.model
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
 
@@ -21,7 +22,7 @@ class OperationIdTest {
   @Test
   fun `when generating multiple ids then all are unique`() {
     val ids = (1..100).map { OperationId.generate() }.toSet()
-    assertTrue(ids.size == 100)
+    assertEquals(100, ids.size)
   }
 
   @Test
@@ -29,7 +30,7 @@ class OperationIdTest {
     val id = OperationId.generate()
     // Format: op_{timestamp}_{random}
     val parts = id.removePrefix("op_").split("_")
-    assertTrue(parts.size == 2)
+    assertEquals(2, parts.size)
     // First part is timestamp (long number)
     assertTrue(parts[0].all { it.isDigit() })
     // Second part is random number

--- a/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/SyncModelsTest.kt
+++ b/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/SyncModelsTest.kt
@@ -69,7 +69,7 @@ class SyncModelsTest {
     val after =
       kotlin.time.Clock.System
         .now()
-    assertTrue(operation.createdAt >= before && operation.createdAt <= after)
+    assertTrue(operation.createdAt in before..after)
   }
 
   @Test

--- a/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/TempMemoNameTest.kt
+++ b/feature/sync/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/domain/model/TempMemoNameTest.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.sync.domain.model
 
 import kotlin.test.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertNotEquals
 import kotlin.test.assertTrue
@@ -37,8 +38,7 @@ class TempMemoNameTest {
   @Test
   fun `when generating multiple names then all are unique`() {
     val names = (1..100).map { TempMemoName.generate() }.toSet()
-    // All generated names should be unique
-    assertTrue(names.size == 100)
+    assertEquals(100, names.size)
   }
 
   @Test
@@ -46,11 +46,11 @@ class TempMemoNameTest {
     val name = TempMemoName.generate()
     // Format: local_{timestamp}_{random}
     val parts = name.removePrefix("local_").split("_")
-    assertTrue(parts.size == 2)
+    assertEquals(2, parts.size)
     // First part is timestamp (long number)
     assertTrue(parts[0].all { it.isDigit() })
     // Second part is random (9 digit number)
-    assertTrue(parts[1].length == 9)
+    assertEquals(9, parts[1].length)
     assertTrue(parts[1].all { it.isDigit() })
   }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -82,7 +82,6 @@ firebase-analytics = { group = "com.google.firebase", name = "firebase-analytics
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-android-kotlin-multiplatform-library = { id = "com.android.kotlin.multiplatform.library" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 compose-multiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
 detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
@@ -90,9 +89,6 @@ kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
-ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
-metro = { id = "dev.zacsweers.metro", version.ref = "metro" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-appdistribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -2,9 +2,7 @@
 
 echo "Running pre-commit checks..."
 
-./gradlew checkAll --quiet
-
-if [ $? -ne 0 ]; then
+if ! ./gradlew checkAll --quiet; then
   echo ""
   echo "Pre-commit verification failed. Please fix the issues above before committing."
   exit 1


### PR DESCRIPTION
## Summary
- Fix actionable warnings from IntelliJ Inspect Code report across 25 files

## Changes
- **const TAG**: Add `const` to 6 TAG fields referencing `SyncLogTags` constants
- **Unused variables**: Remove/replace with `_` in 4 test files
- **Unused receivers**: Remove `ColumnScope` from `CredentialFields`, `BoxWithConstraintsScope` from 2 private ContributionGrid functions
- **Redundant suspend**: Remove from `MemosRemoteSourceImpl.credentials()`
- **Test assertions**: Replace `assertTrue(x == y)` with `assertEquals` in 5 places
- **Redundant SAM constructors**: Remove `ConnectionTester { }` wrapper in 2 test files
- **Code style**: Use `ifBlank`, range check, `when(appMode)` subject, inline unnecessary variable
- **KDoc**: Fix unresolved references in ReducerDsl, HabitParser, CalculateActivityRangeDeltaUseCase
- **Version catalog**: Remove 4 unused plugin aliases (kover, ksp, metro, android-kotlin-multiplatform-library)
- **Shell script**: Fix ShellCheck warning in pre-commit script

## Test plan
- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, all tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)