### PR TITLE
Move edit config warning screenshot to feed tab

### DIFF
--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellScreenshotTest.kt
@@ -504,22 +504,6 @@ class AppShellScreenshotTest {
     }
 
   @Test
-  fun `when edit config warning shown then captures warning dialog`() =
-    runAppUiTest {
-      val range = ActivityRange.Week(LocalDate(2024, 12, 9))
-      setVibitsApp(
-        appState = habitsAppState(),
-        habitsState =
-          habitsStateWithCache(range).copy(
-            showEditConfigWarning = true,
-          ),
-      )
-
-      onNodeWithTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG).assertIsDisplayed()
-      saveScreenshot("app_habits_edit_warning")
-    }
-
-  @Test
   fun `when delete confirm shown then captures delete dialog`() =
     runAppUiTest {
       val testDay =
@@ -588,7 +572,20 @@ class AppShellScreenshotTest {
 
   // endregion
 
-  // region Sync dialogs
+  // region Feed dialogs
+
+  @Test
+  fun `when edit config warning shown then captures warning dialog`() =
+    runAppUiTest {
+      setVibitsApp(
+        appState = feedAppState(),
+        habitsState =
+          HabitsState(showEditConfigWarning = true),
+      )
+
+      onNodeWithTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG).assertIsDisplayed()
+      saveScreenshot("app_feed_edit_warning")
+    }
 
   @Test
   fun `when sync conflict dialog shown then captures conflict dialog`() =


### PR DESCRIPTION
## Summary
- `EditConfigWarningDialog` is only reachable from the feed tab (editing an existing config memo), not from the habits tab
- Moved the screenshot test to use `feedAppState()` and renamed output from `app_habits_edit_warning` to `app_feed_edit_warning`

## Changes
- Removed edit warning test from habits dialogs region
- Added it to feed dialogs region with `feedAppState()` and correct screenshot name
- Renamed region from "Sync dialogs" to "Feed dialogs" to cover both feed-related dialog tests

## Test plan
- [x] `./gradlew :feature:homescreen:desktopTest --tests "*.AppShellScreenshotTest"` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)