### PR TITLE
Polish dialog text, log hints, and credential recovery

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">النوم قبل 11 مساءً</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">تحقق من الرابط ورمز الوصول، ثم حاول مرة أخرى.</string>
     <string name="msg_feed_empty_all">ستظهر ذكرياتك هنا بعد إنشائها.</string>
     <string name="msg_feed_empty_filtered">لا توجد ذكريات تطابق هذا الفلتر.</string>
+    <string name="msg_logs_empty_hint">تظهر السجلات هنا أثناء مزامنة التطبيق ومعالجة البيانات.</string>
     <string name="msg_state_loading">جارٍ إعداد العادات والذكريات…</string>
     <string name="title_feed_empty">لا توجد ذكريات هنا</string>
     <string name="title_state_loading">جارٍ تحميل البيانات</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -244,8 +244,10 @@ Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlk
     <string name="demo_habit_early_sleep">23:00-a qədər yat</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL və giriş tokenini yoxlayın, sonra yenidən cəhd edin.</string>
     <string name="msg_feed_empty_all">Xatirələriniz yaradıldıqdan sonra burada görünəcək.</string>
     <string name="msg_feed_empty_filtered">Bu filtrə uyğun xatirə yoxdur.</string>
+    <string name="msg_logs_empty_hint">Tətbiq sinxronlaşdırma və məlumat emal etdikcə jurnallar burada görünəcək.</string>
     <string name="msg_state_loading">Vərdişlər və xatirələr hazırlanır…</string>
     <string name="title_feed_empty">Burada xatirə yoxdur</string>
     <string name="title_state_loading">Məlumatlar yüklənir</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">Сон да 23:00</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Праверце URL і токен доступу, потым паспрабуйце зноў.</string>
     <string name="msg_feed_empty_all">Вашы ўспаміны з\'явяцца тут пасля стварэння.</string>
     <string name="msg_feed_empty_filtered">Няма ўспамінаў па гэтым фільтры.</string>
+    <string name="msg_logs_empty_hint">Журналы з\'яўляюцца тут па меры сінхранізацыі і апрацоўкі дадзеных.</string>
     <string name="msg_state_loading">Падрыхтоўка звычак і ўспамінаў…</string>
     <string name="title_feed_empty">Тут пакуль пуста</string>
     <string name="title_state_loading">Загрузка даных</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -244,8 +244,10 @@ Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Dat
     <string name="demo_habit_early_sleep">Vor 23 Uhr schlafen</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Überprüfen Sie die URL und das Zugriffstoken und versuchen Sie es erneut.</string>
     <string name="msg_feed_empty_all">Deine Erinnerungen erscheinen hier nach dem Erstellen.</string>
     <string name="msg_feed_empty_filtered">Keine Erinnerungen für diesen Filter.</string>
+    <string name="msg_logs_empty_hint">Protokolle erscheinen hier, wenn die App synchronisiert und Daten verarbeitet.</string>
     <string name="msg_state_loading">Gewohnheiten und Erinnerungen werden vorbereitet…</string>
     <string name="title_feed_empty">Noch keine Erinnerungen</string>
     <string name="title_state_loading">Daten werden geladen</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -240,8 +240,10 @@
     <string name="demo_habit_early_sleep">Dormir antes de las 23h</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Verifica la URL y el token de acceso, luego intenta de nuevo.</string>
     <string name="msg_feed_empty_all">Tus recuerdos aparecerán aquí una vez creados.</string>
     <string name="msg_feed_empty_filtered">No hay recuerdos con este filtro.</string>
+    <string name="msg_logs_empty_hint">Los registros aparecen aquí a medida que la app sincroniza y procesa datos.</string>
     <string name="msg_state_loading">Preparando hábitos y recuerdos…</string>
     <string name="title_feed_empty">No hay recuerdos aquí</string>
     <string name="title_state_loading">Cargando tus datos</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -244,8 +244,10 @@ Bonne pratique : créez une nouvelle configuration. Vos données historiques con
     <string name="demo_habit_early_sleep">Dormir avant 23h</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Vérifiez l\'URL et le jeton d\'accès, puis réessayez.</string>
     <string name="msg_feed_empty_all">Vos souvenirs apparaîtront ici une fois créés.</string>
     <string name="msg_feed_empty_filtered">Aucun souvenir ne correspond à ce filtre.</string>
+    <string name="msg_logs_empty_hint">Les journaux apparaissent ici au fur et à mesure que l\'app synchronise et traite les données.</string>
     <string name="msg_state_loading">Préparation des habitudes et souvenirs…</string>
     <string name="title_feed_empty">Aucun souvenir ici</string>
     <string name="title_state_loading">Chargement de vos données</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">रात 11 बजे तक सोना</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL और एक्सेस टोकन जांचें, फिर दोबारा प्रयास करें।</string>
     <string name="msg_feed_empty_all">आपकी यादें बनाने के बाद यहाँ दिखाई देंगी।</string>
     <string name="msg_feed_empty_filtered">इस फ़िल्टर से कोई याद नहीं मिली।</string>
+    <string name="msg_logs_empty_hint">ऐप के सिंक और डेटा प्रोसेस करने पर लॉग यहां दिखाई देंगे।</string>
     <string name="msg_state_loading">आदतें और यादें तैयार हो रही हैं…</string>
     <string name="title_feed_empty">यहाँ कोई याद नहीं है</string>
     <string name="title_state_loading">डेटा लोड हो रहा है</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">23時までに就寝</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URLとアクセストークンを確認して、もう一度お試しください。</string>
     <string name="msg_feed_empty_all">作成されたメモはここに表示されます。</string>
     <string name="msg_feed_empty_filtered">このフィルターに一致するメモはありません。</string>
+    <string name="msg_logs_empty_hint">アプリが同期やデータ処理を行うと、ここにログが表示されます。</string>
     <string name="msg_state_loading">習慣とメモを準備中…</string>
     <string name="title_feed_empty">メモはまだありません</string>
     <string name="title_state_loading">データを読み込んでいます</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">ძილი 23:00-მდე</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">შეამოწმეთ URL და წვდომის ტოკენი, შემდეგ სცადეთ ხელახლა.</string>
     <string name="msg_feed_empty_all">შენი მოგონებები აქ გამოჩნდება შექმნის შემდეგ.</string>
     <string name="msg_feed_empty_filtered">ამ ფილტრს მოგონება არ შეესაბამება.</string>
+    <string name="msg_logs_empty_hint">ჟურნალები აქ გამოჩნდება, როცა აპი სინქრონიზაციას და მონაცემთა დამუშავებას ახორციელებს.</string>
     <string name="msg_state_loading">ჩვევებისა და მოგონებების მომზადება…</string>
     <string name="title_feed_empty">აქ მოგონება არ არის</string>
     <string name="title_state_loading">მონაცემები იტვირთება</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">23:00-ге дейін ұйықтау</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL мен кіру токенін тексеріңіз, содан кейін қайталап көріңіз.</string>
     <string name="msg_feed_empty_all">Естеліктеріңіз жасалғаннан кейін осында пайда болады.</string>
     <string name="msg_feed_empty_filtered">Бұл сүзгіге сәйкес естелік жоқ.</string>
+    <string name="msg_logs_empty_hint">Қолданба синхрондалып, деректерді өңдеген сайын журналдар мұнда көрсетіледі.</string>
     <string name="msg_state_loading">Әдеттер мен естеліктер дайындалуда…</string>
     <string name="title_feed_empty">Мұнда естелік жоқ</string>
     <string name="title_state_loading">Деректер жүктелуде</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">23:00гө чейин уктоо</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL жана кирүү токенин текшериңиз, андан кийин кайра аракет кылыңыз.</string>
     <string name="msg_feed_empty_all">Эскерүүлөрүңүз түзүлгөндөн кийин бул жерде көрүнөт.</string>
     <string name="msg_feed_empty_filtered">Бул чыпкага туура келген эскерүү жок.</string>
+    <string name="msg_logs_empty_hint">Колдонмо синхрондошуп, маалыматтарды иштеткенде журналдар бул жерде көрүнөт.</string>
     <string name="msg_state_loading">Адаттар жана эскерүүлөр даярдалууда…</string>
     <string name="title_feed_empty">Бул жерде эскерүү жок</string>
     <string name="title_state_loading">Маалыматтар жүктөлүүдө</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -244,8 +244,10 @@ Melhor prática: crie uma nova configuração. Seus dados históricos manterão 
     <string name="demo_habit_early_sleep">Dormir até 23h</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Verifique a URL e o token de acesso e tente novamente.</string>
     <string name="msg_feed_empty_all">Suas memórias aparecerão aqui após serem criadas.</string>
     <string name="msg_feed_empty_filtered">Nenhuma memória corresponde a este filtro.</string>
+    <string name="msg_logs_empty_hint">Os registros aparecem aqui conforme o app sincroniza e processa dados.</string>
     <string name="msg_state_loading">Preparando hábitos e memórias…</string>
     <string name="title_feed_empty">Nenhuma memória aqui</string>
     <string name="title_state_loading">Carregando seus dados</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -244,8 +244,10 @@ Cea mai bună practică: creează o configurație nouă. Datele tale istorice vo
     <string name="demo_habit_early_sleep">Somn până la 23:00</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Verifică URL-ul și tokenul de acces, apoi încearcă din nou.</string>
     <string name="msg_feed_empty_all">Amintirile tale vor apărea aici după creare.</string>
     <string name="msg_feed_empty_filtered">Nicio amintire nu corespunde acestui filtru.</string>
+    <string name="msg_logs_empty_hint">Jurnalele apar aici pe măsură ce aplicația sincronizează și procesează datele.</string>
     <string name="msg_state_loading">Se pregătesc obiceiurile și amintirile…</string>
     <string name="title_feed_empty">Nicio amintire aici</string>
     <string name="title_state_loading">Se încarcă datele</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -240,8 +240,10 @@
     <string name="demo_habit_early_sleep">Сон до 23:00</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Проверьте URL и токен доступа, затем попробуйте снова.</string>
     <string name="msg_feed_empty_all">Воспоминания появятся здесь после создания.</string>
     <string name="msg_feed_empty_filtered">Нет воспоминаний по этому фильтру.</string>
+    <string name="msg_logs_empty_hint">Журналы появляются по мере синхронизации и обработки данных.</string>
     <string name="msg_state_loading">Подготовка привычек и воспоминаний…</string>
     <string name="title_feed_empty">Здесь пока пусто</string>
     <string name="title_state_loading">Загрузка данных</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">Хоб то 23:00</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL ва токени дастрасиро санҷед, сипас дубора кӯшиш кунед.</string>
     <string name="msg_feed_empty_all">Хотираҳои шумо пас аз эҷод дар ин ҷо пайдо мешаванд.</string>
     <string name="msg_feed_empty_filtered">Ягон хотира ба ин филтр мувофиқ нест.</string>
+    <string name="msg_logs_empty_hint">Ҳангоми ҳамоҳангсозӣ ва коркарди маълумот журналҳо дар ин ҷо пайдо мешаванд.</string>
     <string name="msg_state_loading">Одатҳо ва хотираҳо омода мешаванд…</string>
     <string name="title_feed_empty">Дар ин ҷо хотира нест</string>
     <string name="title_state_loading">Маълумот бор мешавад</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -244,8 +244,10 @@ Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigur
     <string name="demo_habit_early_sleep">23:00-a çenli uky</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL we giriş tokenini barlaň, soňra gaýtadan synanyşyň.</string>
     <string name="msg_feed_empty_all">Ýatlamalarыňyz döredilenden soň bu ýerde görüner.</string>
     <string name="msg_feed_empty_filtered">Bu süzgüçe gabat gelýän ýatlama ýok.</string>
+    <string name="msg_logs_empty_hint">Programma sinhronlaşdyranda we maglumatlary işlände žurnallar bu ýerde görkeziler.</string>
     <string name="msg_state_loading">Endikler we ýatlamalar taýýarlanylýar…</string>
     <string name="title_feed_empty">Bu ýerde ýatlama ýok</string>
     <string name="title_state_loading">Maglumatlar ýüklenýär</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -244,8 +244,10 @@
     <string name="demo_habit_early_sleep">Сон до 23:00</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Перевірте URL і токен доступу, потім спробуйте знову.</string>
     <string name="msg_feed_empty_all">Ваші спогади з\'являться тут після створення.</string>
     <string name="msg_feed_empty_filtered">Немає спогадів за цим фільтром.</string>
+    <string name="msg_logs_empty_hint">Журнали з\'являються тут у міру синхронізації та обробки даних.</string>
     <string name="msg_state_loading">Підготовка звичок та спогадів…</string>
     <string name="title_feed_empty">Тут поки порожньо</string>
     <string name="title_state_loading">Завантаження даних</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -244,8 +244,10 @@ Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfi
     <string name="demo_habit_early_sleep">23:00 gacha uxlash</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">URL va kirish tokenini tekshiring, keyin qaytadan urinib ko'ring.</string>
     <string name="msg_feed_empty_all">Xotiralaringiz yaratilgandan keyin bu yerda koʻrinadi.</string>
     <string name="msg_feed_empty_filtered">Bu filtrga mos xotira topilmadi.</string>
+    <string name="msg_logs_empty_hint">Ilova sinxronlash va maʼlumotlarni qayta ishlash jarayonida jurnallar bu yerda paydo bo'ladi.</string>
     <string name="msg_state_loading">Odatlar va xotiralar tayyorlanmoqda…</string>
     <string name="title_feed_empty">Bu yerda xotira yoʻq</string>
     <string name="title_state_loading">Maʼlumotlar yuklanmoqda</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -240,8 +240,10 @@
     <string name="demo_habit_early_sleep">23点前睡觉</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">检查URL和访问令牌，然后重试。</string>
     <string name="msg_feed_empty_all">创建后，你的备忘录会显示在这里。</string>
     <string name="msg_feed_empty_filtered">没有符合此筛选条件的备忘录。</string>
+    <string name="msg_logs_empty_hint">应用同步和处理数据时，日志会显示在此处。</string>
     <string name="msg_state_loading">正在准备习惯和备忘录…</string>
     <string name="title_feed_empty">这里还没有备忘录</string>
     <string name="title_state_loading">正在加载数据</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -240,8 +240,10 @@
     <string name="demo_habit_early_sleep">Sleep by 11pm</string>
 
     <!-- State panels -->
+    <string name="msg_connection_failed_hint">Check the URL and access token, then try again.</string>
     <string name="msg_feed_empty_all">Your memos will appear here once created.</string>
     <string name="msg_feed_empty_filtered">No memos match this filter.</string>
+    <string name="msg_logs_empty_hint">Logs appear here as the app syncs and processes data.</string>
     <string name="msg_state_loading">Setting up your habits and memos…</string>
     <string name="title_feed_empty">No memos here</string>
     <string name="title_state_loading">Loading your data</string>

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/LogViewer.kt
@@ -33,6 +33,7 @@ private val FontSize = 11.sp
 fun LogViewer(
   logs: List<LogEntry>,
   emptyMessage: String,
+  emptyHint: String,
   modifier: Modifier = Modifier,
 ) {
   LazyColumn(
@@ -47,11 +48,18 @@ fun LogViewer(
     }
     if (logs.isEmpty()) {
       item {
-        Text(
-          emptyMessage,
-          style = MaterialTheme.typography.bodyMedium,
-          color = MaterialTheme.colorScheme.onSurfaceVariant,
-        )
+        Column(verticalArrangement = Arrangement.spacedBy(ItemSpacing)) {
+          Text(
+            emptyMessage,
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+          Text(
+            emptyHint,
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
+        }
       }
     }
   }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -8,8 +9,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -41,10 +44,27 @@ fun EditConfigWarningDialog(
       )
     },
     text = {
-      Text(
-        text = stringResource(Res.string.msg_edit_config_warning),
-        style = MaterialTheme.typography.bodyMedium,
-      )
+      val fullText = stringResource(Res.string.msg_edit_config_warning)
+      val paragraphs = remember(fullText) { fullText.split("\n\n") }
+      Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
+        paragraphs.forEachIndexed { index, paragraph ->
+          Text(
+            text = paragraph,
+            style =
+              if (index == 0) {
+                MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
+              } else {
+                MaterialTheme.typography.bodySmall
+              },
+            color =
+              if (index == 0) {
+                MaterialTheme.colorScheme.onSurface
+              } else {
+                MaterialTheme.colorScheme.onSurfaceVariant
+              },
+          )
+        }
+      }
     },
     confirmButton = {
       Button(onClick = { dispatch(HabitsAction.ConfigWarning.CreateNewConfigInstead) }) {

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncLogDialog.kt
@@ -14,6 +14,7 @@ import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_clear
 import space.be1ski.vibits.core.strings.generated.action_close
+import space.be1ski.vibits.core.strings.generated.msg_logs_empty_hint
 import space.be1ski.vibits.core.strings.generated.msg_no_logs
 import space.be1ski.vibits.core.strings.generated.title_sync_logs
 import space.be1ski.vibits.core.ui.LogViewer
@@ -40,6 +41,7 @@ fun SyncLogDialog(
       LogViewer(
         logs = syncLogs,
         emptyMessage = stringResource(Res.string.msg_no_logs),
+        emptyHint = stringResource(Res.string.msg_logs_empty_hint),
       )
     },
     confirmButton = {

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -48,8 +48,10 @@ import space.be1ski.vibits.core.strings.generated.mode_quick_online_desc
 import space.be1ski.vibits.core.strings.generated.mode_quick_online_title
 import space.be1ski.vibits.core.strings.generated.mode_select_subtitle
 import space.be1ski.vibits.core.strings.generated.mode_select_title
+import space.be1ski.vibits.core.strings.generated.msg_connection_failed_hint
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.form.CredentialFields
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.core.ui.form.credentialValidationErrorMessage
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
@@ -196,6 +198,13 @@ private fun CredentialsSetupDialog(
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodySmall,
           )
+          if (error == CredentialValidationError.CONNECTION_FAILED) {
+            Text(
+              text = stringResource(Res.string.msg_connection_failed_hint),
+              style = MaterialTheme.typography.bodySmall,
+              color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+          }
         }
       }
     },

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -100,6 +100,7 @@ import space.be1ski.vibits.core.strings.generated.mode_offline_title
 import space.be1ski.vibits.core.strings.generated.mode_online_title
 import space.be1ski.vibits.core.strings.generated.msg_export_failed
 import space.be1ski.vibits.core.strings.generated.msg_export_success
+import space.be1ski.vibits.core.strings.generated.msg_logs_empty_hint
 import space.be1ski.vibits.core.strings.generated.msg_no_logs
 import space.be1ski.vibits.core.strings.generated.msg_reset_choose_option
 import space.be1ski.vibits.core.strings.generated.msg_restart_required
@@ -639,6 +640,7 @@ private fun LogsDialog(
       LogViewer(
         logs = logs,
         emptyMessage = stringResource(Res.string.msg_no_logs),
+        emptyHint = stringResource(Res.string.msg_logs_empty_hint),
       )
     },
     confirmButton = {


### PR DESCRIPTION
## Summary
- Improve visual structure in long-text dialogs (EditConfigWarning: bold summary paragraph, lighter secondary text)
- Add guidance hint to empty logs state
- Show recovery hint below credentials connection failure

## Changes
- `EditConfigWarningDialog`: split single text block into paragraphs with font weight/color hierarchy
- `LogViewer`: add required `emptyHint` parameter, update both callers
- `ModeSelectionScreen`: show `msg_connection_failed_hint` below CONNECTION_FAILED error
- 2 new string resources with translations for all 20 locales

## Test plan
- [x] `checkJvm` passes
- [x] `screenshotTests` passes
- [x] Verified affected screenshots: logs dialog, credentials error, edit config warning