### PR TITLE
Add visual regression to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,6 +90,15 @@ jobs:
           find . -path "*/build/ui-screenshots/*.png" -exec cp {} build/ui-screenshots/ \;
           cd build && zip -r Vibits-${APP_VERSION#v}-screenshots.zip ui-screenshots/
 
+      - name: Visual regression (release-to-release)
+        if: always()
+        uses: reg-viz/reg-actions@v3
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+          image-directory-path: "./build/ui-screenshots"
+          artifact-name: "release-screenshots"
+          enable-antialias: "true"
+
       - name: Upload screenshots to Release
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary
- Add `reg-viz/reg-actions@v3` step to the release workflow's `check-jvm` job
- Uses a separate `release-screenshots` artifact name to keep its own baseline independent from CI
- Produces a visual diff between releases in the Actions workflow summary tab

## Changes
- Added "Visual regression (release-to-release)" step between screenshot collection and release upload

## Test plan
- [ ] Trigger a release and verify the workflow summary shows the visual regression report