### PR TITLE
Fix CI permissions and replace deprecated compose.uiTest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   check-jvm:
     runs-on: ubuntu-latest

--- a/build-logic/convention/src/main/kotlin/vibits.kmp.compose.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.compose.gradle.kts
@@ -4,12 +4,13 @@ plugins {
   id("org.jetbrains.kotlin.plugin.compose")
 }
 
-@OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
+val libs = the<VersionCatalogsExtension>().named("libs")
+
 kotlin {
   sourceSets {
     val desktopTest by getting {
       dependencies {
-        implementation(compose.uiTest)
+        implementation(libs.findLibrary("compose-ui-test").get())
         implementation(compose.desktop.currentOs)
       }
     }

--- a/core/ui/testing/build.gradle.kts
+++ b/core/ui/testing/build.gradle.kts
@@ -4,10 +4,9 @@ plugins {
 
 kotlin {
   sourceSets {
-    @OptIn(org.jetbrains.compose.ExperimentalComposeLibrary::class)
     val desktopMain by getting {
       dependencies {
-        api(compose.uiTest)
+        api(libs.compose.ui.test)
         api(projects.core.ui)
         implementation(libs.compose.foundation)
         implementation(libs.compose.material3)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -51,6 +51,7 @@ compose-multiplatform-plugin = { group = "org.jetbrains.compose", name = "compos
 compose-resources = { group = "org.jetbrains.compose.components", name = "components-resources", version.ref = "composeMultiplatform" }
 compose-runtime = { group = "org.jetbrains.compose.runtime", name = "runtime", version.ref = "composeMultiplatform" }
 compose-ui = { group = "org.jetbrains.compose.ui", name = "ui", version.ref = "composeMultiplatform" }
+compose-ui-test = { group = "org.jetbrains.compose.ui", name = "ui-test", version.ref = "composeMultiplatform" }
 detekt-plugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 kotlin-compose-plugin = { group = "org.jetbrains.kotlin", name = "compose-compiler-gradle-plugin", version.ref = "kotlin" }
 kotlin-gradle-plugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary
- Add `pull-requests: write` permission so the screenshot comment bot can post comments
- Replace deprecated `compose.uiTest` with `libs.compose.ui.test` from version catalog

## Changes
- **ci.yml** — add `permissions: pull-requests: write`
- **vibits.kmp.compose.gradle.kts** — replace `@OptIn(ExperimentalComposeLibrary)` + `compose.uiTest` with version catalog lookup
- **core/ui/testing/build.gradle.kts** — same replacement
- **libs.versions.toml** — add `compose-ui-test` entry

## Test plan
- [x] `./gradlew checkJvm` passes locally
- [ ] CI screenshot comment appears on this PR