### PR TITLE
Fix dark theme text color on mode selection screen

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -481,7 +481,7 @@ When modifying UI code, always:
 
 **Infrastructure** (`core/ui/testing`):
 - `runAppUiTest { }` — runs a desktop Compose test at 540x1080 px
-- `setThemedContent(darkTheme = false) { }` — wraps content in `VibitsTheme` + `Surface`
+- `setThemedContent(darkTheme = false) { }` — wraps content in `VibitsTheme` only (no `Surface` — screens must provide their own)
 - `captureInBothThemes("name") { }` — renders content in light and dark theme, saving `<name>.png` and `<name>_dark.png`
 - `saveScreenshot("scenario_name")` — captures all root layers (including dialogs/popups), composites them, saves to `build/ui-screenshots/<scenario>.png`
 

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -1,9 +1,6 @@
 package space.be1ski.vibits.core.ui.test
 
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toAwtImage
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.DesktopComposeUiTest
@@ -31,9 +28,7 @@ fun ComposeUiTest.setThemedContent(
 ) {
   setContent {
     VibitsTheme(darkTheme = darkTheme) {
-      Surface(modifier = Modifier.fillMaxSize()) {
-        content()
-      }
+      content()
     }
   }
 }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -1,7 +1,6 @@
 package space.be1ski.vibits.feature.mode.presentation.view
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -23,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -67,61 +67,62 @@ fun ModeSelectionScreen(
   val state by feature.state.collectAsState()
   val dispatch: (ModeSelectionAction) -> Unit = feature::send
 
-  Column(
-    modifier =
-      Modifier
-        .fillMaxSize()
-        .background(MaterialTheme.colorScheme.background)
-        .padding(Indent.l),
-    horizontalAlignment = Alignment.CenterHorizontally,
-    verticalArrangement = Arrangement.Center,
+  Surface(
+    modifier = Modifier.fillMaxSize(),
+    color = MaterialTheme.colorScheme.background,
   ) {
-    Text(
-      text = stringResource(Res.string.mode_select_title),
-      style = MaterialTheme.typography.headlineMedium,
-      color = MaterialTheme.colorScheme.onBackground,
-    )
-    Spacer(modifier = Modifier.height(Indent.xs))
-    Text(
-      text = stringResource(Res.string.mode_select_subtitle),
-      style = MaterialTheme.typography.bodyMedium,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
-    Spacer(modifier = Modifier.height(Indent.l))
+    Column(
+      modifier = Modifier.fillMaxSize().padding(Indent.l),
+      horizontalAlignment = Alignment.CenterHorizontally,
+      verticalArrangement = Arrangement.Center,
+    ) {
+      Text(
+        text = stringResource(Res.string.mode_select_title),
+        style = MaterialTheme.typography.headlineMedium,
+        color = MaterialTheme.colorScheme.onBackground,
+      )
+      Spacer(modifier = Modifier.height(Indent.xs))
+      Text(
+        text = stringResource(Res.string.mode_select_subtitle),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+      Spacer(modifier = Modifier.height(Indent.l))
 
-    ModeCard(
-      icon = Icons.Outlined.Cloud,
-      title = stringResource(Res.string.mode_online_title),
-      description = stringResource(Res.string.mode_online_desc),
-      isPrimary = true,
-      onClick = { dispatch(ModeSelectionAction.Dialog.Show) },
-      modifier = Modifier.testTag(ModeSelectionTestTags.ONLINE_CARD),
-      buttonTag = ModeSelectionTestTags.ONLINE_BUTTON,
-    )
+      ModeCard(
+        icon = Icons.Outlined.Cloud,
+        title = stringResource(Res.string.mode_online_title),
+        description = stringResource(Res.string.mode_online_desc),
+        isPrimary = true,
+        onClick = { dispatch(ModeSelectionAction.Dialog.Show) },
+        modifier = Modifier.testTag(ModeSelectionTestTags.ONLINE_CARD),
+        buttonTag = ModeSelectionTestTags.ONLINE_BUTTON,
+      )
 
-    Spacer(modifier = Modifier.height(Indent.m))
+      Spacer(modifier = Modifier.height(Indent.m))
 
-    ModeCard(
-      icon = Icons.Outlined.PhoneAndroid,
-      title = stringResource(Res.string.mode_offline_title),
-      description = stringResource(Res.string.mode_offline_desc),
-      isPrimary = false,
-      onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.OFFLINE)) },
-      modifier = Modifier.testTag(ModeSelectionTestTags.OFFLINE_CARD),
-      buttonTag = ModeSelectionTestTags.OFFLINE_BUTTON,
-    )
+      ModeCard(
+        icon = Icons.Outlined.PhoneAndroid,
+        title = stringResource(Res.string.mode_offline_title),
+        description = stringResource(Res.string.mode_offline_desc),
+        isPrimary = false,
+        onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.OFFLINE)) },
+        modifier = Modifier.testTag(ModeSelectionTestTags.OFFLINE_CARD),
+        buttonTag = ModeSelectionTestTags.OFFLINE_BUTTON,
+      )
 
-    Spacer(modifier = Modifier.height(Indent.m))
+      Spacer(modifier = Modifier.height(Indent.m))
 
-    ModeCard(
-      icon = Icons.Outlined.PlayCircle,
-      title = stringResource(Res.string.mode_demo_title),
-      description = stringResource(Res.string.mode_demo_desc),
-      isPrimary = false,
-      onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO)) },
-      modifier = Modifier.testTag(ModeSelectionTestTags.DEMO_CARD),
-      buttonTag = ModeSelectionTestTags.DEMO_BUTTON,
-    )
+      ModeCard(
+        icon = Icons.Outlined.PlayCircle,
+        title = stringResource(Res.string.mode_demo_title),
+        description = stringResource(Res.string.mode_demo_desc),
+        isPrimary = false,
+        onClick = { dispatch(ModeSelectionAction.Selection.SelectMode(AppMode.DEMO)) },
+        modifier = Modifier.testTag(ModeSelectionTestTags.DEMO_CARD),
+        buttonTag = ModeSelectionTestTags.DEMO_BUTTON,
+      )
+    }
   }
 
   ModeSelectionDialogs(state = state, dispatch = dispatch)


### PR DESCRIPTION
## Summary
- `ModeSelectionScreen` used `.background()` which doesn't set `LocalContentColor`, causing card text to be black in dark theme
- `setThemedContent` wrapped content in `Surface` which masked this bug in screenshot tests

## Changes
- `ModeSelectionScreen.kt`: replace `.background()` with `Surface` to properly provide `LocalContentColor`
- `ScreenshotCapture.kt`: remove `Surface` wrapper from `setThemedContent` so tests match real app rendering
- Updated AGENTS.md docs

## Test plan
- [x] `checkJvm` passes
- [x] Dark theme screenshots show correct white text on cards
- [x] Light theme screenshots unchanged
- [x] Onboarding + loading screenshots still render correctly (they have their own `Surface`)


🤖 Generated with [Claude Code](https://claude.com/claude-code)