### PR TITLE
Assert delete dialog visibility before capturing screenshot

### DIFF
--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
@@ -548,6 +548,7 @@ class AppShellScreenshotTest {
           ),
       )
 
+      onNodeWithTag(StatsTestTags.EMPTY_DELETE_DIALOG).assertIsDisplayed()
       saveScreenshot("app_habits_delete")
     }
 


### PR DESCRIPTION
## Summary
- Add missing `assertIsDisplayed()` guard for the delete confirmation dialog in `AppShellScreenshotTest`
- Without this, a regression that stops the dialog from rendering would silently capture the base screen instead of failing the test

## Changes
- Added `onNodeWithTag(StatsTestTags.EMPTY_DELETE_DIALOG).assertIsDisplayed()` before `saveScreenshot("app_habits_delete")`, matching the pattern used by all other dialog screenshot tests

## Test plan
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)