### PR TITLE
Restore library API in ReducerDsl/ReducerTestDsl with @Suppress

### DIFF
--- a/core/elm/src/commonMain/kotlin/space/be1ski/vibits/core/elm/ReducerDsl.kt
+++ b/core/elm/src/commonMain/kotlin/space/be1ski/vibits/core/elm/ReducerDsl.kt
@@ -55,6 +55,7 @@ public fun <Action, State, Command, Notification> reducer(
  * If [state] is called multiple times, only the last transformation is applied.
  * Commands and notifications accumulate with each call.
  */
+@Suppress("unused") // Library API — not all methods are used yet
 @ReducerDslMarker
 public class ReducerContext<State, Command, Notification> {
   private var stateUpdate: (State.() -> State) = { this }
@@ -151,6 +152,32 @@ public class ReducerContext<State, Command, Notification> {
    */
   public fun notify(notification: Notification) {
     notifications.add(notification)
+  }
+
+  /**
+   * Emits multiple notifications to external observers.
+   *
+   * ```
+   * notifications(MyNotification.Saved, MyNotification.DialogClosed)
+   * ```
+   *
+   * @param notifications The notifications to emit
+   */
+  public fun notifications(vararg notifications: Notification) {
+    notifications(notifications.toList())
+  }
+
+  /**
+   * Emits a list of notifications to external observers.
+   *
+   * ```
+   * notifications(listOf(MyNotification.Saved, MyNotification.DialogClosed))
+   * ```
+   *
+   * @param notifications The list of notifications to emit
+   */
+  public fun notifications(notifications: List<Notification>) {
+    this.notifications.addAll(notifications)
   }
 
   internal fun getResult(initialState: State): ReducerResult<State, Command, Notification> =

--- a/core/elm/src/commonTest/kotlin/space/be1ski/vibits/core/elm/ReducerContextTest.kt
+++ b/core/elm/src/commonTest/kotlin/space/be1ski/vibits/core/elm/ReducerContextTest.kt
@@ -19,6 +19,12 @@ class ReducerContextTest {
     ) : TestEffect
   }
 
+  private sealed interface TestNotification {
+    data object Saved : TestNotification
+
+    data object Closed : TestNotification
+  }
+
   @Test
   fun `when no changes then getResult returns initial state with empty effects`() {
     val context = ReducerContext<TestState, TestEffect, Nothing>()
@@ -125,5 +131,26 @@ class ReducerContextTest {
 
     assertEquals(initialState, result.state)
     assertEquals(listOf(TestEffect.EffectA), result.commands)
+  }
+
+  @Test
+  fun `when notifications called with vararg then all notifications are added`() {
+    val context = ReducerContext<TestState, TestEffect, TestNotification>()
+    context.notifications(TestNotification.Saved, TestNotification.Closed)
+
+    val result = context.getResult(TestState())
+
+    assertEquals(listOf(TestNotification.Saved, TestNotification.Closed), result.notifications)
+  }
+
+  @Test
+  fun `when notifications called with list then all notifications are added`() {
+    val context = ReducerContext<TestState, TestEffect, TestNotification>()
+    val notificationList = listOf(TestNotification.Saved, TestNotification.Closed)
+    context.notifications(notificationList)
+
+    val result = context.getResult(TestState())
+
+    assertEquals(notificationList, result.notifications)
   }
 }

--- a/core/elm/test/src/commonMain/kotlin/space/be1ski/vibits/core/elm/test/ReducerTestDsl.kt
+++ b/core/elm/test/src/commonMain/kotlin/space/be1ski/vibits/core/elm/test/ReducerTestDsl.kt
@@ -37,7 +37,7 @@ fun <Action, State, Command, Notification> Reducer<Action, State, Command, Notif
   ReducerTestScope(this, initialState).apply(block)
 }
 
-@Suppress("TooManyFunctions") // Test DSL requires many helper methods
+@Suppress("TooManyFunctions", "unused") // Library API — not all methods are used yet
 class ReducerTestScope<Action, State, Command, Notification>(
   private val reducer: Reducer<Action, State, Command, Notification>,
   initialState: State,
@@ -45,6 +45,7 @@ class ReducerTestScope<Action, State, Command, Notification>(
   private var currentState: State = initialState
   private var lastResult: ReducerResult<State, Command, Notification>? = null
   private val allCommands = mutableListOf<Command>()
+  private val allNotifications = mutableListOf<Notification>()
 
   /**
    * Sends an action to the reducer and captures the result.
@@ -53,6 +54,7 @@ class ReducerTestScope<Action, State, Command, Notification>(
     lastResult = reducer(action, currentState)
     currentState = lastResult!!.state
     allCommands.addAll(lastResult!!.commands)
+    allNotifications.addAll(lastResult!!.notifications)
   }
 
   /**
@@ -74,6 +76,11 @@ class ReducerTestScope<Action, State, Command, Notification>(
    * Returns all commands accumulated from all sent actions.
    */
   val allEmittedCommands: List<Command> get() = allCommands.toList()
+
+  /**
+   * Returns all notifications accumulated from all sent actions.
+   */
+  val allEmittedNotifications: List<Notification> get() = allNotifications.toList()
 
   /**
    * Asserts that the current state equals the expected state.
@@ -125,10 +132,24 @@ class ReducerTestScope<Action, State, Command, Notification>(
   }
 
   /**
+   * Asserts that the last action emitted exactly these commands in order.
+   */
+  fun assertCommands(expected: List<Command>) {
+    assertEquals(expected, commands, "Commands mismatch")
+  }
+
+  /**
    * Asserts that the last action emitted exactly these notifications in order.
    */
   fun assertNotifications(vararg expected: Notification) {
     assertEquals(expected.toList(), notifications, "Notifications mismatch")
+  }
+
+  /**
+   * Asserts that the last action emitted exactly these notifications in order.
+   */
+  fun assertNotifications(expected: List<Notification>) {
+    assertEquals(expected, notifications, "Notifications mismatch")
   }
 
   /**
@@ -162,9 +183,26 @@ class ReducerTestScope<Action, State, Command, Notification>(
   }
 
   /**
+   * Asserts that the last action emitted a notification matching the predicate.
+   */
+  inline fun <reified N : Notification> assertHasNotification(predicate: (N) -> Boolean): N {
+    val notification =
+      notifications.filterIsInstance<N>().firstOrNull(predicate)
+        ?: fail("Expected notification of type ${N::class.simpleName} matching predicate but got: $notifications")
+    return notification
+  }
+
+  /**
    * Asserts the number of commands emitted from the last action.
    */
   fun assertCommandCount(expected: Int) {
     assertEquals(expected, commands.size, "Command count mismatch")
+  }
+
+  /**
+   * Asserts the number of notifications emitted from the last action.
+   */
+  fun assertNotificationCount(expected: Int) {
+    assertEquals(expected, notifications.size, "Notification count mismatch")
   }
 }

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/Indent.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/Indent.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.core.ui
 
 import androidx.compose.ui.unit.dp
 
+@Suppress("unused") // Design system — not all values are used yet
 object Indent {
   val x5s = 1.dp
   val x4s = 2.dp
@@ -13,4 +14,8 @@ object Indent {
   val l = 20.dp
   val xl = 24.dp
   val x2l = 32.dp
+  val x3l = 40.dp
+  val x4l = 48.dp
+  val x5l = 56.dp
+  val x6l = 64.dp
 }


### PR DESCRIPTION
## Summary
- Restore all functions removed from `ReducerDsl` and `ReducerTestDsl` — they are library API
- Add class-level `@Suppress("unused")` with explanation that these are library APIs

## Changes
- `ReducerContext`: restored `notifications(vararg)` and `notifications(List)`, added `@Suppress("unused")` on class
- `ReducerTestScope`: restored `allEmittedNotifications`, `assertCommands(List)`, `assertNotifications(List)`, `assertHasNotification(predicate)`, `assertNotificationCount`, added `@Suppress("unused")` on class

## Test plan
- [x] `./gradlew checkJvm` passes