### PR TITLE
Add guided state system for empty and loading screens

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">بدون سكر</string>
     <string name="demo_habit_early_sleep">النوم قبل 11 مساءً</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">ستظهر ذكرياتك هنا بعد إنشائها.</string>
+    <string name="msg_feed_empty_filtered">لا توجد ذكريات تطابق هذا الفلتر.</string>
+    <string name="msg_state_loading">جارٍ إعداد العادات والذكريات…</string>
+    <string name="title_feed_empty">لا توجد ذكريات هنا</string>
+    <string name="title_state_loading">جارٍ تحميل البيانات</string>
+
     <!-- Sync -->
     <string name="action_sync">مزامنة</string>
     <string name="action_keep_local">الاحتفاظ بالمحلي</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -243,6 +243,13 @@ Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlk
     <string name="demo_habit_no_sugar">Şəkərsiz</string>
     <string name="demo_habit_early_sleep">23:00-a qədər yat</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Xatirələriniz yaradıldıqdan sonra burada görünəcək.</string>
+    <string name="msg_feed_empty_filtered">Bu filtrə uyğun xatirə yoxdur.</string>
+    <string name="msg_state_loading">Vərdişlər və xatirələr hazırlanır…</string>
+    <string name="title_feed_empty">Burada xatirə yoxdur</string>
+    <string name="title_state_loading">Məlumatlar yüklənir</string>
+
     <!-- Sync -->
     <string name="action_sync">Sinxronizasiya</string>
     <string name="action_keep_local">Yerli saxla</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">Без цукру</string>
     <string name="demo_habit_early_sleep">Сон да 23:00</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Вашы ўспаміны з\'явяцца тут пасля стварэння.</string>
+    <string name="msg_feed_empty_filtered">Няма ўспамінаў па гэтым фільтры.</string>
+    <string name="msg_state_loading">Падрыхтоўка звычак і ўспамінаў…</string>
+    <string name="title_feed_empty">Тут пакуль пуста</string>
+    <string name="title_state_loading">Загрузка даных</string>
+
     <!-- Sync -->
     <string name="action_sync">Сінхранізаваць</string>
     <string name="action_keep_local">Пакінуць лакальныя</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -243,6 +243,13 @@ Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Dat
     <string name="demo_habit_no_sugar">Kein Zucker</string>
     <string name="demo_habit_early_sleep">Vor 23 Uhr schlafen</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Deine Erinnerungen erscheinen hier nach dem Erstellen.</string>
+    <string name="msg_feed_empty_filtered">Keine Erinnerungen für diesen Filter.</string>
+    <string name="msg_state_loading">Gewohnheiten und Erinnerungen werden vorbereitet…</string>
+    <string name="title_feed_empty">Noch keine Erinnerungen</string>
+    <string name="title_state_loading">Daten werden geladen</string>
+
     <!-- Sync -->
     <string name="action_sync">Synchronisieren</string>
     <string name="action_keep_local">Lokal behalten</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -239,6 +239,13 @@
     <string name="demo_habit_no_sugar">Sin azúcar</string>
     <string name="demo_habit_early_sleep">Dormir antes de las 23h</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Tus recuerdos aparecerán aquí una vez creados.</string>
+    <string name="msg_feed_empty_filtered">No hay recuerdos con este filtro.</string>
+    <string name="msg_state_loading">Preparando hábitos y recuerdos…</string>
+    <string name="title_feed_empty">No hay recuerdos aquí</string>
+    <string name="title_state_loading">Cargando tus datos</string>
+
     <!-- Sync -->
     <string name="action_sync">Sincronizar</string>
     <string name="action_keep_local">Mantener local</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -243,6 +243,13 @@ Bonne pratique : créez une nouvelle configuration. Vos données historiques con
     <string name="demo_habit_no_sugar">Sans sucre</string>
     <string name="demo_habit_early_sleep">Dormir avant 23h</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Vos souvenirs apparaîtront ici une fois créés.</string>
+    <string name="msg_feed_empty_filtered">Aucun souvenir ne correspond à ce filtre.</string>
+    <string name="msg_state_loading">Préparation des habitudes et souvenirs…</string>
+    <string name="title_feed_empty">Aucun souvenir ici</string>
+    <string name="title_state_loading">Chargement de vos données</string>
+
     <!-- Sync -->
     <string name="action_sync">Synchroniser</string>
     <string name="action_keep_local">Garder local</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">बिना चीनी</string>
     <string name="demo_habit_early_sleep">रात 11 बजे तक सोना</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">आपकी यादें बनाने के बाद यहाँ दिखाई देंगी।</string>
+    <string name="msg_feed_empty_filtered">इस फ़िल्टर से कोई याद नहीं मिली।</string>
+    <string name="msg_state_loading">आदतें और यादें तैयार हो रही हैं…</string>
+    <string name="title_feed_empty">यहाँ कोई याद नहीं है</string>
+    <string name="title_state_loading">डेटा लोड हो रहा है</string>
+
     <!-- Sync -->
     <string name="action_sync">सिंक करें</string>
     <string name="action_keep_local">स्थानीय रखें</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">砂糖なし</string>
     <string name="demo_habit_early_sleep">23時までに就寝</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">作成されたメモはここに表示されます。</string>
+    <string name="msg_feed_empty_filtered">このフィルターに一致するメモはありません。</string>
+    <string name="msg_state_loading">習慣とメモを準備中…</string>
+    <string name="title_feed_empty">メモはまだありません</string>
+    <string name="title_state_loading">データを読み込んでいます</string>
+
     <!-- Sync -->
     <string name="action_sync">同期</string>
     <string name="action_keep_local">ローカルを保持</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">შაქრის გარეშე</string>
     <string name="demo_habit_early_sleep">ძილი 23:00-მდე</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">შენი მოგონებები აქ გამოჩნდება შექმნის შემდეგ.</string>
+    <string name="msg_feed_empty_filtered">ამ ფილტრს მოგონება არ შეესაბამება.</string>
+    <string name="msg_state_loading">ჩვევებისა და მოგონებების მომზადება…</string>
+    <string name="title_feed_empty">აქ მოგონება არ არის</string>
+    <string name="title_state_loading">მონაცემები იტვირთება</string>
+
     <!-- Sync -->
     <string name="action_sync">სინქრონიზაცია</string>
     <string name="action_keep_local">ლოკალური შენარჩუნება</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">Қантсыз</string>
     <string name="demo_habit_early_sleep">23:00-ге дейін ұйықтау</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Естеліктеріңіз жасалғаннан кейін осында пайда болады.</string>
+    <string name="msg_feed_empty_filtered">Бұл сүзгіге сәйкес естелік жоқ.</string>
+    <string name="msg_state_loading">Әдеттер мен естеліктер дайындалуда…</string>
+    <string name="title_feed_empty">Мұнда естелік жоқ</string>
+    <string name="title_state_loading">Деректер жүктелуде</string>
+
     <!-- Sync -->
     <string name="action_sync">Синхрондау</string>
     <string name="action_keep_local">Жергілікті сақтау</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">Кантсыз</string>
     <string name="demo_habit_early_sleep">23:00гө чейин уктоо</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Эскерүүлөрүңүз түзүлгөндөн кийин бул жерде көрүнөт.</string>
+    <string name="msg_feed_empty_filtered">Бул чыпкага туура келген эскерүү жок.</string>
+    <string name="msg_state_loading">Адаттар жана эскерүүлөр даярдалууда…</string>
+    <string name="title_feed_empty">Бул жерде эскерүү жок</string>
+    <string name="title_state_loading">Маалыматтар жүктөлүүдө</string>
+
     <!-- Sync -->
     <string name="action_sync">Шайкештирүү</string>
     <string name="action_keep_local">Жергиликтүү сактоо</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -243,6 +243,13 @@ Melhor prática: crie uma nova configuração. Seus dados históricos manterão 
     <string name="demo_habit_no_sugar">Sem açúcar</string>
     <string name="demo_habit_early_sleep">Dormir até 23h</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Suas memórias aparecerão aqui após serem criadas.</string>
+    <string name="msg_feed_empty_filtered">Nenhuma memória corresponde a este filtro.</string>
+    <string name="msg_state_loading">Preparando hábitos e memórias…</string>
+    <string name="title_feed_empty">Nenhuma memória aqui</string>
+    <string name="title_state_loading">Carregando seus dados</string>
+
     <!-- Sync -->
     <string name="action_sync">Sincronizar</string>
     <string name="action_keep_local">Manter local</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -243,6 +243,13 @@ Cea mai bună practică: creează o configurație nouă. Datele tale istorice vo
     <string name="demo_habit_no_sugar">Fără zahăr</string>
     <string name="demo_habit_early_sleep">Somn până la 23:00</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Amintirile tale vor apărea aici după creare.</string>
+    <string name="msg_feed_empty_filtered">Nicio amintire nu corespunde acestui filtru.</string>
+    <string name="msg_state_loading">Se pregătesc obiceiurile și amintirile…</string>
+    <string name="title_feed_empty">Nicio amintire aici</string>
+    <string name="title_state_loading">Se încarcă datele</string>
+
     <!-- Sync -->
     <string name="action_sync">Sincronizare</string>
     <string name="action_keep_local">Păstrează local</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -239,6 +239,13 @@
     <string name="demo_habit_no_sugar">Без сахара</string>
     <string name="demo_habit_early_sleep">Сон до 23:00</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Воспоминания появятся здесь после создания.</string>
+    <string name="msg_feed_empty_filtered">Нет воспоминаний по этому фильтру.</string>
+    <string name="msg_state_loading">Подготовка привычек и воспоминаний…</string>
+    <string name="title_feed_empty">Здесь пока пусто</string>
+    <string name="title_state_loading">Загрузка данных</string>
+
     <!-- Sync -->
     <string name="action_sync">Синхронизировать</string>
     <string name="action_keep_local">Оставить локальные</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">Бе қанд</string>
     <string name="demo_habit_early_sleep">Хоб то 23:00</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Хотираҳои шумо пас аз эҷод дар ин ҷо пайдо мешаванд.</string>
+    <string name="msg_feed_empty_filtered">Ягон хотира ба ин филтр мувофиқ нест.</string>
+    <string name="msg_state_loading">Одатҳо ва хотираҳо омода мешаванд…</string>
+    <string name="title_feed_empty">Дар ин ҷо хотира нест</string>
+    <string name="title_state_loading">Маълумот бор мешавад</string>
+
     <!-- Sync -->
     <string name="action_sync">Ҳамоҳангсозӣ</string>
     <string name="action_keep_local">Маҳаллӣ нигоҳ доред</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -243,6 +243,13 @@ Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigur
     <string name="demo_habit_no_sugar">Şekersiz</string>
     <string name="demo_habit_early_sleep">23:00-a çenli uky</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Ýatlamalarыňyz döredilenden soň bu ýerde görüner.</string>
+    <string name="msg_feed_empty_filtered">Bu süzgüçe gabat gelýän ýatlama ýok.</string>
+    <string name="msg_state_loading">Endikler we ýatlamalar taýýarlanylýar…</string>
+    <string name="title_feed_empty">Bu ýerde ýatlama ýok</string>
+    <string name="title_state_loading">Maglumatlar ýüklenýär</string>
+
     <!-- Sync -->
     <string name="action_sync">Sinhronizasiýa</string>
     <string name="action_keep_local">Ýerli sakla</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -243,6 +243,13 @@
     <string name="demo_habit_no_sugar">Без цукру</string>
     <string name="demo_habit_early_sleep">Сон до 23:00</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Ваші спогади з\'являться тут після створення.</string>
+    <string name="msg_feed_empty_filtered">Немає спогадів за цим фільтром.</string>
+    <string name="msg_state_loading">Підготовка звичок та спогадів…</string>
+    <string name="title_feed_empty">Тут поки порожньо</string>
+    <string name="title_state_loading">Завантаження даних</string>
+
     <!-- Sync -->
     <string name="action_sync">Синхронізувати</string>
     <string name="action_keep_local">Залишити локальні</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -243,6 +243,13 @@ Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfi
     <string name="demo_habit_no_sugar">Shakarsiz</string>
     <string name="demo_habit_early_sleep">23:00 gacha uxlash</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Xotiralaringiz yaratilgandan keyin bu yerda koʻrinadi.</string>
+    <string name="msg_feed_empty_filtered">Bu filtrga mos xotira topilmadi.</string>
+    <string name="msg_state_loading">Odatlar va xotiralar tayyorlanmoqda…</string>
+    <string name="title_feed_empty">Bu yerda xotira yoʻq</string>
+    <string name="title_state_loading">Maʼlumotlar yuklanmoqda</string>
+
     <!-- Sync -->
     <string name="action_sync">Sinxronlash</string>
     <string name="action_keep_local">Mahalliyni saqlash</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -239,6 +239,13 @@
     <string name="demo_habit_no_sugar">无糖</string>
     <string name="demo_habit_early_sleep">23点前睡觉</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">创建后，你的备忘录会显示在这里。</string>
+    <string name="msg_feed_empty_filtered">没有符合此筛选条件的备忘录。</string>
+    <string name="msg_state_loading">正在准备习惯和备忘录…</string>
+    <string name="title_feed_empty">这里还没有备忘录</string>
+    <string name="title_state_loading">正在加载数据</string>
+
     <!-- Sync -->
     <string name="action_sync">同步</string>
     <string name="action_keep_local">保留本地</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -239,6 +239,13 @@
     <string name="demo_habit_no_sugar">No Sugar</string>
     <string name="demo_habit_early_sleep">Sleep by 11pm</string>
 
+    <!-- State panels -->
+    <string name="msg_feed_empty_all">Your memos will appear here once created.</string>
+    <string name="msg_feed_empty_filtered">No memos match this filter.</string>
+    <string name="msg_state_loading">Setting up your habits and memos…</string>
+    <string name="title_feed_empty">No memos here</string>
+    <string name="title_state_loading">Loading your data</string>
+
     <!-- Sync -->
     <string name="action_sync">Sync</string>
     <string name="action_keep_local">Keep local</string>

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/StatePanel.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/StatePanel.kt
@@ -1,0 +1,74 @@
+package space.be1ski.vibits.core.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+
+@Composable
+fun StatePanel(
+  title: String,
+  message: String,
+  modifier: Modifier = Modifier,
+  icon: @Composable (() -> Unit)? = null,
+  primaryActionLabel: String? = null,
+  onPrimaryAction: (() -> Unit)? = null,
+  secondaryActionLabel: String? = null,
+  onSecondaryAction: (() -> Unit)? = null,
+) {
+  Column(
+    modifier = modifier.fillMaxWidth(),
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.Center,
+  ) {
+    if (icon != null) {
+      icon()
+      Spacer(modifier = Modifier.height(Indent.l))
+    }
+
+    Text(
+      text = title,
+      style = MaterialTheme.typography.titleMedium,
+      color = MaterialTheme.colorScheme.onSurface,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    Spacer(modifier = Modifier.height(Indent.xs))
+
+    Text(
+      text = message,
+      style = MaterialTheme.typography.bodyMedium,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+      textAlign = TextAlign.Center,
+      modifier = Modifier.fillMaxWidth(),
+    )
+
+    if (primaryActionLabel != null && onPrimaryAction != null) {
+      Spacer(modifier = Modifier.height(Indent.l))
+      Button(
+        onClick = onPrimaryAction,
+      ) {
+        Text(primaryActionLabel)
+      }
+    }
+
+    if (secondaryActionLabel != null && onSecondaryAction != null) {
+      Spacer(modifier = Modifier.height(Indent.xs))
+      TextButton(
+        onClick = onSecondaryAction,
+      ) {
+        Text(secondaryActionLabel)
+      }
+    }
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.feature.homescreen.presentation.view
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
@@ -12,8 +13,14 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.msg_state_loading
+import space.be1ski.vibits.core.strings.generated.title_state_loading
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.ui.StatePanel
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
@@ -132,10 +139,18 @@ private fun LoadingScreen() {
     color = MaterialTheme.colorScheme.background,
   ) {
     Box(
-      modifier = Modifier.fillMaxSize().testTag(AppShellTestTags.LOADING_SCREEN),
+      modifier =
+        Modifier
+          .fillMaxSize()
+          .padding(Indent.xl)
+          .testTag(AppShellTestTags.LOADING_SCREEN),
       contentAlignment = Alignment.Center,
     ) {
-      CircularProgressIndicator()
+      StatePanel(
+        title = stringResource(Res.string.title_state_loading),
+        message = stringResource(Res.string.msg_state_loading),
+        icon = { CircularProgressIndicator() },
+      )
     }
   }
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
@@ -14,6 +14,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
+import androidx.compose.material.icons.outlined.Description
 import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
@@ -44,9 +45,13 @@ import space.be1ski.vibits.core.strings.generated.filter_config
 import space.be1ski.vibits.core.strings.generated.filter_habit_tracking
 import space.be1ski.vibits.core.strings.generated.filter_regular
 import space.be1ski.vibits.core.strings.generated.label_post_filter
+import space.be1ski.vibits.core.strings.generated.msg_feed_empty_all
+import space.be1ski.vibits.core.strings.generated.msg_feed_empty_filtered
 import space.be1ski.vibits.core.strings.generated.title_delete_memo
+import space.be1ski.vibits.core.strings.generated.title_feed_empty
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.SegmentedSelector
+import space.be1ski.vibits.core.ui.StatePanel
 import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.model.PostFilter
@@ -110,42 +115,49 @@ fun FeedScreen(
           .fillMaxSize()
           .then(containerModifier),
     ) {
-      LazyColumn(state = listState, verticalArrangement = Arrangement.spacedBy(Indent.s)) {
-        items(filteredMemos) { memo ->
-          Card(
-            modifier =
-              Modifier
-                .fillMaxWidth()
-                .clickable { onMemoClick(memo) },
-          ) {
-            Row(
-              modifier = Modifier.padding(start = 0.dp, top = Indent.s, bottom = Indent.s, end = Indent.xs),
-              verticalAlignment = Alignment.Top,
+      if (filteredMemos.isEmpty()) {
+        FeedEmptyState(
+          isFiltered = activeFilter != PostFilter.ALL,
+          modifier = Modifier.align(Alignment.Center).padding(horizontal = Indent.xl),
+        )
+      } else {
+        LazyColumn(state = listState, verticalArrangement = Arrangement.spacedBy(Indent.s)) {
+          items(filteredMemos) { memo ->
+            Card(
+              modifier =
+                Modifier
+                  .fillMaxWidth()
+                  .clickable { onMemoClick(memo) },
             ) {
-              PostTypeIndicator(memo = memo)
-              Column(
-                modifier = Modifier.weight(1f).padding(start = Indent.s),
-                verticalArrangement = Arrangement.spacedBy(Indent.x2s),
+              Row(
+                modifier = Modifier.padding(start = 0.dp, top = Indent.s, bottom = Indent.s, end = Indent.xs),
+                verticalAlignment = Alignment.Top,
               ) {
-                MemoCardContent(
-                  memo = memo,
-                  allMemos = memos,
-                  dateFormatter = dateFormatter,
-                  timeZone = timeZone,
-                  demoMode = demoMode,
-                )
-              }
-              if (onDeleteMemo != null && memo.canDeleteFromFeed) {
-                IconButton(
-                  onClick = { memoToDelete = memo },
-                  modifier = Modifier.size(36.dp),
+                PostTypeIndicator(memo = memo)
+                Column(
+                  modifier = Modifier.weight(1f).padding(start = Indent.s),
+                  verticalArrangement = Arrangement.spacedBy(Indent.x2s),
                 ) {
-                  Icon(
-                    imageVector = Icons.Filled.Delete,
-                    contentDescription = stringResource(Res.string.action_delete),
-                    modifier = Modifier.size(18.dp),
-                    tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                  MemoCardContent(
+                    memo = memo,
+                    allMemos = memos,
+                    dateFormatter = dateFormatter,
+                    timeZone = timeZone,
+                    demoMode = demoMode,
                   )
+                }
+                if (onDeleteMemo != null && memo.canDeleteFromFeed) {
+                  IconButton(
+                    onClick = { memoToDelete = memo },
+                    modifier = Modifier.size(36.dp),
+                  ) {
+                    Icon(
+                      imageVector = Icons.Filled.Delete,
+                      contentDescription = stringResource(Res.string.action_delete),
+                      modifier = Modifier.size(18.dp),
+                      tint = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                  }
                 }
               }
             }
@@ -215,4 +227,29 @@ private fun memoDateLabel(
 ): String {
   val instant = memo.createTime ?: return ""
   return formatter.dateTime(instant.toLocalDateTime(timeZone))
+}
+
+@Composable
+private fun FeedEmptyState(
+  isFiltered: Boolean,
+  modifier: Modifier = Modifier,
+) {
+  StatePanel(
+    title = stringResource(Res.string.title_feed_empty),
+    message =
+      if (isFiltered) {
+        stringResource(Res.string.msg_feed_empty_filtered)
+      } else {
+        stringResource(Res.string.msg_feed_empty_all)
+      },
+    icon = {
+      Icon(
+        imageVector = Icons.Outlined.Description,
+        contentDescription = null,
+        modifier = Modifier.size(48.dp),
+        tint = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    },
+    modifier = modifier.testTag(FeedTestTags.FEED_EMPTY_STATE),
+  )
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedTestTags.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedTestTags.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.memos.presentation.view
 
 object FeedTestTags {
+  const val FEED_EMPTY_STATE = "feed_empty_state"
   const val FEED_SCREEN = "feed_screen"
   const val SYNC_CONFLICT_DIALOG = "sync_conflict_dialog"
   const val SYNC_LOG_DIALOG = "sync_log_dialog"

--- a/feature/mode/presentation/build.gradle.kts
+++ b/feature/mode/presentation/build.gradle.kts
@@ -17,6 +17,7 @@ kotlin {
         implementation(projects.feature.mode.domain)
         implementation(libs.compose.resources)
         implementation(libs.compose.foundation)
+        implementation(libs.compose.material.icons.extended)
         implementation(libs.compose.material3)
         implementation(libs.compose.runtime)
         implementation(libs.compose.ui)

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -3,15 +3,21 @@ package space.be1ski.vibits.feature.mode.presentation.view
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.Cloud
+import androidx.compose.material.icons.outlined.PhoneAndroid
+import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
@@ -22,6 +28,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
@@ -78,6 +85,7 @@ fun ModeSelectionScreen(
     Spacer(modifier = Modifier.height(Indent.l))
 
     ModeCard(
+      icon = Icons.Outlined.Cloud,
       title = stringResource(Res.string.mode_online_title),
       description = stringResource(Res.string.mode_online_desc),
       isPrimary = true,
@@ -89,6 +97,7 @@ fun ModeSelectionScreen(
     Spacer(modifier = Modifier.height(Indent.m))
 
     ModeCard(
+      icon = Icons.Outlined.PhoneAndroid,
       title = stringResource(Res.string.mode_offline_title),
       description = stringResource(Res.string.mode_offline_desc),
       isPrimary = false,
@@ -100,6 +109,7 @@ fun ModeSelectionScreen(
     Spacer(modifier = Modifier.height(Indent.m))
 
     ModeCard(
+      icon = Icons.Outlined.PlayCircle,
       title = stringResource(Res.string.mode_demo_title),
       description = stringResource(Res.string.mode_demo_desc),
       isPrimary = false,
@@ -218,6 +228,7 @@ private fun CredentialsSetupDialog(
 
 @Composable
 private fun ModeCard(
+  icon: ImageVector,
   title: String,
   description: String,
   isPrimary: Boolean,
@@ -232,10 +243,21 @@ private fun ModeCard(
       modifier = Modifier.padding(Indent.m),
       verticalArrangement = Arrangement.spacedBy(Indent.s),
     ) {
-      Text(
-        text = title,
-        style = MaterialTheme.typography.titleMedium,
-      )
+      Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(Indent.s),
+      ) {
+        Icon(
+          imageVector = icon,
+          contentDescription = null,
+          modifier = Modifier.size(Indent.xl),
+          tint = if (isPrimary) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Text(
+          text = title,
+          style = MaterialTheme.typography.titleMedium,
+        )
+      }
       Text(
         text = description,
         style = MaterialTheme.typography.bodySmall,

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/WelcomeScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/WelcomeScreen.kt
@@ -6,7 +6,11 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.material3.Button
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -14,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_create_first_habit
@@ -39,6 +44,15 @@ fun WelcomeScreen(
     horizontalAlignment = Alignment.CenterHorizontally,
     verticalArrangement = Arrangement.Center,
   ) {
+    Icon(
+      imageVector = Icons.Outlined.PhoneAndroid,
+      contentDescription = null,
+      tint = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.size(80.dp),
+    )
+
+    Spacer(modifier = Modifier.height(Indent.xl))
+
     Text(
       text = stringResource(Res.string.title_offline_onboarding_welcome),
       style = MaterialTheme.typography.headlineLarge,


### PR DESCRIPTION
## Summary
- Add reusable `StatePanel` component in `core/ui` for consistent empty/loading/first-run states
- Replace spinner-only loading screen with contextual title and message
- Add empty state to feed screen with icon and helpful text
- Add icons to mode selection cards (Cloud, Phone, Play) for visual distinction
- Add phone icon to onboarding welcome screen to reduce dead space
- Add 5 new localized strings across all 20 locales

## Changes
- **New:** `core/ui/StatePanel.kt` -- reusable component with icon slot, title, message, and optional actions
- **Updated:** `AppContent.kt` -- loading screen now uses StatePanel
- **Updated:** `FeedScreen.kt` -- empty state when no memos match (different messages for "all" vs filtered)
- **Updated:** `ModeSelectionScreen.kt` -- mode cards now include icons
- **Updated:** `WelcomeScreen.kt` -- added phone icon above title
- **Updated:** `FeedTestTags.kt` -- added `FEED_EMPTY_STATE` tag
- **Updated:** `mode/presentation/build.gradle.kts` -- added material-icons-extended dependency
- **Updated:** 20 locale `strings.xml` files with native translations

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] `./gradlew screenshotTests` passes with updated PNGs
- [x] Verified `app_loading.png` shows title + message + spinner
- [x] Verified `app_feed_empty.png` shows icon + title + message
- [x] Verified `mode_selection_default.png` shows icons in cards
- [x] Verified `onboarding_welcome.png` shows phone icon