### PR TITLE
Add animations to stats screen components

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -1,6 +1,13 @@
 @file:Suppress("TooManyFunctions")
 
 package space.be1ski.vibits.feature.habits.presentation.view
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.animation.expandVertically
+import androidx.compose.animation.fadeIn
+import androidx.compose.animation.fadeOut
+import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -28,6 +35,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -392,7 +400,15 @@ internal fun StatsCollapsiblePosts(
         },
       )
     }
-    if (expanded) {
+    AnimatedVisibility(
+      visible = expanded,
+      enter =
+        fadeIn(animationSpec = tween(durationMillis = POSTS_LIST_ANIMATION_MS)) +
+          expandVertically(animationSpec = tween(durationMillis = POSTS_LIST_ANIMATION_MS)),
+      exit =
+        fadeOut(animationSpec = tween(durationMillis = POSTS_LIST_ANIMATION_MS)) +
+          shrinkVertically(animationSpec = tween(durationMillis = POSTS_LIST_ANIMATION_MS)),
+    ) {
       Column(
         modifier =
           Modifier
@@ -415,6 +431,8 @@ internal fun StatsCollapsiblePosts(
 
 private val POSTS_LIST_MAX_HEIGHT = 200.dp
 private const val DIVIDER_ALPHA = 0.5f
+private const val DISABLED_CELL_ALPHA = 0.3f
+private const val POSTS_LIST_ANIMATION_MS = 200
 
 @Composable
 private fun CompactPostRow(
@@ -451,6 +469,7 @@ private fun CompactPostRow(
 }
 
 private const val COMPACT_POST_MAX_LENGTH = 50
+private const val MATRIX_CELL_FILL_MS = 220
 
 @Suppress("LongMethod")
 @Composable
@@ -715,14 +734,18 @@ private fun LastSevenDaysMatrix(
           )
           days.forEach { day ->
             val done = day.habitStatuses.firstOrNull { status -> status.tag == habit.tag }?.done == true
-            val baseColor =
+            val alpha = if (!day.isClickable) DISABLED_CELL_ALPHA else 1f
+            val targetColor =
               if (done) {
                 androidx.compose.ui.graphics
                   .Color(habit.color.argb)
               } else {
                 pendingColor
               }
-            val cellColor = if (!day.isClickable) baseColor.copy(alpha = 0.3f) else baseColor
+            val cellColor by animateColorAsState(
+              targetValue = targetColor.copy(alpha = alpha),
+              animationSpec = tween(durationMillis = MATRIX_CELL_FILL_MS),
+            )
             Box(
               modifier =
                 Modifier

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -1,6 +1,10 @@
 @file:Suppress("TooManyFunctions")
 
 package space.be1ski.vibits.feature.habits.presentation.view.components
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
@@ -22,12 +26,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
@@ -84,6 +90,9 @@ private const val REGULAR_CELL_DP = 10
 private const val MAX_COMPACT_CELL_DP = 40
 
 private const val HABIT_COLOR_LIGHT_RATIO = 0.3f
+private const val CELL_BORDER_ANIMATION_MS = 140
+private const val CELL_FILL_ANIMATION_MS = 220
+private const val GRID_ENTER_ANIMATION_MS = 220
 
 /**
  * Renders GitHub-style daily activity grid for the provided [state].
@@ -102,8 +111,16 @@ fun ContributionGrid(
   if (!state.isActiveSelection && interaction.tooltip != null) {
     interaction.tooltip = null
   }
+  var animateIn by remember(state.range, state.weekData.weeks, state.calendarLayout) { mutableStateOf(false) }
+  LaunchedEffect(state.range, state.weekData.weeks, state.calendarLayout) { animateIn = true }
+  val contentAlpha by animateFloatAsState(
+    targetValue = if (animateIn) 1f else 0f,
+    animationSpec = tween(durationMillis = GRID_ENTER_ANIMATION_MS),
+  )
   Column(modifier = modifier) {
-    ContributionGridLayout(state, dateFormatter, onDaySelected, onClearSelection, interaction)
+    Box(modifier = Modifier.alpha(contentAlpha)) {
+      ContributionGridLayout(state, dateFormatter, onDaySelected, onClearSelection, interaction)
+    }
     ContributionGridTooltip(state, interaction, onEditRequested, onCreateRequested)
   }
 }
@@ -655,6 +672,7 @@ private fun ContributionCell(
   val defaultStartColor = AppColors.habitGradientStart.resolve()
   val defaultEndColor = AppColors.habitGradientEnd.resolve()
   val inactiveCellColor = AppColors.inactiveCell.resolve()
+  val disabledCellColor = MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
   val (startColor, endColor) =
     remember(state.habitColor, defaultStartColor, defaultEndColor) {
       if (state.habitColor != null) {
@@ -665,40 +683,46 @@ private fun ContributionCell(
         defaultStartColor to defaultEndColor
       }
     }
-  val color =
-    when {
-      !state.enabled -> MaterialTheme.colorScheme.surfaceVariant.copy(alpha = 0.4f)
-      else -> {
-        val ratio =
-          if (state.day.totalHabits > 0) {
-            state.day.completionRatio
-          } else if (state.maxCount > 0) {
-            state.day.count.toFloat() / state.maxCount.toFloat()
-          } else {
-            0f
-          }
-        if (ratio <= 0f) {
-          inactiveCellColor
-        } else {
-          lerp(startColor, endColor, ratio.coerceIn(0f, 1f))
-        }
-      }
+  val targetRatio =
+    if (!state.enabled) {
+      0f
+    } else if (state.day.totalHabits > 0) {
+      state.day.completionRatio
+    } else if (state.maxCount > 0) {
+      state.day.count.toFloat() / state.maxCount.toFloat()
+    } else {
+      0f
     }
+  val animatedRatio by animateFloatAsState(
+    targetValue = targetRatio.coerceIn(0f, 1f),
+    animationSpec = tween(durationMillis = CELL_FILL_ANIMATION_MS),
+  )
 
   // Apply subtle highlight for today and weekends
   val todayOverlay = AppColors.todayHighlight.resolve()
   val weekendOverlay = Color.Black.copy(alpha = WEEKEND_CELL_ALPHA)
-  val baseColor =
-    if (state.isWeekend && state.enabled) {
-      color.compositeOver(weekendOverlay)
+
+  fun applyOverlays(color: Color): Color {
+    if (!state.enabled) return color
+    val weekendApplied =
+      if (state.isWeekend) {
+        color.compositeOver(weekendOverlay)
+      } else {
+        color
+      }
+    return if (state.isToday) {
+      weekendApplied.compositeOver(todayOverlay)
     } else {
-      color
+      weekendApplied
     }
+  }
   val cellColor =
-    if (state.isToday && state.enabled) {
-      baseColor.compositeOver(todayOverlay)
+    if (!state.enabled) {
+      disabledCellColor
+    } else if (animatedRatio <= 0f) {
+      applyOverlays(inactiveCellColor)
     } else {
-      baseColor
+      applyOverlays(lerp(startColor, endColor, animatedRatio))
     }
 
   val borderColor =
@@ -714,13 +738,20 @@ private fun ContributionCell(
       state.isHovered || state.isWeekSelected -> Indent.x5s
       else -> 0.dp
     }
-
+  val animatedBorderColor by animateColorAsState(
+    targetValue = borderColor,
+    animationSpec = tween(durationMillis = CELL_BORDER_ANIMATION_MS),
+  )
+  val animatedBorderWidth by animateDpAsState(
+    targetValue = borderWidth,
+    animationSpec = tween(durationMillis = CELL_BORDER_ANIMATION_MS),
+  )
   Box(
     modifier =
       Modifier
         .size(state.size)
         .background(color = cellColor, shape = MaterialTheme.shapes.extraSmall)
-        .border(width = borderWidth, color = borderColor, shape = MaterialTheme.shapes.extraSmall)
+        .border(width = animatedBorderWidth, color = animatedBorderColor, shape = MaterialTheme.shapes.extraSmall)
         .onGloballyPositioned { coordinates = it }
         .then(
           if (onHoverChange != null) {

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridModels.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridModels.kt
@@ -1,3 +1,0 @@
-package space.be1ski.vibits.feature.habits.presentation.view.components
-
-internal const val QUARTER_START_DAY_LIMIT = 7

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridTimeline.kt
@@ -46,6 +46,8 @@ internal fun buildTimelineLabels(
   }
 }
 
+private const val QUARTER_START_DAY_LIMIT = 7
+
 private fun isQuarterStart(date: LocalDate): Boolean =
   date.day <= QUARTER_START_DAY_LIMIT &&
     date.month in setOf(Month.JANUARY, Month.APRIL, Month.JULY, Month.OCTOBER)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeeklyBarChart.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeeklyBarChart.kt
@@ -1,4 +1,7 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.horizontalScroll
@@ -14,6 +17,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -28,11 +32,14 @@ import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Popup
 import kotlinx.datetime.DatePeriod
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.plus
 import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
 
 private val WEEKLY_BAR_MAX_HEIGHT = 72.dp
 private val WEEKLY_BAR_MIN_HEIGHT = 4.dp
+private const val BAR_HEIGHT_ANIMATION_MS = 320
+private const val BAR_COLOR_ANIMATION_MS = 180
 
 /**
  * Tooltip payload for a selected week.
@@ -105,6 +112,7 @@ private fun WeeklyBarChartBars(
             maxCount = state.weekData.maxWeekly,
             width = layout.columnSize,
             isSelected = state.selectedWeek?.startDate == week.startDate,
+            weekStart = week.startDate,
             onClick = { offset ->
               onWeekSelected(week)
               onTooltipChange(WeekTooltip(week, offset))
@@ -151,17 +159,33 @@ private fun WeeklyBar(
   maxCount: Int,
   width: Dp,
   isSelected: Boolean,
+  weekStart: LocalDate,
   onClick: (IntOffset) -> Unit,
 ) {
   var coordinates by remember { mutableStateOf<LayoutCoordinates?>(null) }
   val maxHeight = WEEKLY_BAR_MAX_HEIGHT
-  val height =
+  val targetHeight =
     if (maxCount <= 0) {
       WEEKLY_BAR_MIN_HEIGHT
     } else {
       (maxHeight.value * (count.toFloat() / maxCount.toFloat())).dp
     }
-  val color = if (isSelected) MaterialTheme.colorScheme.outline else MaterialTheme.colorScheme.outlineVariant
+  var animateIn by remember(weekStart) { mutableStateOf(false) }
+  LaunchedEffect(weekStart) { animateIn = true }
+  val height by animateDpAsState(
+    targetValue = if (animateIn) targetHeight else WEEKLY_BAR_MIN_HEIGHT,
+    animationSpec = tween(durationMillis = BAR_HEIGHT_ANIMATION_MS),
+  )
+  val targetColor =
+    if (isSelected) {
+      MaterialTheme.colorScheme.outline
+    } else {
+      MaterialTheme.colorScheme.outlineVariant
+    }
+  val color by animateColorAsState(
+    targetValue = targetColor,
+    animationSpec = tween(durationMillis = BAR_COLOR_ANIMATION_MS),
+  )
   Column(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Bottom,


### PR DESCRIPTION
## Summary
- ContributionGrid: smooth fade-in on range change, animated cell color transitions, animated border on selection/hover
- LastSevenDaysMatrix: smooth color transition (gray to habit color) on habit toggle
- WeeklyBarChart: animated bar height on period change, animated color on week selection
- Inline `QUARTER_START_DAY_LIMIT` constant into its only consumer and delete `ContributionGridModels.kt`

## Changes
- **ContributionGrid.kt** — add `animateFloatAsState` for cell color, `animateColorAsState`/`animateDpAsState` for borders, alpha fade-in on grid enter
- **StatsScreenContent.kt** — add `animateColorAsState` for habit matrix cell toggle
- **WeeklyBarChart.kt** — existing animation changes (bar height, selection color)
- **ContributionGridTimeline.kt** — absorb constant from deleted models file
- **ContributionGridModels.kt** — deleted (single constant moved)

## Test plan
- [x] `checkAll` passes via pre-commit hook