### PR TITLE
Fix weekly view gap, add dialog bullets, highlight primary mode card

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -4,6 +4,7 @@ package space.be1ski.vibits.feature.habits.presentation.view
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -166,7 +167,7 @@ private fun StatsScreenContent(
 
   Column(
     verticalArrangement = Arrangement.spacedBy(Indent.s),
-    modifier = columnModifier.testTag(StatsTestTags.STATS_SCREEN),
+    modifier = Modifier.fillMaxSize().then(columnModifier).testTag(StatsTestTags.STATS_SCREEN),
   ) {
     StatsHeaderRow()
     StatsHabitsEmptyState(derived, dispatch)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
@@ -1,8 +1,13 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
@@ -13,6 +18,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -37,32 +43,34 @@ fun EditConfigWarningDialog(
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) },
     modifier = Modifier.testTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG),
-    title = {
-      Text(
-        text = stringResource(Res.string.title_edit_config_warning),
-        style = MaterialTheme.typography.headlineSmall,
-      )
-    },
+    title = { Text(stringResource(Res.string.title_edit_config_warning), style = MaterialTheme.typography.headlineSmall) },
     text = {
-      val fullText = stringResource(Res.string.msg_edit_config_warning)
-      val paragraphs = remember(fullText) { fullText.split("\n\n") }
+      val paragraphs = stringResource(Res.string.msg_edit_config_warning).let { remember(it) { it.split("\n\n") } }
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
         paragraphs.forEachIndexed { index, paragraph ->
-          Text(
-            text = paragraph,
-            style =
-              if (index == 0) {
-                MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold)
-              } else {
-                MaterialTheme.typography.bodySmall
-              },
-            color =
-              if (index == 0) {
-                MaterialTheme.colorScheme.onSurface
-              } else {
-                MaterialTheme.colorScheme.onSurfaceVariant
-              },
-          )
+          if (index == 0) {
+            Text(
+              text = paragraph,
+              style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
+              color = MaterialTheme.colorScheme.onSurface,
+            )
+          } else {
+            Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
+              Box(
+                modifier =
+                  Modifier
+                    .padding(top = BULLET_TOP_OFFSET)
+                    .size(BULLET_SIZE)
+                    .background(MaterialTheme.colorScheme.onSurfaceVariant, CircleShape),
+              )
+              Text(
+                text = paragraph,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                modifier = Modifier.weight(1f),
+              )
+            }
+          }
         }
       }
     },
@@ -83,3 +91,6 @@ fun EditConfigWarningDialog(
     },
   )
 }
+
+private val BULLET_SIZE = 5.dp
+private val BULLET_TOP_OFFSET = 7.dp

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.mode.presentation.view
 
+import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -16,6 +17,7 @@ import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.material.icons.outlined.PlayCircle
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -247,6 +249,18 @@ private fun ModeCard(
 ) {
   OutlinedCard(
     modifier = modifier.fillMaxWidth(),
+    colors =
+      if (isPrimary) {
+        CardDefaults.outlinedCardColors(containerColor = MaterialTheme.colorScheme.primaryContainer.copy(alpha = CARD_HIGHLIGHT_ALPHA))
+      } else {
+        CardDefaults.outlinedCardColors()
+      },
+    border =
+      if (isPrimary) {
+        BorderStroke(CARD_BORDER_WIDTH, MaterialTheme.colorScheme.primary.copy(alpha = CARD_BORDER_ALPHA))
+      } else {
+        CardDefaults.outlinedCardBorder()
+      },
   ) {
     Column(
       modifier = Modifier.padding(Indent.m),
@@ -272,27 +286,16 @@ private fun ModeCard(
         style = MaterialTheme.typography.bodySmall,
         color = MaterialTheme.colorScheme.onSurfaceVariant,
       )
-      val buttonModifier =
-        if (buttonTag != null) {
-          Modifier.fillMaxWidth().testTag(buttonTag)
-        } else {
-          Modifier.fillMaxWidth()
-        }
+      val buttonModifier = Modifier.fillMaxWidth().then(buttonTag?.let { Modifier.testTag(it) } ?: Modifier)
       if (isPrimary) {
-        Button(
-          onClick = onClick,
-          modifier = buttonModifier,
-        ) {
-          Text(title)
-        }
+        Button(onClick = onClick, modifier = buttonModifier) { Text(title) }
       } else {
-        OutlinedButton(
-          onClick = onClick,
-          modifier = buttonModifier,
-        ) {
-          Text(title)
-        }
+        OutlinedButton(onClick = onClick, modifier = buttonModifier) { Text(title) }
       }
     }
   }
 }
+
+private const val CARD_HIGHLIGHT_ALPHA = 0.15f
+private const val CARD_BORDER_ALPHA = 0.5f
+private val CARD_BORDER_WIDTH = 1.5.dp


### PR DESCRIPTION
## Summary
- Fix vertical gap in weekly habits/stats views by pinning content to top
- Add bullet point markers to warning dialog detail paragraphs
- Highlight primary mode card with tinted background and border

## Changes
- `StatsScreenContent`: add `fillMaxSize()` to fix pager content vertical centering
- `EditConfigWarningDialog`: use `Box` circle bullets instead of Unicode characters for cross-platform safety
- `ModeCard`: add `primaryContainer` tint and highlighted border for primary card

## Test plan
- [x] `checkJvm` passes
- [x] `screenshotTests` passes
- [x] Verified: weekly gap eliminated, bullets visible, card highlight present