### PR TITLE
Polish UI: reduce weekly gap, destructive accents, credentials hint

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">تحقق من الرابط ورمز الوصول، ثم حاول مرة أخرى.</string>
+    <string name="msg_credentials_stored_locally">يتم تخزين بيانات اعتمادك بأمان على هذا الجهاز.</string>
     <string name="msg_feed_empty_all">ستظهر ذكرياتك هنا بعد إنشائها.</string>
     <string name="msg_feed_empty_filtered">لا توجد ذكريات تطابق هذا الفلتر.</string>
     <string name="msg_logs_empty_hint">تظهر السجلات هنا أثناء مزامنة التطبيق ومعالجة البيانات.</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -245,6 +245,7 @@ Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlk
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL və giriş tokenini yoxlayın, sonra yenidən cəhd edin.</string>
+    <string name="msg_credentials_stored_locally">Sizin məlumatlarınız bu cihazda təhlükəsiz saxlanılır.</string>
     <string name="msg_feed_empty_all">Xatirələriniz yaradıldıqdan sonra burada görünəcək.</string>
     <string name="msg_feed_empty_filtered">Bu filtrə uyğun xatirə yoxdur.</string>
     <string name="msg_logs_empty_hint">Tətbiq sinxronlaşdırma və məlumat emal etdikcə jurnallar burada görünəcək.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Праверце URL і токен доступу, потым паспрабуйце зноў.</string>
+    <string name="msg_credentials_stored_locally">Вашы ўліковыя даныя надзейна захоўваюцца на гэтай прыладзе.</string>
     <string name="msg_feed_empty_all">Вашы ўспаміны з\'явяцца тут пасля стварэння.</string>
     <string name="msg_feed_empty_filtered">Няма ўспамінаў па гэтым фільтры.</string>
     <string name="msg_logs_empty_hint">Журналы з\'яўляюцца тут па меры сінхранізацыі і апрацоўкі дадзеных.</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -245,6 +245,7 @@ Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Dat
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Überprüfen Sie die URL und das Zugriffstoken und versuchen Sie es erneut.</string>
+    <string name="msg_credentials_stored_locally">Ihre Anmeldedaten werden sicher auf diesem Gerät gespeichert.</string>
     <string name="msg_feed_empty_all">Deine Erinnerungen erscheinen hier nach dem Erstellen.</string>
     <string name="msg_feed_empty_filtered">Keine Erinnerungen für diesen Filter.</string>
     <string name="msg_logs_empty_hint">Protokolle erscheinen hier, wenn die App synchronisiert und Daten verarbeitet.</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -241,6 +241,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Verifica la URL y el token de acceso, luego intenta de nuevo.</string>
+    <string name="msg_credentials_stored_locally">Tus credenciales se almacenan de forma segura en este dispositivo.</string>
     <string name="msg_feed_empty_all">Tus recuerdos aparecerán aquí una vez creados.</string>
     <string name="msg_feed_empty_filtered">No hay recuerdos con este filtro.</string>
     <string name="msg_logs_empty_hint">Los registros aparecen aquí a medida que la app sincroniza y procesa datos.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -245,6 +245,7 @@ Bonne pratique : créez une nouvelle configuration. Vos données historiques con
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Vérifiez l\'URL et le jeton d\'accès, puis réessayez.</string>
+    <string name="msg_credentials_stored_locally">Vos identifiants sont stockés en toute sécurité sur cet appareil.</string>
     <string name="msg_feed_empty_all">Vos souvenirs apparaîtront ici une fois créés.</string>
     <string name="msg_feed_empty_filtered">Aucun souvenir ne correspond à ce filtre.</string>
     <string name="msg_logs_empty_hint">Les journaux apparaissent ici au fur et à mesure que l\'app synchronise et traite les données.</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL और एक्सेस टोकन जांचें, फिर दोबारा प्रयास करें।</string>
+    <string name="msg_credentials_stored_locally">आपके प्रमाण-पत्र इस डिवाइस पर सुरक्षित रूप से संग्रहीत हैं।</string>
     <string name="msg_feed_empty_all">आपकी यादें बनाने के बाद यहाँ दिखाई देंगी।</string>
     <string name="msg_feed_empty_filtered">इस फ़िल्टर से कोई याद नहीं मिली।</string>
     <string name="msg_logs_empty_hint">ऐप के सिंक और डेटा प्रोसेस करने पर लॉग यहां दिखाई देंगे।</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URLとアクセストークンを確認して、もう一度お試しください。</string>
+    <string name="msg_credentials_stored_locally">認証情報はこのデバイスに安全に保存されます。</string>
     <string name="msg_feed_empty_all">作成されたメモはここに表示されます。</string>
     <string name="msg_feed_empty_filtered">このフィルターに一致するメモはありません。</string>
     <string name="msg_logs_empty_hint">アプリが同期やデータ処理を行うと、ここにログが表示されます。</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">შეამოწმეთ URL და წვდომის ტოკენი, შემდეგ სცადეთ ხელახლა.</string>
+    <string name="msg_credentials_stored_locally">თქვენი ავტორიზაციის მონაცემები უსაფრთხოდ ინახება ამ მოწყობილობაზე.</string>
     <string name="msg_feed_empty_all">შენი მოგონებები აქ გამოჩნდება შექმნის შემდეგ.</string>
     <string name="msg_feed_empty_filtered">ამ ფილტრს მოგონება არ შეესაბამება.</string>
     <string name="msg_logs_empty_hint">ჟურნალები აქ გამოჩნდება, როცა აპი სინქრონიზაციას და მონაცემთა დამუშავებას ახორციელებს.</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL мен кіру токенін тексеріңіз, содан кейін қайталап көріңіз.</string>
+    <string name="msg_credentials_stored_locally">Сіздің тіркелгі деректеріңіз осы құрылғыда қауіпсіз сақталады.</string>
     <string name="msg_feed_empty_all">Естеліктеріңіз жасалғаннан кейін осында пайда болады.</string>
     <string name="msg_feed_empty_filtered">Бұл сүзгіге сәйкес естелік жоқ.</string>
     <string name="msg_logs_empty_hint">Қолданба синхрондалып, деректерді өңдеген сайын журналдар мұнда көрсетіледі.</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL жана кирүү токенин текшериңиз, андан кийин кайра аракет кылыңыз.</string>
+    <string name="msg_credentials_stored_locally">Сиздин каттоо маалыматтарыңыз бул түзмөктө коопсуз сакталат.</string>
     <string name="msg_feed_empty_all">Эскерүүлөрүңүз түзүлгөндөн кийин бул жерде көрүнөт.</string>
     <string name="msg_feed_empty_filtered">Бул чыпкага туура келген эскерүү жок.</string>
     <string name="msg_logs_empty_hint">Колдонмо синхрондошуп, маалыматтарды иштеткенде журналдар бул жерде көрүнөт.</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -245,6 +245,7 @@ Melhor prática: crie uma nova configuração. Seus dados históricos manterão 
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Verifique a URL e o token de acesso e tente novamente.</string>
+    <string name="msg_credentials_stored_locally">Suas credenciais são armazenadas com segurança neste dispositivo.</string>
     <string name="msg_feed_empty_all">Suas memórias aparecerão aqui após serem criadas.</string>
     <string name="msg_feed_empty_filtered">Nenhuma memória corresponde a este filtro.</string>
     <string name="msg_logs_empty_hint">Os registros aparecem aqui conforme o app sincroniza e processa dados.</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -245,6 +245,7 @@ Cea mai bună practică: creează o configurație nouă. Datele tale istorice vo
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Verifică URL-ul și tokenul de acces, apoi încearcă din nou.</string>
+    <string name="msg_credentials_stored_locally">Datele tale de autentificare sunt stocate în siguranță pe acest dispozitiv.</string>
     <string name="msg_feed_empty_all">Amintirile tale vor apărea aici după creare.</string>
     <string name="msg_feed_empty_filtered">Nicio amintire nu corespunde acestui filtru.</string>
     <string name="msg_logs_empty_hint">Jurnalele apar aici pe măsură ce aplicația sincronizează și procesează datele.</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -241,6 +241,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Проверьте URL и токен доступа, затем попробуйте снова.</string>
+    <string name="msg_credentials_stored_locally">Ваши учётные данные надёжно хранятся на этом устройстве.</string>
     <string name="msg_feed_empty_all">Воспоминания появятся здесь после создания.</string>
     <string name="msg_feed_empty_filtered">Нет воспоминаний по этому фильтру.</string>
     <string name="msg_logs_empty_hint">Журналы появляются по мере синхронизации и обработки данных.</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL ва токени дастрасиро санҷед, сипас дубора кӯшиш кунед.</string>
+    <string name="msg_credentials_stored_locally">Маълумоти эътборномаи шумо дар ин дастгоҳ бехатар нигоҳ дошта мешавад.</string>
     <string name="msg_feed_empty_all">Хотираҳои шумо пас аз эҷод дар ин ҷо пайдо мешаванд.</string>
     <string name="msg_feed_empty_filtered">Ягон хотира ба ин филтр мувофиқ нест.</string>
     <string name="msg_logs_empty_hint">Ҳангоми ҳамоҳангсозӣ ва коркарди маълумот журналҳо дар ин ҷо пайдо мешаванд.</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -245,6 +245,7 @@ Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigur
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL we giriş tokenini barlaň, soňra gaýtadan synanyşyň.</string>
+    <string name="msg_credentials_stored_locally">Siziň hasap maglumatlaryňyz bu enjamda ygtybarly saklanýar.</string>
     <string name="msg_feed_empty_all">Ýatlamalarыňyz döredilenden soň bu ýerde görüner.</string>
     <string name="msg_feed_empty_filtered">Bu süzgüçe gabat gelýän ýatlama ýok.</string>
     <string name="msg_logs_empty_hint">Programma sinhronlaşdyranda we maglumatlary işlände žurnallar bu ýerde görkeziler.</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -245,6 +245,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Перевірте URL і токен доступу, потім спробуйте знову.</string>
+    <string name="msg_credentials_stored_locally">Ваші облікові дані надійно зберігаються на цьому пристрої.</string>
     <string name="msg_feed_empty_all">Ваші спогади з\'являться тут після створення.</string>
     <string name="msg_feed_empty_filtered">Немає спогадів за цим фільтром.</string>
     <string name="msg_logs_empty_hint">Журнали з\'являються тут у міру синхронізації та обробки даних.</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -245,6 +245,7 @@ Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfi
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">URL va kirish tokenini tekshiring, keyin qaytadan urinib ko'ring.</string>
+    <string name="msg_credentials_stored_locally">Sizning hisob maʼlumotlaringiz ushbu qurilmada xavfsiz saqlanadi.</string>
     <string name="msg_feed_empty_all">Xotiralaringiz yaratilgandan keyin bu yerda koʻrinadi.</string>
     <string name="msg_feed_empty_filtered">Bu filtrga mos xotira topilmadi.</string>
     <string name="msg_logs_empty_hint">Ilova sinxronlash va maʼlumotlarni qayta ishlash jarayonida jurnallar bu yerda paydo bo'ladi.</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -241,6 +241,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">检查URL和访问令牌，然后重试。</string>
+    <string name="msg_credentials_stored_locally">您的凭据安全地存储在此设备上。</string>
     <string name="msg_feed_empty_all">创建后，你的备忘录会显示在这里。</string>
     <string name="msg_feed_empty_filtered">没有符合此筛选条件的备忘录。</string>
     <string name="msg_logs_empty_hint">应用同步和处理数据时，日志会显示在此处。</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -241,6 +241,7 @@
 
     <!-- State panels -->
     <string name="msg_connection_failed_hint">Check the URL and access token, then try again.</string>
+    <string name="msg_credentials_stored_locally">Your credentials are stored securely on this device.</string>
     <string name="msg_feed_empty_all">Your memos will appear here once created.</string>
     <string name="msg_feed_empty_filtered">No memos match this filter.</string>
     <string name="msg_logs_empty_hint">Logs appear here as the app syncs and processes data.</string>

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -169,7 +169,6 @@ private fun StatsScreenContent(
     verticalArrangement = Arrangement.spacedBy(Indent.s),
     modifier = Modifier.fillMaxSize().then(columnModifier).testTag(StatsTestTags.STATS_SCREEN),
   ) {
-    StatsHeaderRow()
     StatsHabitsEmptyState(derived, dispatch)
     StatsInfoCard(derived, dispatch)
     StatsPostsInfoCard(derived)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -55,7 +55,6 @@ import space.be1ski.vibits.core.strings.generated.format_habits_progress
 import space.be1ski.vibits.core.strings.generated.format_memos_count
 import space.be1ski.vibits.core.strings.generated.format_memos_today
 import space.be1ski.vibits.core.strings.generated.hint_add_habits_config
-import space.be1ski.vibits.core.strings.generated.label_activity
 import space.be1ski.vibits.core.strings.generated.label_habits_config
 import space.be1ski.vibits.core.strings.generated.label_time_day
 import space.be1ski.vibits.core.strings.generated.label_time_evening
@@ -127,11 +126,6 @@ internal fun StatsInfoCard(
       }
     },
   )
-}
-
-@Composable
-internal fun StatsHeaderRow() {
-  Text(stringResource(Res.string.label_activity), style = MaterialTheme.typography.titleMedium)
 }
 
 @Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
@@ -1,6 +1,8 @@
 package space.be1ski.vibits.feature.habits.presentation.view
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -35,7 +37,10 @@ internal fun EmptyDeleteDialog(
     title = { Text(stringResource(Res.string.title_delete_day)) },
     text = { Text(stringResource(Res.string.msg_delete_day_confirm)) },
     confirmButton = {
-      Button(onClick = { dispatch(HabitsAction.Editor.ConfirmDelete) }) {
+      Button(
+        onClick = { dispatch(HabitsAction.Editor.ConfirmDelete) },
+        colors = ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.error),
+      ) {
         Text(stringResource(Res.string.action_delete))
       }
     },

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -36,9 +37,7 @@ fun EditConfigWarningDialog(
   habitsState: HabitsState,
   dispatch: (HabitsAction) -> Unit,
 ) {
-  if (!habitsState.showEditConfigWarning) {
-    return
-  }
+  if (!habitsState.showEditConfigWarning) return
 
   AlertDialog(
     onDismissRequest = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) },
@@ -84,7 +83,10 @@ fun EditConfigWarningDialog(
         TextButton(onClick = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) }) {
           Text(stringResource(Res.string.action_cancel))
         }
-        TextButton(onClick = { dispatch(HabitsAction.ConfigWarning.ConfirmEditExistingConfig) }) {
+        TextButton(
+          onClick = { dispatch(HabitsAction.ConfigWarning.ConfirmEditExistingConfig) },
+          colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+        ) {
           Text(stringResource(Res.string.action_edit_anyway))
         }
       }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -51,6 +51,7 @@ import space.be1ski.vibits.core.strings.generated.mode_quick_online_title
 import space.be1ski.vibits.core.strings.generated.mode_select_subtitle
 import space.be1ski.vibits.core.strings.generated.mode_select_title
 import space.be1ski.vibits.core.strings.generated.msg_connection_failed_hint
+import space.be1ski.vibits.core.strings.generated.msg_credentials_stored_locally
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.form.CredentialFields
 import space.be1ski.vibits.core.ui.form.CredentialValidationError
@@ -194,27 +195,30 @@ private fun CredentialsSetupDialog(
           onTokenChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
           enabled = !state.isValidating,
         )
-        state.error?.let { error ->
+        if (state.error != null) {
           Text(
-            text = credentialValidationErrorMessage(error),
+            text = credentialValidationErrorMessage(state.error),
             color = MaterialTheme.colorScheme.error,
             style = MaterialTheme.typography.bodySmall,
           )
-          if (error == CredentialValidationError.CONNECTION_FAILED) {
+          if (state.error == CredentialValidationError.CONNECTION_FAILED) {
             Text(
               text = stringResource(Res.string.msg_connection_failed_hint),
               style = MaterialTheme.typography.bodySmall,
               color = MaterialTheme.colorScheme.onSurfaceVariant,
             )
           }
+        } else {
+          Text(
+            stringResource(Res.string.msg_credentials_stored_locally),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
         }
       }
     },
     confirmButton = {
-      Button(
-        onClick = { dispatch(ModeSelectionAction.Validation.Submit) },
-        enabled = !state.isValidating,
-      ) {
+      Button(onClick = { dispatch(ModeSelectionAction.Validation.Submit) }, enabled = !state.isValidating) {
         if (state.isValidating) {
           CircularProgressIndicator(
             modifier = Modifier.size(16.dp),
@@ -227,10 +231,7 @@ private fun CredentialsSetupDialog(
       }
     },
     dismissButton = {
-      TextButton(
-        onClick = { dispatch(ModeSelectionAction.Dialog.Dismiss) },
-        enabled = !state.isValidating,
-      ) {
+      TextButton(onClick = { dispatch(ModeSelectionAction.Dialog.Dismiss) }, enabled = !state.isValidating) {
         Text(stringResource(Res.string.action_cancel))
       }
     },


### PR DESCRIPTION
## Summary
- Remove redundant "Activity" header from stats/habits views to reduce gap between range controls and content
- Add destructive styling (error colors) to Delete and "Edit anyway" buttons in dialogs
- Add helper text to credentials dialog when no error is shown

## Changes
- Removed `StatsHeaderRow` ("Activity" text) — tab name already conveys this
- `EmptyDeleteDialog`: Delete button uses `error` container color
- `EditConfigWarningDialog`: "Edit anyway" uses `error` text color
- `CredentialsSetupDialog`: shows "Your credentials are stored securely on this device" below form fields
- New string `msg_credentials_stored_locally` with translations for all 20 locales

## Test plan
- [x] `checkJvm` passes
- [x] Screenshots verified: weekly gap reduced, red buttons visible, credentials hint shown