### PR TITLE
Improve screenshot tests with rich demo data

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,11 +52,7 @@ jobs:
         if: always()
         run: |
           mkdir -p build/ui-screenshots
-          find . -path "*/build/ui-screenshots/*" -name "*.png" | while read -r f; do
-            rel=$(echo "$f" | sed 's|.*/build/ui-screenshots/||')
-            mkdir -p "build/ui-screenshots/$(dirname "$rel")"
-            cp "$f" "build/ui-screenshots/$rel"
-          done
+          find . -path "*/build/ui-screenshots/*.png" -not -path "./build/*" -exec cp {} build/ui-screenshots/ \;
 
       - name: Visual regression test
         if: always()

--- a/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
@@ -15,7 +15,9 @@ tasks.register("screenshotTests") {
     rootProject.subprojects.forEach { sub ->
       val screenshotsDir = sub.layout.buildDirectory.dir("ui-screenshots").get().asFile
       if (screenshotsDir.exists()) {
-        screenshotsDir.copyRecursively(outputDir, overwrite = true)
+        screenshotsDir.walkTopDown().filter { it.isFile && it.extension == "png" }.forEach { file ->
+          file.copyTo(File(outputDir, file.name), overwrite = true)
+        }
       }
     }
   }

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -36,11 +36,7 @@ fun ComposeUiTest.setThemedContent(content: @Composable () -> Unit) {
 }
 
 @OptIn(ExperimentalTestApi::class)
-fun ComposeUiTest.saveScreenshot(
-  feature: String,
-  testClass: String,
-  scenario: String,
-) {
+fun ComposeUiTest.saveScreenshot(scenario: String) {
   waitForIdle()
   val roots = onAllNodes(isRoot())
   val firstImage = roots[0].captureToImage().toAwtImage()
@@ -53,6 +49,6 @@ fun ComposeUiTest.saveScreenshot(
     g.drawImage(layerImage, 0, 0, null)
   }
   g.dispose()
-  val dir = File("build/ui-screenshots/$feature/$testClass").also { it.mkdirs() }
+  val dir = File("build/ui-screenshots").also { it.mkdirs() }
   ImageIO.write(composite, "png", File(dir, "$scenario.png"))
 }

--- a/feature/habits/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenshotTest.kt
+++ b/feature/habits/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenshotTest.kt
@@ -1,29 +1,47 @@
 package space.be1ski.vibits.feature.habits.presentation.view
 
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.Month
+import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.core.ui.test.runAppUiTest
 import space.be1ski.vibits.core.ui.test.saveScreenshot
 import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.feature.habits.domain.formatHexColor
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
+import space.be1ski.vibits.feature.habits.domain.usecase.BuildActivityDataUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.BuildDayDataUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.CalculateSuccessRateUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.ExtractDailyMemosUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
+import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.view.components.EditConfigWarningDialog
 import space.be1ski.vibits.feature.habits.presentation.view.components.HabitsConfigDialog
+import space.be1ski.vibits.feature.memos.domain.model.Memo
+import space.be1ski.vibits.feature.memos.domain.model.PostTags
+import kotlin.random.Random
 import kotlin.test.Test
+import kotlin.time.Instant
 
 @OptIn(ExperimentalTestApi::class)
+@Suppress("LargeClass")
 class StatsScreenshotTest {
   private val testDateFormatter =
     DateFormatter(
@@ -31,71 +49,207 @@ class StatsScreenshotTest {
       days = DayOfWeek.entries.associateWith { it.name.lowercase().take(3) },
     )
 
-  private val testDate = LocalDate(2025, 1, 6)
+  private val today = LocalDate(2025, 1, 20) // Monday
+  private val timeZone = TimeZone.UTC
 
   private val exerciseConfig = HabitConfig(tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF4CAF50))
-  private val waterConfig = HabitConfig(tag = "#habits/water", label = "Water", color = HabitColor(0xFF2196F3))
+  private val readingConfig = HabitConfig(tag = "#habits/reading", label = "Reading", color = HabitColor(0xFFFF9800))
+  private val meditationConfig = HabitConfig(tag = "#habits/meditation", label = "Meditation", color = HabitColor(0xFF9C27B0))
+  private val waterConfig = HabitConfig(tag = "#habits/water", label = "Water", color = HabitColor(0xFF00BCD4))
+  private val learningConfig = HabitConfig(tag = "#habits/learning", label = "Learning", color = HabitColor(0xFFE91E63))
+  private val walkingConfig = HabitConfig(tag = "#habits/walking", label = "Walking", color = HabitColor(0xFF607D8B))
+  private val noSugarConfig = HabitConfig(tag = "#habits/no_sugar", label = "no sugar", color = HabitColor(0xFFF44336))
+  private val earlySleepConfig = HabitConfig(tag = "#habits/early_sleep", label = "early sleep", color = HabitColor(0xFF2196F3))
 
-  @Test
-  fun `when no habits configured then captures empty stats`() =
-    runAppUiTest {
-      setThemedContent {
-        StatsScreen(
-          state =
-            StatsScreenState(
-              memos = emptyList(),
-              range = ActivityRange.Week(startDate = testDate),
-              activityMode = ActivityMode.HABITS,
-            ),
-          appMode = AppMode.DEMO,
-          dateFormatter = testDateFormatter,
-        )
+  private val allHabits =
+    listOf(exerciseConfig, readingConfig, meditationConfig, waterConfig, learningConfig, walkingConfig, noSugarConfig, earlySleepConfig)
+
+  private val demoMemos: List<Memo> by lazy { generateDeterministicDemoMemos() }
+
+  @Suppress("MagicNumber")
+  private fun generateDeterministicDemoMemos(): List<Memo> {
+    val memos = mutableListOf<Memo>()
+    val random = Random(42)
+    val configDate = LocalDate(2024, 1, 1)
+    val configContent =
+      buildString {
+        appendLine(PostTags.HABITS_CONFIG)
+        appendLine()
+        allHabits.forEach { habit -> appendLine("${habit.label} | ${habit.tag} | ${formatHexColor(habit.color)}") }
       }
+    memos.add(Memo(name = "memos/demo_config", content = configContent.trim(), createTime = instantForDate(configDate, 8)))
 
+    var current = configDate
+    val rates = floatArrayOf(0.95f, 0.85f, 0.80f, 0.95f, 0.70f, 0.80f, 0.65f, 0.75f)
+    while (current <= today) {
+      val completed = allHabits.filterIndexed { i, _ -> random.nextFloat() < rates[i] }
+      if (completed.isNotEmpty()) {
+        val content =
+          buildString {
+            appendLine("${PostTags.HABITS_DAILY} $current")
+            appendLine()
+            completed.forEach { appendLine(it.tag) }
+          }
+        memos.add(Memo(name = "memos/demo_daily_$current", content = content.trim(), createTime = instantForDate(current, 9)))
+      }
+      if (random.nextFloat() < 0.15f) {
+        memos.add(Memo(name = "memos/demo_post_$current", content = "Note for $current", createTime = instantForDate(current, 14)))
+      }
+      current = LocalDate.fromEpochDays(current.toEpochDays() + 1)
+    }
+    return memos
+  }
+
+  @Suppress("MagicNumber")
+  private fun instantForDate(
+    date: LocalDate,
+    hour: Int,
+  ): Instant {
+    val epochSeconds = date.toEpochDays() * 86_400L + hour * 3_600
+    return Instant.fromEpochSeconds(epochSeconds)
+  }
+
+  private fun computeCache(
+    memos: List<Memo>,
+    range: ActivityRange,
+    mode: ActivityMode,
+  ): CachedActivity {
+    val buildActivityData = BuildActivityDataUseCase(BuildDayDataUseCase())
+    val configTimeline = ExtractHabitsConfigUseCase(memos, timeZone)
+    val dailyMemos = ExtractDailyMemosUseCase(memos, timeZone)
+    val weekData = buildActivityData.buildWeekData(configTimeline, dailyMemos, timeZone, memos, range, mode, today)
+    val successRate =
+      if (mode == ActivityMode.HABITS) {
+        CalculateSuccessRateUseCase(weekData, range, today, configTimeline.firstOrNull()?.date)
+      } else {
+        null
+      }
+    return CachedActivity(weekData, configTimeline, successRate)
+  }
+
+  private fun habitsStateWithCache(
+    range: ActivityRange,
+    mode: ActivityMode,
+  ): HabitsState {
+    val key = ActivityCacheKey(range, mode, AppMode.DEMO)
+    return HabitsState(activityDataCache = mapOf(key to computeCache(demoMemos, range, mode)))
+  }
+
+  // --- Week Habits ---
+  @Test
+  fun `when week habits then captures week view`() =
+    runAppUiTest {
+      val range = ActivityRange.Week(startDate = LocalDate(2024, 12, 9))
+      setThemedContent {
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.HABITS),
+          )
+        }
+      }
       onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "stats_habits_empty")
+      saveScreenshot("stats_week_habits")
     }
 
+  // --- Month Habits ---
   @Test
-  fun `when habits data present then captures stats with data`() =
+  fun `when month habits then captures month view`() =
     runAppUiTest {
+      val range = ActivityRange.Month(2024, Month.NOVEMBER)
       setThemedContent {
-        StatsScreen(
-          state =
-            StatsScreenState(
-              memos = emptyList(),
-              range = ActivityRange.Week(startDate = testDate),
-              activityMode = ActivityMode.HABITS,
-            ),
-          appMode = AppMode.DEMO,
-          dateFormatter = testDateFormatter,
-        )
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.HABITS),
+          )
+        }
       }
-
       onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "stats_habits_data")
+      saveScreenshot("stats_month_habits")
     }
 
+  // --- Quarter Habits ---
   @Test
-  fun `when posts mode then captures posts stats`() =
+  fun `when quarter habits then captures quarter view`() =
     runAppUiTest {
+      val range = ActivityRange.Quarter(2024, 4)
       setThemedContent {
-        StatsScreen(
-          state =
-            StatsScreenState(
-              memos = emptyList(),
-              range = ActivityRange.Week(startDate = testDate),
-              activityMode = ActivityMode.POSTS,
-            ),
-          appMode = AppMode.DEMO,
-          dateFormatter = testDateFormatter,
-        )
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.HABITS),
+          )
+        }
       }
-
       onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "stats_posts_data")
+      saveScreenshot("stats_quarter_habits")
     }
 
+  // --- Year Habits ---
+  @Test
+  fun `when year habits then captures year view`() =
+    runAppUiTest {
+      val range = ActivityRange.Year(2024)
+      setThemedContent {
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.HABITS),
+          )
+        }
+      }
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("stats_year_habits")
+    }
+
+  // --- Week Posts ---
+  @Test
+  fun `when week posts then captures posts week view`() =
+    runAppUiTest {
+      val range = ActivityRange.Week(startDate = LocalDate(2024, 12, 9))
+      setThemedContent {
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.POSTS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.POSTS),
+          )
+        }
+      }
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("stats_week_posts")
+    }
+
+  // --- Month Posts ---
+  @Test
+  fun `when month posts then captures posts month view`() =
+    runAppUiTest {
+      val range = ActivityRange.Month(2024, Month.NOVEMBER)
+      setThemedContent {
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.POSTS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = habitsStateWithCache(range, ActivityMode.POSTS),
+          )
+        }
+      }
+      onNodeWithTag(StatsTestTags.STATS_SCREEN).assertIsDisplayed()
+      saveScreenshot("stats_month_posts")
+    }
+
+  // --- Config Dialog ---
   @Test
   fun `when config dialog open then captures habits config`() =
     runAppUiTest {
@@ -113,9 +267,8 @@ class StatsScreenshotTest {
           dispatch = {},
         )
       }
-
       onNodeWithTag(StatsTestTags.HABITS_CONFIG_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "habits_config_dialog")
+      saveScreenshot("habits_config_dialog")
     }
 
   @Test
@@ -136,11 +289,11 @@ class StatsScreenshotTest {
           dispatch = {},
         )
       }
-
       onNodeWithTag(StatsTestTags.HABITS_CONFIG_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "habits_config_dialog_demo")
+      saveScreenshot("habits_config_dialog_demo")
     }
 
+  // --- Edit Config Warning ---
   @Test
   fun `when edit config warning shown then captures warning dialog`() =
     runAppUiTest {
@@ -150,17 +303,18 @@ class StatsScreenshotTest {
           dispatch = {},
         )
       }
-
       onNodeWithTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "habits_edit_warning_dialog")
+      saveScreenshot("habits_edit_warning_dialog")
     }
 
+  // --- Delete Confirm ---
   @Test
   fun `when delete confirm shown then captures delete dialog`() =
     runAppUiTest {
+      val range = ActivityRange.Week(startDate = LocalDate(2024, 12, 9))
       val testDay =
         ContributionDay(
-          date = testDate,
+          date = LocalDate(2024, 12, 11),
           count = 2,
           totalHabits = 2,
           completionRatio = 1f,
@@ -172,34 +326,29 @@ class StatsScreenshotTest {
           dailyMemo = null,
           inRange = true,
         )
+      val cache = habitsStateWithCache(range, ActivityMode.HABITS)
       setThemedContent {
-        StatsScreen(
-          state =
-            StatsScreenState(
-              memos = emptyList(),
-              range = ActivityRange.Week(startDate = testDate),
-              activityMode = ActivityMode.HABITS,
-            ),
-          appMode = AppMode.DEMO,
-          dateFormatter = testDateFormatter,
-          habitsState =
-            HabitsState(
-              showDeleteConfirm = true,
-              editorDay = testDay,
-            ),
-        )
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState = cache.copy(showDeleteConfirm = true, editorDay = testDay),
+          )
+        }
       }
-
       onNodeWithTag(StatsTestTags.EMPTY_DELETE_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "habit_delete_confirm_dialog")
+      saveScreenshot("habit_delete_confirm_dialog")
     }
 
+  // --- Single Toggle ---
   @Test
   fun `when single toggle confirm shown then captures toggle dialog`() =
     runAppUiTest {
+      val range = ActivityRange.Week(startDate = LocalDate(2024, 12, 9))
       val testDay =
         ContributionDay(
-          date = testDate,
+          date = LocalDate(2024, 12, 11),
           count = 1,
           totalHabits = 2,
           completionRatio = 0.5f,
@@ -211,27 +360,24 @@ class StatsScreenshotTest {
           dailyMemo = null,
           inRange = true,
         )
+      val cache = habitsStateWithCache(range, ActivityMode.HABITS)
       setThemedContent {
-        StatsScreen(
-          state =
-            StatsScreenState(
-              memos = emptyList(),
-              range = ActivityRange.Week(startDate = testDate),
-              activityMode = ActivityMode.HABITS,
-            ),
-          appMode = AppMode.DEMO,
-          dateFormatter = testDateFormatter,
-          habitsState =
-            HabitsState(
-              singleToggleDay = testDay,
-              singleToggleHabitTag = "#habits/water",
-              singleToggleHabitLabel = "Water",
-              singleToggleConfig = listOf(exerciseConfig, waterConfig),
-            ),
-        )
+        Box(modifier = Modifier.padding(Indent.m)) {
+          StatsScreen(
+            state = StatsScreenState(memos = demoMemos, range = range, activityMode = ActivityMode.HABITS),
+            appMode = AppMode.DEMO,
+            dateFormatter = testDateFormatter,
+            habitsState =
+              cache.copy(
+                singleToggleDay = testDay,
+                singleToggleHabitTag = "#habits/water",
+                singleToggleHabitLabel = "Water",
+                singleToggleConfig = listOf(exerciseConfig, waterConfig),
+              ),
+          )
+        }
       }
-
       onNodeWithTag(StatsTestTags.SINGLE_TOGGLE_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "StatsScreenshotTest", "single_habit_toggle_dialog")
+      saveScreenshot("single_habit_toggle_dialog")
     }
 }

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
@@ -91,7 +91,7 @@ class AppShellScreenshotTest {
       }
 
       onNodeWithTag(AppShellTestTags.LOADING_SCREEN).assertIsDisplayed()
-      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_loading")
+      saveScreenshot("app_loading")
     }
 
   @Test
@@ -99,7 +99,7 @@ class AppShellScreenshotTest {
     runAppUiTest {
       setVibitsApp(Screen.HABITS)
       onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
-      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_habits_tab")
+      saveScreenshot("app_habits_tab")
     }
 
   @Test
@@ -107,7 +107,7 @@ class AppShellScreenshotTest {
     runAppUiTest {
       setVibitsApp(Screen.STATS)
       onNodeWithTag(AppShellTestTags.BOTTOM_NAV_STATS).assertIsDisplayed()
-      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_stats_tab")
+      saveScreenshot("app_stats_tab")
     }
 
   @Test
@@ -115,6 +115,6 @@ class AppShellScreenshotTest {
     runAppUiTest {
       setVibitsApp(Screen.FEED)
       onNodeWithTag(AppShellTestTags.BOTTOM_NAV_FEED).assertIsDisplayed()
-      saveScreenshot("homescreen", "AppShellScreenshotTest", "app_feed_tab")
+      saveScreenshot("app_feed_tab")
     }
 }

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitEditorScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitEditorScreenshotTest.kt
@@ -54,6 +54,6 @@ class HabitEditorScreenshotTest {
       }
 
       onNodeWithTag(AppShellTestTags.HABIT_EDITOR_DIALOG).assertIsDisplayed()
-      saveScreenshot("habits", "HabitEditorScreenshotTest", "habit_editor_dialog")
+      saveScreenshot("habit_editor_dialog")
     }
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
@@ -26,8 +26,11 @@ import space.be1ski.vibits.feature.sync.domain.SyncLogTags
  * Filters the app logs to show only sync-related entries.
  */
 @Composable
-fun SyncLogDialog(onDismiss: () -> Unit) {
-  var syncLogs by remember { mutableStateOf(filterSyncLogs(Log.logs)) }
+fun SyncLogDialog(
+  onDismiss: () -> Unit,
+  initialLogs: List<LogEntry> = filterSyncLogs(Log.logs),
+) {
+  var syncLogs by remember { mutableStateOf(initialLogs) }
 
   AlertDialog(
     onDismissRequest = onDismiss,
@@ -57,4 +60,4 @@ fun SyncLogDialog(onDismiss: () -> Unit) {
   )
 }
 
-private fun filterSyncLogs(logs: List<LogEntry>): List<LogEntry> = logs.filter { entry -> entry.tag in SyncLogTags.allTags }
+internal fun filterSyncLogs(logs: List<LogEntry>): List<LogEntry> = logs.filter { entry -> entry.tag in SyncLogTags.allTags }

--- a/feature/memos/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreenshotTest.kt
+++ b/feature/memos/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreenshotTest.kt
@@ -5,14 +5,17 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import kotlinx.datetime.DayOfWeek
 import kotlinx.datetime.Month
+import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.core.ui.test.runAppUiTest
 import space.be1ski.vibits.core.ui.test.saveScreenshot
 import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.model.PostFilter
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.hours
+import kotlin.time.Instant
 
 @OptIn(ExperimentalTestApi::class)
 class FeedScreenshotTest {
@@ -22,33 +25,50 @@ class FeedScreenshotTest {
       days = DayOfWeek.entries.associateWith { it.name.lowercase().take(3) },
     )
 
-  private val baseInstant = kotlin.time.Instant.fromEpochMilliseconds(1_704_067_200_000) // 2024-01-01T00:00:00Z
+  private val baseInstant = Instant.fromEpochMilliseconds(1_704_067_200_000) // 2024-01-01T00:00:00Z
 
-  private val testMemos =
+  private val demoMemos =
     listOf(
       Memo(
         name = "memos/1",
-        content = "#habits/config\n\nExercise | #habits/exercise | #4CAF50\nWater | #habits/water | #2196F3",
+        content =
+          "#habits/config\n\nExercise | #habits/exercise | #4CAF50\n" +
+            "Water | #habits/water | #2196F3\nReading | #habits/reading | #FF9800",
         createTime = baseInstant,
       ),
       Memo(name = "memos/2", content = "#habits/daily 2024-01-01\n\n#habits/exercise\n#habits/water", createTime = baseInstant + 1.hours),
-      Memo(name = "memos/3", content = "Today was a good day!", createTime = baseInstant + 2.hours),
-      Memo(name = "memos/4", content = "Remember to buy groceries", createTime = baseInstant + 3.hours),
+      Memo(
+        name = "memos/3",
+        content = "#habits/daily 2024-01-02\n\n#habits/exercise\n#habits/reading",
+        createTime = baseInstant + 25.hours,
+      ),
+      Memo(name = "memos/4", content = "Today was a good day!", createTime = baseInstant + 2.hours),
+      Memo(name = "memos/5", content = "Remember to buy groceries", createTime = baseInstant + 3.hours),
+      Memo(name = "memos/6", content = "Interesting article about productivity I found today.", createTime = baseInstant + 26.hours),
+      Memo(name = "memos/7", content = "Book recommendation from a friend - need to check it out.", createTime = baseInstant + 27.hours),
+      Memo(name = "memos/8", content = "#habits/daily 2024-01-03\n\n#habits/exercise", createTime = baseInstant + 49.hours),
+    )
+
+  private val testSyncLogs =
+    listOf(
+      LogEntry("2025-01-06 10:00:00", LogLevel.INFO, "SyncEngine", "Sync started"),
+      LogEntry("2025-01-06 10:00:01", LogLevel.DEBUG, "SyncEngine", "Fetching 42 memos from server"),
+      LogEntry("2025-01-06 10:00:02", LogLevel.INFO, "SyncEngine", "Sync completed successfully"),
     )
 
   @Test
-  fun `when feed has memos then captures default feed`() =
+  fun `when feed has demo data then captures feed`() =
     runAppUiTest {
       setThemedContent {
         FeedScreen(
-          memos = testMemos,
+          memos = demoMemos,
           dateFormatter = testDateFormatter,
           enablePullRefresh = false,
+          demoMode = true,
         )
       }
-
       onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "feed_default")
+      saveScreenshot("feed_demo_data")
     }
 
   @Test
@@ -61,9 +81,8 @@ class FeedScreenshotTest {
           enablePullRefresh = false,
         )
       }
-
       onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "feed_empty")
+      saveScreenshot("feed_empty")
     }
 
   @Test
@@ -71,31 +90,30 @@ class FeedScreenshotTest {
     runAppUiTest {
       setThemedContent {
         FeedScreen(
-          memos = testMemos,
+          memos = demoMemos,
           dateFormatter = testDateFormatter,
           activeFilter = PostFilter.CONFIG,
           enablePullRefresh = false,
         )
       }
-
       onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "feed_filtered_config")
+      saveScreenshot("feed_filtered_config")
     }
 
   @Test
-  fun `when demo mode then captures feed with localized habit labels`() =
+  fun `when filtered to tracking then captures tracking filter`() =
     runAppUiTest {
       setThemedContent {
         FeedScreen(
-          memos = testMemos,
+          memos = demoMemos,
           dateFormatter = testDateFormatter,
+          activeFilter = PostFilter.HABIT_TRACKING,
           enablePullRefresh = false,
           demoMode = true,
         )
       }
-
       onNodeWithTag(FeedTestTags.FEED_SCREEN).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "feed_demo_mode")
+      saveScreenshot("feed_filtered_tracking")
     }
 
   @Test
@@ -109,19 +127,20 @@ class FeedScreenshotTest {
           onDismiss = {},
         )
       }
-
       onNodeWithTag(FeedTestTags.SYNC_CONFLICT_DIALOG).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "sync_conflict_dialog")
+      saveScreenshot("sync_conflict_dialog")
     }
 
   @Test
   fun `when sync log dialog shown then captures dialog`() =
     runAppUiTest {
       setThemedContent {
-        SyncLogDialog(onDismiss = {})
+        SyncLogDialog(
+          onDismiss = {},
+          initialLogs = testSyncLogs,
+        )
       }
-
       onNodeWithTag(FeedTestTags.SYNC_LOG_DIALOG).assertIsDisplayed()
-      saveScreenshot("memos", "FeedScreenshotTest", "sync_log_dialog")
+      saveScreenshot("sync_log_dialog")
     }
 }

--- a/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
+++ b/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
@@ -29,7 +29,7 @@ class ModeSelectionScreenshotTest {
       setThemedContent { ModeSelectionScreen(createFeature()) }
 
       onNodeWithTag(ModeSelectionTestTags.ONLINE_CARD).assertIsDisplayed()
-      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_default")
+      saveScreenshot("mode_selection_default")
     }
 
   @Test
@@ -38,7 +38,7 @@ class ModeSelectionScreenshotTest {
       setThemedContent { ModeSelectionScreen(createFeature(ModeSelectionState(showQuickOnlineDialog = true))) }
 
       onNodeWithTag(ModeSelectionTestTags.QUICK_ONLINE_DIALOG).assertIsDisplayed()
-      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_quick_online_dialog")
+      saveScreenshot("mode_selection_quick_online_dialog")
     }
 
   @Test
@@ -47,7 +47,7 @@ class ModeSelectionScreenshotTest {
       setThemedContent { ModeSelectionScreen(createFeature(ModeSelectionState(showCredentialsDialog = true))) }
 
       onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
-      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_credentials_dialog")
+      saveScreenshot("mode_selection_credentials_dialog")
     }
 
   @Test
@@ -63,6 +63,6 @@ class ModeSelectionScreenshotTest {
       setThemedContent { ModeSelectionScreen(feature) }
 
       onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
-      saveScreenshot("mode", "ModeSelectionScreenshotTest", "mode_selection_credentials_error")
+      saveScreenshot("mode_selection_credentials_error")
     }
 }

--- a/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
+++ b/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
@@ -27,7 +27,7 @@ class OnboardingScreenshotTest {
       }
 
       onNodeWithTag(OnboardingTestTags.WELCOME_SCREEN).assertIsDisplayed()
-      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_welcome")
+      saveScreenshot("onboarding_welcome")
     }
 
   @Test
@@ -46,7 +46,7 @@ class OnboardingScreenshotTest {
       }
 
       onNodeWithTag(OnboardingTestTags.CHOOSE_PRESET_SCREEN).assertIsDisplayed()
-      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_choose_preset")
+      saveScreenshot("onboarding_choose_preset")
     }
 
   @Test
@@ -66,7 +66,7 @@ class OnboardingScreenshotTest {
       }
 
       onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
-      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_habit_setup")
+      saveScreenshot("onboarding_habit_setup")
     }
 
   @Test
@@ -87,7 +87,7 @@ class OnboardingScreenshotTest {
       }
 
       onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
-      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_habit_setup_error")
+      saveScreenshot("onboarding_habit_setup_error")
     }
 
   @Test
@@ -101,6 +101,6 @@ class OnboardingScreenshotTest {
       }
 
       onNodeWithTag(OnboardingTestTags.SUCCESS_SCREEN).assertIsDisplayed()
-      saveScreenshot("onboarding", "OnboardingScreenshotTest", "onboarding_success")
+      saveScreenshot("onboarding_success")
     }
 }

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -114,6 +114,7 @@ import space.be1ski.vibits.core.ui.SegmentedSelector
 import space.be1ski.vibits.core.ui.form.CredentialFields
 import space.be1ski.vibits.core.ui.form.credentialValidationErrorMessage
 import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.memos.domain.model.ExportResult
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
@@ -125,6 +126,7 @@ fun SettingsDialog(
   state: SettingsState,
   dispatch: (SettingsAction) -> Unit,
   exportService: ExportService,
+  testLogs: List<LogEntry>? = null,
 ) {
   if (!state.isOpen) {
     return
@@ -141,7 +143,10 @@ fun SettingsDialog(
   )
 
   if (state.showLogsDialog) {
-    LogsDialog(onDismiss = { dispatch(SettingsAction.SaveAndLogs.CloseLogs) })
+    LogsDialog(
+      onDismiss = { dispatch(SettingsAction.SaveAndLogs.CloseLogs) },
+      initialLogs = testLogs ?: Log.logs,
+    )
   }
 
   if (state.showResetConfirmation) {
@@ -620,8 +625,11 @@ private fun ResetOptionsDialog(
 }
 
 @Composable
-private fun LogsDialog(onDismiss: () -> Unit) {
-  var logs by remember { mutableStateOf(Log.logs) }
+private fun LogsDialog(
+  onDismiss: () -> Unit,
+  initialLogs: List<LogEntry> = Log.logs,
+) {
+  var logs by remember { mutableStateOf(initialLogs) }
 
   AlertDialog(
     onDismissRequest = onDismiss,

--- a/feature/settings/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsScreenshotTest.kt
+++ b/feature/settings/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsScreenshotTest.kt
@@ -3,11 +3,13 @@ package space.be1ski.vibits.feature.settings.presentation.view
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
+import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.core.ui.test.runAppUiTest
 import space.be1ski.vibits.core.ui.test.saveScreenshot
 import space.be1ski.vibits.core.ui.test.setThemedContent
+import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.memos.domain.model.ExportResult
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
@@ -40,7 +42,7 @@ class SettingsScreenshotTest {
       }
 
       onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_online")
+      saveScreenshot("settings_online")
     }
 
   @Test
@@ -59,7 +61,7 @@ class SettingsScreenshotTest {
       }
 
       onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_offline")
+      saveScreenshot("settings_offline")
     }
 
   @Test
@@ -78,7 +80,7 @@ class SettingsScreenshotTest {
       }
 
       onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_demo")
+      saveScreenshot("settings_demo")
     }
 
   @Test
@@ -100,8 +102,16 @@ class SettingsScreenshotTest {
       }
 
       onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_validation_error")
+      saveScreenshot("settings_validation_error")
     }
+
+  private val testLogs =
+    listOf(
+      LogEntry("2025-01-06 10:00:00", LogLevel.INFO, "SyncEngine", "Sync started"),
+      LogEntry("2025-01-06 10:00:01", LogLevel.DEBUG, "SyncEngine", "Fetching 42 memos from server"),
+      LogEntry("2025-01-06 10:00:02", LogLevel.WARN, "SyncEngine", "Slow network detected"),
+      LogEntry("2025-01-06 10:00:03", LogLevel.INFO, "SyncEngine", "Sync completed successfully"),
+    )
 
   @Test
   fun `when logs dialog open then captures logs dialog`() =
@@ -116,11 +126,11 @@ class SettingsScreenshotTest {
             ),
           dispatch = {},
           exportService = fakeExportService,
+          testLogs = testLogs,
         )
       }
-
       onNodeWithTag(SettingsTestTags.LOGS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_logs_dialog")
+      saveScreenshot("settings_logs_dialog")
     }
 
   @Test
@@ -140,6 +150,6 @@ class SettingsScreenshotTest {
       }
 
       onNodeWithTag(SettingsTestTags.RESET_OPTIONS_DIALOG).assertIsDisplayed()
-      saveScreenshot("settings", "SettingsScreenshotTest", "settings_reset_options_dialog")
+      saveScreenshot("settings_reset_options_dialog")
     }
 }


### PR DESCRIPTION
## Summary
- Populate screenshot tests with deterministic demo data (full year 2024, high habit completion rates) so all grid cells are colorful
- Use past time ranges (Q4 2024, Nov 2024, Dec 9-15 2024) instead of current/future ranges
- Flatten screenshot output into a single `build/ui-screenshots/` directory
- Fix flaky log dialogs by injecting fixed `initialLogs` instead of reading from global `Log` singleton

## Changes
- **StatsScreenshotTest**: Rewritten with demo data generator (`Random(42)`, config from Jan 1 2024, 8 habits with 65-95% rates). All ranges use past intervals with full data coverage
- **FeedScreenshotTest**: Richer demo memos with config + daily + regular posts
- **SettingsScreenshotTest**: Fixed logs dialog with deterministic log entries
- **ScreenshotCapture**: Simplified `saveScreenshot(scenario)` — flat output, no subdirectories
- **SyncLogDialog/SettingsDialogContent**: Added `initialLogs` parameter for test injection
- **CI workflow**: Simplified screenshot collection for flat structure

## Test plan
- [x] `checkJvm` passes
- [x] All screenshots verified visually — grids fully populated with colorful data

🤖 Generated with [Claude Code](https://claude.com/claude-code)