### PR TITLE
Reduce reg-actions screenshot retention to 7 days

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,6 +63,7 @@ jobs:
           artifact-name: "ui-screenshots"
           comment-report-format: "summarized"
           enable-antialias: "true"
+          retention-days: "7"
 
   check-ios:
     runs-on: macos-latest


### PR DESCRIPTION
## Summary
- Set `retention-days: 7` for reg-actions to reduce `reg_actions` branch bloat (was default 30 days)

## Test plan
- [x] CI workflow syntax is valid