### PR TITLE
Add screenshot tests for all features

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.kmp.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.compose.gradle.kts
@@ -3,3 +3,15 @@ plugins {
   id("org.jetbrains.compose")
   id("org.jetbrains.kotlin.plugin.compose")
 }
+
+@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+kotlin {
+  sourceSets {
+    val desktopTest by getting {
+      dependencies {
+        implementation(compose.uiTest)
+        implementation(compose.desktop.currentOs)
+      }
+    }
+  }
+}

--- a/core/elm/test/build.gradle.kts
+++ b/core/elm/test/build.gradle.kts
@@ -8,6 +8,7 @@ kotlin {
       dependencies {
         api(projects.core.elm)
         implementation(kotlin("test"))
+        implementation(libs.kotlinx.coroutines.core)
       }
     }
   }

--- a/core/elm/test/src/commonMain/kotlin/space/be1ski/vibits/core/elm/test/RecordingFeature.kt
+++ b/core/elm/test/src/commonMain/kotlin/space/be1ski/vibits/core/elm/test/RecordingFeature.kt
@@ -1,0 +1,31 @@
+package space.be1ski.vibits.core.elm.test
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.emptyFlow
+import space.be1ski.vibits.core.elm.Feature
+
+class RecordingFeature<Action, State, Command, Notification>(
+  initialState: State,
+) : Feature<Action, State, Command, Notification> {
+  private val _state = MutableStateFlow(initialState)
+  override val state: StateFlow<State> = _state.asStateFlow()
+
+  override val notifications: Flow<Notification> = emptyFlow()
+
+  private val _actions = mutableListOf<Action>()
+  val actions: List<Action> get() = _actions.toList()
+
+  override fun send(action: Action) {
+    _actions.add(action)
+  }
+
+  override fun launchIn(scope: CoroutineScope) = Unit
+
+  fun setState(newState: State) {
+    _state.value = newState
+  }
+}

--- a/core/ui/testing/build.gradle.kts
+++ b/core/ui/testing/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+  id("vibits.kmp.compose")
+}
+
+kotlin {
+  sourceSets {
+    @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+    val desktopMain by getting {
+      dependencies {
+        api(compose.uiTest)
+        api(projects.core.ui)
+        implementation(libs.compose.foundation)
+        implementation(libs.compose.material3)
+      }
+    }
+  }
+}

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -1,0 +1,58 @@
+package space.be1ski.vibits.core.ui.test
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.toAwtImage
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.DesktopComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.captureToImage
+import androidx.compose.ui.test.isRoot
+import androidx.compose.ui.test.runDesktopComposeUiTest
+import space.be1ski.vibits.core.ui.theme.VibitsTheme
+import java.awt.Graphics2D
+import java.awt.image.BufferedImage
+import java.io.File
+import javax.imageio.ImageIO
+
+private const val APP_WIDTH = 540
+private const val APP_HEIGHT = 1080
+
+@OptIn(ExperimentalTestApi::class)
+fun runAppUiTest(block: suspend DesktopComposeUiTest.() -> Unit) =
+  runDesktopComposeUiTest(width = APP_WIDTH, height = APP_HEIGHT, block = block)
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.setThemedContent(content: @Composable () -> Unit) {
+  setContent {
+    VibitsTheme(darkTheme = false) {
+      Surface(modifier = Modifier.fillMaxSize()) {
+        content()
+      }
+    }
+  }
+}
+
+@OptIn(ExperimentalTestApi::class)
+fun ComposeUiTest.saveScreenshot(
+  feature: String,
+  testClass: String,
+  scenario: String,
+) {
+  waitForIdle()
+  val roots = onAllNodes(isRoot())
+  val firstImage = roots[0].captureToImage().toAwtImage()
+  val composite = BufferedImage(firstImage.width, firstImage.height, BufferedImage.TYPE_INT_ARGB)
+  val g: Graphics2D = composite.createGraphics()
+  g.drawImage(firstImage, 0, 0, null)
+  val count = roots.fetchSemanticsNodes().size
+  for (i in 1 until count) {
+    val layerImage = roots[i].captureToImage().toAwtImage()
+    g.drawImage(layerImage, 0, 0, null)
+  }
+  g.dispose()
+  val dir = File("build/ui-screenshots/$feature/$testClass").also { it.mkdirs() }
+  ImageIO.write(composite, "png", File(dir, "$scenario.png"))
+}

--- a/feature/habits/presentation/build.gradle.kts
+++ b/feature/habits/presentation/build.gradle.kts
@@ -33,5 +33,10 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.platform.mode.AppMode
@@ -165,7 +166,7 @@ private fun StatsScreenContent(
 
   Column(
     verticalArrangement = Arrangement.spacedBy(Indent.s),
-    modifier = columnModifier,
+    modifier = columnModifier.testTag(StatsTestTags.STATS_SCREEN),
   ) {
     StatsHeaderRow()
     StatsHabitsEmptyState(derived, dispatch)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
@@ -4,6 +4,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -29,6 +31,7 @@ internal fun EmptyDeleteDialog(
   }
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.Editor.CancelDelete) },
+    modifier = Modifier.testTag(StatsTestTags.EMPTY_DELETE_DIALOG),
     title = { Text(stringResource(Res.string.title_delete_day)) },
     text = { Text(stringResource(Res.string.msg_delete_day_confirm)) },
     confirmButton = {
@@ -69,6 +72,7 @@ internal fun SingleHabitToggleDialog(
 
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.SingleToggle.CancelSingleHabitToggle) },
+    modifier = Modifier.testTag(StatsTestTags.SINGLE_TOGGLE_DIALOG),
     title = { Text(stringResource(titleRes)) },
     text = {
       Text(stringResource(messageRes, displayLabel, day.date.toString()))

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsTestTags.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsTestTags.kt
@@ -1,0 +1,9 @@
+package space.be1ski.vibits.feature.habits.presentation.view
+
+object StatsTestTags {
+  const val STATS_SCREEN = "stats_screen"
+  const val HABITS_CONFIG_DIALOG = "habits_config_dialog"
+  const val EDIT_CONFIG_WARNING_DIALOG = "habits_edit_config_warning_dialog"
+  const val EMPTY_DELETE_DIALOG = "habits_empty_delete_dialog"
+  const val SINGLE_TOGGLE_DIALOG = "habits_single_toggle_dialog"
+}

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
@@ -8,6 +8,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -18,6 +20,7 @@ import space.be1ski.vibits.core.strings.generated.title_edit_config_warning
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 
 @Composable
 fun EditConfigWarningDialog(
@@ -30,6 +33,7 @@ fun EditConfigWarningDialog(
 
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) },
+    modifier = Modifier.testTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG),
     title = {
       Text(
         text = stringResource(Res.string.title_edit_config_warning),

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitsConfigDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitsConfigDialog.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
@@ -49,6 +50,7 @@ import space.be1ski.vibits.feature.habits.domain.model.demoHabit
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 
 private val COLOR_CIRCLE_SIZE = 24.dp
 private val SELECTED_BORDER_WIDTH = 2.dp
@@ -65,6 +67,7 @@ fun HabitsConfigDialog(
 
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.Config.CloseConfigDialog) },
+    modifier = Modifier.testTag(StatsTestTags.HABITS_CONFIG_DIALOG),
     title = { Text(stringResource(Res.string.label_habits_config)) },
     text = { HabitsConfigDialogContent(habitsState, demoMode, dispatch) },
     confirmButton = {

--- a/feature/habits/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenshotTest.kt
+++ b/feature/habits/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenshotTest.kt
@@ -1,0 +1,214 @@
+package space.be1ski.vibits.feature.habits.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.Month
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
+import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.feature.habits.domain.model.HabitColor
+import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
+import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.view.components.EditConfigWarningDialog
+import space.be1ski.vibits.feature.habits.presentation.view.components.HabitsConfigDialog
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class StatsScreenshotTest {
+  private val testDateFormatter =
+    DateFormatter(
+      months = Month.entries.associateWith { it.name.lowercase().take(3) },
+      days = DayOfWeek.entries.associateWith { it.name.lowercase().take(3) },
+    )
+
+  private val testDate = LocalDate(2025, 1, 6)
+
+  private val exerciseConfig = HabitConfig(tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF4CAF50))
+  private val waterConfig = HabitConfig(tag = "#habits/water", label = "Water", color = HabitColor(0xFF2196F3))
+
+  @Test
+  fun `when no habits configured then captures empty stats`() =
+    runAppUiTest {
+      setThemedContent {
+        StatsScreen(
+          state =
+            StatsScreenState(
+              memos = emptyList(),
+              range = ActivityRange.Week(startDate = testDate),
+              activityMode = ActivityMode.HABITS,
+            ),
+          appMode = AppMode.DEMO,
+          dateFormatter = testDateFormatter,
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "stats_habits_empty")
+    }
+
+  @Test
+  fun `when habits data present then captures stats with data`() =
+    runAppUiTest {
+      setThemedContent {
+        StatsScreen(
+          state =
+            StatsScreenState(
+              memos = emptyList(),
+              range = ActivityRange.Week(startDate = testDate),
+              activityMode = ActivityMode.HABITS,
+            ),
+          appMode = AppMode.DEMO,
+          dateFormatter = testDateFormatter,
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "stats_habits_data")
+    }
+
+  @Test
+  fun `when posts mode then captures posts stats`() =
+    runAppUiTest {
+      setThemedContent {
+        StatsScreen(
+          state =
+            StatsScreenState(
+              memos = emptyList(),
+              range = ActivityRange.Week(startDate = testDate),
+              activityMode = ActivityMode.POSTS,
+            ),
+          appMode = AppMode.DEMO,
+          dateFormatter = testDateFormatter,
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "stats_posts_data")
+    }
+
+  @Test
+  fun `when config dialog open then captures habits config`() =
+    runAppUiTest {
+      setThemedContent {
+        HabitsConfigDialog(
+          habitsState =
+            HabitsState(
+              showConfigDialog = true,
+              editingHabits =
+                listOf(
+                  EditableHabit(id = "1", tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF4CAF50)),
+                  EditableHabit(id = "2", tag = "#habits/water", label = "Water", color = HabitColor(0xFF2196F3)),
+                ),
+            ),
+          dispatch = {},
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.HABITS_CONFIG_DIALOG).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "habits_config_dialog")
+    }
+
+  @Test
+  fun `when edit config warning shown then captures warning dialog`() =
+    runAppUiTest {
+      setThemedContent {
+        EditConfigWarningDialog(
+          habitsState = HabitsState(showEditConfigWarning = true),
+          dispatch = {},
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "habits_edit_warning_dialog")
+    }
+
+  @Test
+  fun `when delete confirm shown then captures delete dialog`() =
+    runAppUiTest {
+      val testDay =
+        ContributionDay(
+          date = testDate,
+          count = 2,
+          totalHabits = 2,
+          completionRatio = 1f,
+          habitStatuses =
+            listOf(
+              HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
+              HabitStatus(tag = "#habits/water", label = "Water", done = true),
+            ),
+          dailyMemo = null,
+          inRange = true,
+        )
+      setThemedContent {
+        StatsScreen(
+          state =
+            StatsScreenState(
+              memos = emptyList(),
+              range = ActivityRange.Week(startDate = testDate),
+              activityMode = ActivityMode.HABITS,
+            ),
+          appMode = AppMode.DEMO,
+          dateFormatter = testDateFormatter,
+          habitsState =
+            HabitsState(
+              showDeleteConfirm = true,
+              editorDay = testDay,
+            ),
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.EMPTY_DELETE_DIALOG).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "habit_delete_confirm_dialog")
+    }
+
+  @Test
+  fun `when single toggle confirm shown then captures toggle dialog`() =
+    runAppUiTest {
+      val testDay =
+        ContributionDay(
+          date = testDate,
+          count = 1,
+          totalHabits = 2,
+          completionRatio = 0.5f,
+          habitStatuses =
+            listOf(
+              HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
+              HabitStatus(tag = "#habits/water", label = "Water", done = false),
+            ),
+          dailyMemo = null,
+          inRange = true,
+        )
+      setThemedContent {
+        StatsScreen(
+          state =
+            StatsScreenState(
+              memos = emptyList(),
+              range = ActivityRange.Week(startDate = testDate),
+              activityMode = ActivityMode.HABITS,
+            ),
+          appMode = AppMode.DEMO,
+          dateFormatter = testDateFormatter,
+          habitsState =
+            HabitsState(
+              singleToggleDay = testDay,
+              singleToggleHabitTag = "#habits/water",
+              singleToggleHabitLabel = "Water",
+              singleToggleConfig = listOf(exerciseConfig, waterConfig),
+            ),
+        )
+      }
+
+      onNodeWithTag(StatsTestTags.SINGLE_TOGGLE_DIALOG).assertIsDisplayed()
+      saveScreenshot("habits", "StatsScreenshotTest", "single_habit_toggle_dialog")
+    }
+}

--- a/feature/homescreen/build.gradle.kts
+++ b/feature/homescreen/build.gradle.kts
@@ -63,6 +63,11 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
     androidMain {
       dependencies {
         implementation(libs.androidx.appcompat)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
@@ -131,7 +132,7 @@ private fun LoadingScreen() {
     color = MaterialTheme.colorScheme.background,
   ) {
     Box(
-      modifier = Modifier.fillMaxSize(),
+      modifier = Modifier.fillMaxSize().testTag(AppShellTestTags.LOADING_SCREEN),
       contentAlignment = Alignment.Center,
     ) {
       CircularProgressIndicator()

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
@@ -1,0 +1,10 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+object AppShellTestTags {
+  const val LOADING_SCREEN = "app_loading_screen"
+  const val BOTTOM_NAV_HABITS = "app_nav_habits"
+  const val BOTTOM_NAV_STATS = "app_nav_stats"
+  const val BOTTOM_NAV_FEED = "app_nav_feed"
+  const val FAB = "app_fab"
+  const val HABIT_EDITOR_DIALOG = "app_habit_editor_dialog"
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -57,6 +59,7 @@ private fun HabitEditorDialog(
   val demoMode = appState.isDemoMode
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.Editor.CloseEditor) },
+    modifier = Modifier.testTag(AppShellTestTags.HABIT_EDITOR_DIALOG),
     title = {
       val titleRes = if (habitsState.isEditing) Res.string.title_update_day else Res.string.title_create_day
       Text(stringResource(titleRes))

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.platform.isDesktop
@@ -130,60 +131,40 @@ internal fun MemosBottomNavigation(
   onClearSelection: () -> Unit,
   onFeedScrollToTop: () -> Unit,
 ) {
+  val onTabClick = { screen: Screen ->
+    onClearSelection()
+    if (appState.selectedScreen == screen) {
+      if (screen == Screen.FEED) {
+        onFeedScrollToTop()
+      } else {
+        onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
+      }
+    } else {
+      onAppAction(AppAction.Navigation.SelectScreen(screen))
+    }
+  }
+
   NavigationBar {
     NavigationBarItem(
       selected = appState.selectedScreen == Screen.HABITS,
-      onClick = {
-        onClearSelection()
-        if (appState.selectedScreen == Screen.HABITS) {
-          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
-        } else {
-          onAppAction(AppAction.Navigation.SelectScreen(Screen.HABITS))
-        }
-      },
-      icon = {
-        Icon(
-          imageVector = Icons.Filled.CheckCircle,
-          contentDescription = stringResource(Res.string.nav_habits),
-        )
-      },
+      onClick = { onTabClick(Screen.HABITS) },
+      icon = { Icon(Icons.Filled.CheckCircle, contentDescription = stringResource(Res.string.nav_habits)) },
       label = { Text(stringResource(Res.string.nav_habits)) },
+      modifier = Modifier.testTag(AppShellTestTags.BOTTOM_NAV_HABITS),
     )
     NavigationBarItem(
       selected = appState.selectedScreen == Screen.STATS,
-      onClick = {
-        onClearSelection()
-        if (appState.selectedScreen == Screen.STATS) {
-          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
-        } else {
-          onAppAction(AppAction.Navigation.SelectScreen(Screen.STATS))
-        }
-      },
-      icon = {
-        Icon(
-          imageVector = Icons.AutoMirrored.Filled.StickyNote2,
-          contentDescription = stringResource(Res.string.nav_memos),
-        )
-      },
+      onClick = { onTabClick(Screen.STATS) },
+      icon = { Icon(Icons.AutoMirrored.Filled.StickyNote2, contentDescription = stringResource(Res.string.nav_memos)) },
       label = { Text(stringResource(Res.string.nav_memos)) },
+      modifier = Modifier.testTag(AppShellTestTags.BOTTOM_NAV_STATS),
     )
     NavigationBarItem(
       selected = appState.selectedScreen == Screen.FEED,
-      onClick = {
-        onClearSelection()
-        if (appState.selectedScreen == Screen.FEED) {
-          onFeedScrollToTop()
-        } else {
-          onAppAction(AppAction.Navigation.SelectScreen(Screen.FEED))
-        }
-      },
-      icon = {
-        Icon(
-          imageVector = Icons.AutoMirrored.Filled.List,
-          contentDescription = stringResource(Res.string.nav_feed),
-        )
-      },
+      onClick = { onTabClick(Screen.FEED) },
+      icon = { Icon(Icons.AutoMirrored.Filled.List, contentDescription = stringResource(Res.string.nav_feed)) },
       label = { Text(stringResource(Res.string.nav_feed)) },
+      modifier = Modifier.testTag(AppShellTestTags.BOTTOM_NAV_FEED),
     )
   }
 }

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
@@ -1,0 +1,120 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.ui.test.ComposeUiTest
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.core.elm.test.RecordingFeature
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.memos.domain.model.ExportResult
+import space.be1ski.vibits.feature.memos.domain.repository.ExportService
+import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class AppShellScreenshotTest {
+  private val testDate = LocalDate(2025, 1, 6)
+
+  private val fakeExportService =
+    object : ExportService {
+      override fun exportLogs() = ExportResult.Success("/fake")
+
+      override fun exportMemos() = ExportResult.Success("/fake")
+    }
+
+  private fun createAppFeatures(
+    appState: AppState = AppState(appMode = AppMode.DEMO, periodStartDate = testDate),
+    memosState: MemosState = MemosState(initialDataLoaded = true),
+  ) = AppFeatures(
+    app = RecordingFeature(appState),
+    memos = RecordingFeature(memosState),
+    habits = RecordingFeature(HabitsState()),
+    settings = RecordingFeature(SettingsState()),
+  )
+
+  @OptIn(ExperimentalTestApi::class)
+  private fun ComposeUiTest.setVibitsApp(selectedScreen: Screen) {
+    val features =
+      createAppFeatures(
+        appState =
+          AppState(
+            appMode = AppMode.DEMO,
+            selectedScreen = selectedScreen,
+            periodStartDate = testDate,
+            autoLoaded = true,
+          ),
+      )
+    setContent {
+      VibitsApp(
+        features = features,
+        currentTheme = AppTheme.SYSTEM,
+        currentLanguage = AppLanguage.ENGLISH,
+        exportService = fakeExportService,
+      )
+    }
+  }
+
+  @Test
+  fun `when app is loading then captures loading screen`() =
+    runAppUiTest {
+      val features = createAppFeatures(memosState = MemosState(initialDataLoaded = false))
+      setThemedContent {
+        AppContent(
+          appMode = AppMode.DEMO,
+          showOnboarding = false,
+          featuresState =
+            FeaturesState(
+              modeSelection = RecordingFeature(ModeSelectionState()),
+              onboarding = RecordingFeature(OnboardingState()),
+              app = features,
+            ),
+          appTheme = AppTheme.SYSTEM,
+          appLanguage = AppLanguage.ENGLISH,
+          exportService = fakeExportService,
+          onResetApp = {},
+          onThemeChanged = {},
+          onLanguageChanged = {},
+        )
+      }
+
+      onNodeWithTag(AppShellTestTags.LOADING_SCREEN).assertIsDisplayed()
+      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_loading")
+    }
+
+  @Test
+  fun `when habits tab selected then captures habits screen`() =
+    runAppUiTest {
+      setVibitsApp(Screen.HABITS)
+      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
+      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_habits_tab")
+    }
+
+  @Test
+  fun `when stats tab selected then captures stats screen`() =
+    runAppUiTest {
+      setVibitsApp(Screen.STATS)
+      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_STATS).assertIsDisplayed()
+      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_stats_tab")
+    }
+
+  @Test
+  fun `when feed tab selected then captures feed screen`() =
+    runAppUiTest {
+      setVibitsApp(Screen.FEED)
+      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_FEED).assertIsDisplayed()
+      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_feed_tab")
+    }
+}

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitEditorScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitEditorScreenshotTest.kt
@@ -1,0 +1,59 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.feature.habits.domain.model.HabitColor
+import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class HabitEditorScreenshotTest {
+  private val testDate = LocalDate(2025, 1, 6)
+
+  @Test
+  fun `when editor open then captures habit editor dialog`() =
+    runAppUiTest {
+      val editorDay =
+        ContributionDay(
+          date = testDate,
+          count = 0,
+          totalHabits = 2,
+          completionRatio = 0f,
+          habitStatuses = emptyList(),
+          dailyMemo = null,
+          inRange = true,
+        )
+      setThemedContent {
+        HabitsDialogs(
+          appState = AppState(appMode = AppMode.DEMO, periodStartDate = testDate),
+          habitsState =
+            HabitsState(
+              editorDay = editorDay,
+              editorConfig =
+                listOf(
+                  HabitConfig(tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF4CAF50)),
+                  HabitConfig(tag = "#habits/water", label = "Water", color = HabitColor(0xFF2196F3)),
+                ),
+              editorSelections =
+                mapOf(
+                  "#habits/exercise" to true,
+                  "#habits/water" to false,
+                ),
+            ),
+          dispatch = {},
+        )
+      }
+
+      onNodeWithTag(AppShellTestTags.HABIT_EDITOR_DIALOG).assertIsDisplayed()
+      saveScreenshot("habits", "HabitEditorScreenshotTest", "habit_editor_dialog")
+    }
+}

--- a/feature/memos/presentation/build.gradle.kts
+++ b/feature/memos/presentation/build.gradle.kts
@@ -37,5 +37,10 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
   }
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import kotlinx.datetime.TimeZone
 import kotlinx.datetime.toLocalDateTime
@@ -85,7 +86,7 @@ fun FeedScreen(
 
   val filteredMemos = FilterMemosByTypeUseCase(memos, activeFilter)
 
-  Column(modifier = Modifier.fillMaxSize()) {
+  Column(modifier = Modifier.fillMaxSize().testTag(FeedTestTags.FEED_SCREEN)) {
     Column(modifier = Modifier.padding(horizontal = Indent.s, vertical = Indent.s)) {
       SegmentedSelector(
         label = stringResource(Res.string.label_post_filter),

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedTestTags.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedTestTags.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.memos.presentation.view
+
+object FeedTestTags {
+  const val FEED_SCREEN = "feed_screen"
+  const val SYNC_CONFLICT_DIALOG = "sync_conflict_dialog"
+  const val SYNC_LOG_DIALOG = "sync_log_dialog"
+}

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -34,6 +35,7 @@ fun SyncConflictDialog(
 ) {
   AlertDialog(
     onDismissRequest = onDismiss,
+    modifier = Modifier.testTag(FeedTestTags.SYNC_CONFLICT_DIALOG),
     title = {
       Text(
         text = stringResource(Res.string.title_sync_conflict),

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
@@ -8,6 +8,8 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_clear
@@ -29,6 +31,7 @@ fun SyncLogDialog(onDismiss: () -> Unit) {
 
   AlertDialog(
     onDismissRequest = onDismiss,
+    modifier = Modifier.testTag(FeedTestTags.SYNC_LOG_DIALOG),
     title = { Text(stringResource(Res.string.title_sync_logs, syncLogs.size)) },
     text = {
       LogViewer(

--- a/feature/memos/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreenshotTest.kt
+++ b/feature/memos/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreenshotTest.kt
@@ -1,0 +1,111 @@
+package space.be1ski.vibits.feature.memos.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.Month
+import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.memos.domain.model.Memo
+import space.be1ski.vibits.feature.memos.domain.model.PostFilter
+import kotlin.test.Test
+import kotlin.time.Duration.Companion.hours
+
+@OptIn(ExperimentalTestApi::class)
+class FeedScreenshotTest {
+  private val testDateFormatter =
+    DateFormatter(
+      months = Month.entries.associateWith { it.name.lowercase().take(3) },
+      days = DayOfWeek.entries.associateWith { it.name.lowercase().take(3) },
+    )
+
+  private val baseInstant = kotlin.time.Instant.fromEpochMilliseconds(1_704_067_200_000) // 2024-01-01T00:00:00Z
+
+  private val testMemos =
+    listOf(
+      Memo(
+        name = "memos/1",
+        content = "#habits/config\n\nExercise | #habits/exercise | #4CAF50\nWater | #habits/water | #2196F3",
+        createTime = baseInstant,
+      ),
+      Memo(name = "memos/2", content = "#habits/daily 2024-01-01\n\n#habits/exercise\n#habits/water", createTime = baseInstant + 1.hours),
+      Memo(name = "memos/3", content = "Today was a good day!", createTime = baseInstant + 2.hours),
+      Memo(name = "memos/4", content = "Remember to buy groceries", createTime = baseInstant + 3.hours),
+    )
+
+  @Test
+  fun `when feed has memos then captures default feed`() =
+    runAppUiTest {
+      setThemedContent {
+        FeedScreen(
+          memos = testMemos,
+          dateFormatter = testDateFormatter,
+          enablePullRefresh = false,
+        )
+      }
+
+      onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
+      saveScreenshot("memos", "FeedScreenshotTest", "feed_default")
+    }
+
+  @Test
+  fun `when feed is empty then captures empty state`() =
+    runAppUiTest {
+      setThemedContent {
+        FeedScreen(
+          memos = emptyList(),
+          dateFormatter = testDateFormatter,
+          enablePullRefresh = false,
+        )
+      }
+
+      onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
+      saveScreenshot("memos", "FeedScreenshotTest", "feed_empty")
+    }
+
+  @Test
+  fun `when filtered to config then captures config filter`() =
+    runAppUiTest {
+      setThemedContent {
+        FeedScreen(
+          memos = testMemos,
+          dateFormatter = testDateFormatter,
+          activeFilter = PostFilter.CONFIG,
+          enablePullRefresh = false,
+        )
+      }
+
+      onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
+      saveScreenshot("memos", "FeedScreenshotTest", "feed_filtered_config")
+    }
+
+  @Test
+  fun `when sync conflict dialog shown then captures dialog`() =
+    runAppUiTest {
+      setThemedContent {
+        SyncConflictDialog(
+          conflictCount = 3,
+          onKeepLocal = {},
+          onKeepServer = {},
+          onDismiss = {},
+        )
+      }
+
+      onNodeWithTag(FeedTestTags.SYNC_CONFLICT_DIALOG).assertIsDisplayed()
+      saveScreenshot("memos", "FeedScreenshotTest", "sync_conflict_dialog")
+    }
+
+  @Test
+  fun `when sync log dialog shown then captures dialog`() =
+    runAppUiTest {
+      setThemedContent {
+        SyncLogDialog(onDismiss = {})
+      }
+
+      onNodeWithTag(FeedTestTags.SYNC_LOG_DIALOG).assertIsDisplayed()
+      saveScreenshot("memos", "FeedScreenshotTest", "sync_log_dialog")
+    }
+}

--- a/feature/mode/presentation/build.gradle.kts
+++ b/feature/mode/presentation/build.gradle.kts
@@ -33,5 +33,10 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
   }
 }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.elm.Feature
@@ -81,6 +82,8 @@ fun ModeSelectionScreen(
       description = stringResource(Res.string.mode_online_desc),
       isPrimary = true,
       onClick = { dispatch(ModeSelectionAction.Dialog.Show) },
+      modifier = Modifier.testTag(ModeSelectionTestTags.ONLINE_CARD),
+      buttonTag = ModeSelectionTestTags.ONLINE_BUTTON,
     )
 
     Spacer(modifier = Modifier.height(Indent.m))
@@ -90,6 +93,8 @@ fun ModeSelectionScreen(
       description = stringResource(Res.string.mode_offline_desc),
       isPrimary = false,
       onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.OFFLINE)) },
+      modifier = Modifier.testTag(ModeSelectionTestTags.OFFLINE_CARD),
+      buttonTag = ModeSelectionTestTags.OFFLINE_BUTTON,
     )
 
     Spacer(modifier = Modifier.height(Indent.m))
@@ -99,21 +104,24 @@ fun ModeSelectionScreen(
       description = stringResource(Res.string.mode_demo_desc),
       isPrimary = false,
       onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO)) },
+      modifier = Modifier.testTag(ModeSelectionTestTags.DEMO_CARD),
+      buttonTag = ModeSelectionTestTags.DEMO_BUTTON,
     )
   }
 
+  ModeSelectionDialogs(state = state, dispatch = dispatch)
+}
+
+@Composable
+private fun ModeSelectionDialogs(
+  state: ModeSelectionState,
+  dispatch: (ModeSelectionAction) -> Unit,
+) {
   if (state.showQuickOnlineDialog) {
-    QuickOnlineDialog(
-      state = state,
-      dispatch = dispatch,
-    )
+    QuickOnlineDialog(state = state, dispatch = dispatch)
   }
-
   if (state.showCredentialsDialog) {
-    CredentialsSetupDialog(
-      state = state,
-      dispatch = dispatch,
-    )
+    CredentialsSetupDialog(state = state, dispatch = dispatch)
   }
 }
 
@@ -124,6 +132,7 @@ private fun QuickOnlineDialog(
 ) {
   AlertDialog(
     onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.QuickOnline.Dismiss) },
+    modifier = Modifier.testTag(ModeSelectionTestTags.QUICK_ONLINE_DIALOG),
     title = { Text(stringResource(Res.string.mode_quick_online_title)) },
     text = { Text(stringResource(Res.string.mode_quick_online_desc)) },
     confirmButton = {
@@ -160,6 +169,7 @@ private fun CredentialsSetupDialog(
 ) {
   AlertDialog(
     onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.Dialog.Dismiss) },
+    modifier = Modifier.testTag(ModeSelectionTestTags.CREDENTIALS_DIALOG),
     title = { Text(stringResource(Res.string.mode_online_title)) },
     text = {
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
@@ -212,9 +222,11 @@ private fun ModeCard(
   description: String,
   isPrimary: Boolean,
   onClick: () -> Unit,
+  modifier: Modifier = Modifier,
+  buttonTag: String? = null,
 ) {
   OutlinedCard(
-    modifier = Modifier.fillMaxWidth(),
+    modifier = modifier.fillMaxWidth(),
   ) {
     Column(
       modifier = Modifier.padding(Indent.m),
@@ -229,17 +241,23 @@ private fun ModeCard(
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
+      val buttonModifier =
+        if (buttonTag != null) {
+          Modifier.fillMaxWidth().testTag(buttonTag)
+        } else {
+          Modifier.fillMaxWidth()
+        }
       if (isPrimary) {
         Button(
           onClick = onClick,
-          modifier = Modifier.fillMaxWidth(),
+          modifier = buttonModifier,
         ) {
           Text(title)
         }
       } else {
         OutlinedButton(
           onClick = onClick,
-          modifier = Modifier.fillMaxWidth(),
+          modifier = buttonModifier,
         ) {
           Text(title)
         }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionTestTags.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionTestTags.kt
@@ -1,0 +1,12 @@
+package space.be1ski.vibits.feature.mode.presentation.view
+
+object ModeSelectionTestTags {
+  const val ONLINE_CARD = "mode_online_card"
+  const val OFFLINE_CARD = "mode_offline_card"
+  const val DEMO_CARD = "mode_demo_card"
+  const val ONLINE_BUTTON = "mode_online_button"
+  const val OFFLINE_BUTTON = "mode_offline_button"
+  const val DEMO_BUTTON = "mode_demo_button"
+  const val QUICK_ONLINE_DIALOG = "mode_quick_online_dialog"
+  const val CREDENTIALS_DIALOG = "mode_credentials_dialog"
+}

--- a/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
+++ b/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
@@ -1,0 +1,68 @@
+package space.be1ski.vibits.feature.mode.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import space.be1ski.vibits.core.elm.test.RecordingFeature
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class ModeSelectionScreenshotTest {
+  private fun createFeature(state: ModeSelectionState = ModeSelectionState()) =
+    RecordingFeature<
+      ModeSelectionAction,
+      ModeSelectionState,
+      ModeSelectionEffect.Command,
+      ModeSelectionEffect.Notification,
+    >(state)
+
+  @Test
+  fun `when default state then captures mode selection screen`() =
+    runAppUiTest {
+      setThemedContent { ModeSelectionScreen(createFeature()) }
+
+      onNodeWithTag(ModeSelectionTestTags.ONLINE_CARD).assertIsDisplayed()
+      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_default")
+    }
+
+  @Test
+  fun `when quick online dialog shown then captures dialog`() =
+    runAppUiTest {
+      setThemedContent { ModeSelectionScreen(createFeature(ModeSelectionState(showQuickOnlineDialog = true))) }
+
+      onNodeWithTag(ModeSelectionTestTags.QUICK_ONLINE_DIALOG).assertIsDisplayed()
+      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_quick_online_dialog")
+    }
+
+  @Test
+  fun `when credentials dialog shown then captures dialog`() =
+    runAppUiTest {
+      setThemedContent { ModeSelectionScreen(createFeature(ModeSelectionState(showCredentialsDialog = true))) }
+
+      onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
+      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_credentials_dialog")
+    }
+
+  @Test
+  fun `when credentials dialog has error then captures error state`() =
+    runAppUiTest {
+      val feature =
+        createFeature(
+          ModeSelectionState(
+            showCredentialsDialog = true,
+            error = CredentialValidationError.CONNECTION_FAILED,
+          ),
+        )
+      setThemedContent { ModeSelectionScreen(feature) }
+
+      onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
+      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_credentials_error")
+    }
+}

--- a/feature/onboarding/presentation/build.gradle.kts
+++ b/feature/onboarding/presentation/build.gradle.kts
@@ -35,5 +35,10 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
   }
 }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
@@ -35,6 +35,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
@@ -69,13 +70,14 @@ fun ChoosePresetScreen(
   Column(
     modifier =
       modifier
+        .testTag(OnboardingTestTags.CHOOSE_PRESET_SCREEN)
         .padding(Indent.xl),
   ) {
     Row(
       verticalAlignment = Alignment.CenterVertically,
       modifier = Modifier.fillMaxWidth(),
     ) {
-      IconButton(onClick = onBack) {
+      IconButton(onClick = onBack, modifier = Modifier.testTag(OnboardingTestTags.CHOOSE_PRESET_BACK_BUTTON)) {
         Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.action_back), tint = textColor)
       }
       Text(
@@ -109,7 +111,7 @@ fun ChoosePresetScreen(
     Button(
       onClick = onContinue,
       enabled = selectedPresetId != null,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.CHOOSE_PRESET_CONTINUE_BUTTON),
     ) {
       Text(stringResource(Res.string.action_continue))
     }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/HabitSetupScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/HabitSetupScreen.kt
@@ -32,6 +32,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.luminance
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
@@ -89,6 +90,7 @@ fun HabitSetupScreen(
   Column(
     modifier =
       modifier
+        .testTag(OnboardingTestTags.HABIT_SETUP_SCREEN)
         .padding(Indent.xl),
     verticalArrangement = Arrangement.spacedBy(Indent.m),
   ) {
@@ -126,7 +128,7 @@ fun HabitSetupScreen(
         errorMessage?.let {
           { Text(it, color = AppColors.errorColor.resolve()) }
         },
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.HABIT_SETUP_NAME_FIELD),
     )
 
     Text(
@@ -154,7 +156,7 @@ fun HabitSetupScreen(
     Button(
       onClick = onCreate,
       enabled = !isCreating && habitName.isNotBlank(),
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.HABIT_SETUP_CREATE_BUTTON),
     ) {
       if (isCreating) {
         CircularProgressIndicator(

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingTestTags.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingTestTags.kt
@@ -1,0 +1,16 @@
+package space.be1ski.vibits.feature.onboarding.presentation.view
+
+object OnboardingTestTags {
+  const val WELCOME_SCREEN = "onboarding_welcome_screen"
+  const val WELCOME_CONTINUE_BUTTON = "onboarding_welcome_continue"
+  const val WELCOME_SKIP_BUTTON = "onboarding_welcome_skip"
+  const val CHOOSE_PRESET_SCREEN = "onboarding_choose_preset_screen"
+  const val CHOOSE_PRESET_BACK_BUTTON = "onboarding_choose_preset_back"
+  const val CHOOSE_PRESET_CONTINUE_BUTTON = "onboarding_choose_preset_continue"
+  const val HABIT_SETUP_SCREEN = "onboarding_habit_setup_screen"
+  const val HABIT_SETUP_NAME_FIELD = "onboarding_habit_setup_name"
+  const val HABIT_SETUP_CREATE_BUTTON = "onboarding_habit_setup_create"
+  const val SUCCESS_SCREEN = "onboarding_success_screen"
+  const val SUCCESS_CHECKIN_BUTTON = "onboarding_success_checkin"
+  const val SUCCESS_DASHBOARD_BUTTON = "onboarding_success_dashboard"
+}

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/SuccessScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/SuccessScreen.kt
@@ -1,4 +1,5 @@
 package space.be1ski.vibits.feature.onboarding.presentation.view
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -16,6 +17,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
@@ -38,6 +40,7 @@ fun SuccessScreen(
   Column(
     modifier =
       modifier
+        .testTag(OnboardingTestTags.SUCCESS_SCREEN)
         .padding(Indent.xl),
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
@@ -71,7 +74,7 @@ fun SuccessScreen(
 
     Button(
       onClick = onMarkFirstCheckIn,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.SUCCESS_CHECKIN_BUTTON),
     ) {
       Text(stringResource(Res.string.action_mark_first_checkin))
     }
@@ -80,7 +83,7 @@ fun SuccessScreen(
 
     TextButton(
       onClick = onGoToDashboard,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.SUCCESS_DASHBOARD_BUTTON),
     ) {
       Text(stringResource(Res.string.action_go_to_dashboard))
     }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/WelcomeScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/WelcomeScreen.kt
@@ -1,4 +1,5 @@
 package space.be1ski.vibits.feature.onboarding.presentation.view
+
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
@@ -12,6 +13,7 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_create_first_habit
@@ -32,6 +34,7 @@ fun WelcomeScreen(
   Column(
     modifier =
       modifier
+        .testTag(OnboardingTestTags.WELCOME_SCREEN)
         .padding(Indent.xl),
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
@@ -54,7 +57,7 @@ fun WelcomeScreen(
 
     Button(
       onClick = onContinue,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.WELCOME_CONTINUE_BUTTON),
     ) {
       Text(stringResource(Res.string.action_create_first_habit))
     }
@@ -63,7 +66,7 @@ fun WelcomeScreen(
 
     TextButton(
       onClick = onSkip,
-      modifier = Modifier.fillMaxWidth(),
+      modifier = Modifier.fillMaxWidth().testTag(OnboardingTestTags.WELCOME_SKIP_BUTTON),
     ) {
       Text(stringResource(Res.string.action_maybe_later))
     }

--- a/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
+++ b/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
@@ -1,0 +1,106 @@
+package space.be1ski.vibits.feature.onboarding.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.core.utils.habits.DemoHabit
+import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
+import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
+import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingStep
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class OnboardingScreenshotTest {
+  private val testPresets = DemoHabit.entries.map { HabitPreset(it) } + HabitPreset(null)
+
+  @Test
+  fun `when welcome step then captures welcome screen`() =
+    runAppUiTest {
+      setThemedContent {
+        OnboardingScreen(
+          state = OnboardingState(currentStep = OnboardingStep.Welcome),
+          onAction = {},
+        )
+      }
+
+      onNodeWithTag(OnboardingTestTags.WELCOME_SCREEN).assertIsDisplayed()
+      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_welcome")
+    }
+
+  @Test
+  fun `when choose preset step then captures preset selection screen`() =
+    runAppUiTest {
+      setThemedContent {
+        OnboardingScreen(
+          state =
+            OnboardingState(
+              currentStep = OnboardingStep.ChoosePreset,
+              presets = testPresets,
+              selectedPresetId = "exercise",
+            ),
+          onAction = {},
+        )
+      }
+
+      onNodeWithTag(OnboardingTestTags.CHOOSE_PRESET_SCREEN).assertIsDisplayed()
+      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_choose_preset")
+    }
+
+  @Test
+  fun `when habit setup step then captures habit setup screen`() =
+    runAppUiTest {
+      setThemedContent {
+        OnboardingScreen(
+          state =
+            OnboardingState(
+              currentStep = OnboardingStep.HabitSetup,
+              presets = testPresets,
+              selectedPresetId = "exercise",
+              habitName = "Exercise",
+            ),
+          onAction = {},
+        )
+      }
+
+      onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
+      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_habit_setup")
+    }
+
+  @Test
+  fun `when habit setup has error then captures error state`() =
+    runAppUiTest {
+      setThemedContent {
+        OnboardingScreen(
+          state =
+            OnboardingState(
+              currentStep = OnboardingStep.HabitSetup,
+              presets = testPresets,
+              selectedPresetId = "exercise",
+              habitName = "",
+              creationError = "habit_name_required",
+            ),
+          onAction = {},
+        )
+      }
+
+      onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
+      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_habit_setup_error")
+    }
+
+  @Test
+  fun `when success step then captures success screen`() =
+    runAppUiTest {
+      setThemedContent {
+        OnboardingScreen(
+          state = OnboardingState(currentStep = OnboardingStep.Success),
+          onAction = {},
+        )
+      }
+
+      onNodeWithTag(OnboardingTestTags.SUCCESS_SCREEN).assertIsDisplayed()
+      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_success")
+    }
+}

--- a/feature/settings/presentation/build.gradle.kts
+++ b/feature/settings/presentation/build.gradle.kts
@@ -38,5 +38,10 @@ kotlin {
         implementation(libs.kotlinx.coroutines.test)
       }
     }
+    val desktopTest by getting {
+      dependencies {
+        implementation(projects.core.ui.testing)
+      }
+    }
   }
 }

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -38,6 +38,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.SpanStyle
 import androidx.compose.ui.text.buildAnnotatedString
@@ -130,6 +131,7 @@ fun SettingsDialog(
   }
   AlertDialog(
     onDismissRequest = { dispatch(SettingsAction.Dialog.Dismiss) },
+    modifier = Modifier.testTag(SettingsTestTags.SETTINGS_DIALOG),
     title = { Text(stringResource(Res.string.nav_settings)) },
     text = {
       SettingsDialogBody(state = state, dispatch = dispatch, exportService = exportService)
@@ -558,6 +560,7 @@ private fun ResetOptionsDialog(
 ) {
   AlertDialog(
     onDismissRequest = onDismiss,
+    modifier = Modifier.testTag(SettingsTestTags.RESET_OPTIONS_DIALOG),
     title = { Text(stringResource(Res.string.action_reset_app)) },
     text = {
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
@@ -622,6 +625,7 @@ private fun LogsDialog(onDismiss: () -> Unit) {
 
   AlertDialog(
     onDismissRequest = onDismiss,
+    modifier = Modifier.testTag(SettingsTestTags.LOGS_DIALOG),
     title = { Text(stringResource(Res.string.title_logs, logs.size)) },
     text = {
       LogViewer(

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsTestTags.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsTestTags.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.settings.presentation.view
+
+object SettingsTestTags {
+  const val SETTINGS_DIALOG = "settings_dialog"
+  const val LOGS_DIALOG = "settings_logs_dialog"
+  const val RESET_OPTIONS_DIALOG = "settings_reset_options_dialog"
+}

--- a/feature/settings/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsScreenshotTest.kt
+++ b/feature/settings/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsScreenshotTest.kt
@@ -1,0 +1,126 @@
+package space.be1ski.vibits.feature.settings.presentation.view
+
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onNodeWithTag
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
+import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.saveScreenshot
+import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.memos.domain.model.ExportResult
+import space.be1ski.vibits.feature.memos.domain.repository.ExportService
+import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
+import kotlin.test.Test
+
+@OptIn(ExperimentalTestApi::class)
+class SettingsScreenshotTest {
+  private val fakeExportService =
+    object : ExportService {
+      override fun exportLogs() = ExportResult.Success("/fake")
+
+      override fun exportMemos() = ExportResult.Success("/fake")
+    }
+
+  @Test
+  fun `when online mode then captures online settings`() =
+    runAppUiTest {
+      setThemedContent {
+        SettingsDialog(
+          state =
+            SettingsState(
+              isOpen = true,
+              appMode = AppMode.ONLINE,
+              editBaseUrl = "https://memos.example.com",
+              editToken = "test-token-123",
+            ),
+          dispatch = {},
+          exportService = fakeExportService,
+        )
+      }
+
+      onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
+      saveScreenshot("settings", "SettingsScreenshotTest", "settings_online")
+    }
+
+  @Test
+  fun `when offline mode then captures offline settings`() =
+    runAppUiTest {
+      setThemedContent {
+        SettingsDialog(
+          state =
+            SettingsState(
+              isOpen = true,
+              appMode = AppMode.OFFLINE,
+            ),
+          dispatch = {},
+          exportService = fakeExportService,
+        )
+      }
+
+      onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
+      saveScreenshot("settings", "SettingsScreenshotTest", "settings_offline")
+    }
+
+  @Test
+  fun `when validation error then captures error state`() =
+    runAppUiTest {
+      setThemedContent {
+        SettingsDialog(
+          state =
+            SettingsState(
+              isOpen = true,
+              appMode = AppMode.ONLINE,
+              editBaseUrl = "https://memos.example.com",
+              editToken = "",
+              validationError = CredentialValidationError.CONNECTION_FAILED,
+            ),
+          dispatch = {},
+          exportService = fakeExportService,
+        )
+      }
+
+      onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
+      saveScreenshot("settings", "SettingsScreenshotTest", "settings_validation_error")
+    }
+
+  @Test
+  fun `when logs dialog open then captures logs dialog`() =
+    runAppUiTest {
+      setThemedContent {
+        SettingsDialog(
+          state =
+            SettingsState(
+              isOpen = true,
+              appMode = AppMode.DEMO,
+              showLogsDialog = true,
+            ),
+          dispatch = {},
+          exportService = fakeExportService,
+        )
+      }
+
+      onNodeWithTag(SettingsTestTags.LOGS_DIALOG).assertIsDisplayed()
+      saveScreenshot("settings", "SettingsScreenshotTest", "settings_logs_dialog")
+    }
+
+  @Test
+  fun `when reset confirmation open then captures reset options dialog`() =
+    runAppUiTest {
+      setThemedContent {
+        SettingsDialog(
+          state =
+            SettingsState(
+              isOpen = true,
+              appMode = AppMode.DEMO,
+              showResetConfirmation = true,
+            ),
+          dispatch = {},
+          exportService = fakeExportService,
+        )
+      }
+
+      onNodeWithTag(SettingsTestTags.RESET_OPTIONS_DIALOG).assertIsDisplayed()
+      saveScreenshot("settings", "SettingsScreenshotTest", "settings_reset_options_dialog")
+    }
+}

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -38,6 +38,7 @@ include(
   ":core:platform:testing",
   ":core:strings",
   ":core:ui",
+  ":core:ui:testing",
   ":core:utils",
 
   ":feature:auth:domain",


### PR DESCRIPTION
## Summary
Add desktop screenshot tests across all 6 features (31 screenshots total), with shared test infrastructure.

## Changes
- **New** `core/ui/testing` — `ScreenshotCapture` utility for capturing composables to PNG
- **New** `core/elm/test/RecordingFeature` — test fake for TEA features
- **New** `*TestTags.kt` files — semantic test tags for each feature's composables
- **New** `*ScreenshotTest.kt` files — screenshot tests for habits, homescreen, memos, mode, onboarding, settings
- **Updated** view files — added `testTag` modifiers to composables
- **Updated** `vibits.kmp.compose.gradle.kts` — added `compose.uiTest` dependency for desktop tests
- **Updated** feature `build.gradle.kts` files — added `core:ui:testing` test dependency

## Test plan
- [x] `./gradlew screenshotTests` passes, 31 PNGs generated
- [x] `./gradlew checkJvm` passes