### PR TITLE
Migrate codebase to runSuspendCatching and harden cancellation handling

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -34,8 +34,6 @@ val runCatchingBaseline = setOf(
   "ConnectionTesterImpl.kt",
   "CreateFirstHabitUseCase.kt",
   "CreateFirstCheckInUseCase.kt",
-  "SyncOperationApplier.kt",
-  "SyncEngineImpl.kt",
 )
 
 val coreModulePrefix = ":core:"

--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -26,10 +26,6 @@ val featureDependencyPattern = Regex("""projects\.feature\.|project\(":feature:"
 val rawRunCatchingPattern = Regex("""\brunCatching\s*[\(\{]""")
 val suspendPattern = Regex("""\bsuspend\b""")
 
-// Baseline: existing files with raw runCatching that will be migrated in follow-up PRs.
-// Remove entries as files are migrated to runSuspendCatching.
-val runCatchingBaseline = emptySet<String>()
-
 val coreModulePrefix = ":core:"
 val featureModulePrefix = ":feature:"
 val composableAnnotation = "@Composable"
@@ -94,7 +90,6 @@ fun checkRawRunCatching(
 ) {
   if (!sourceSet.endsWith("Main")) return
   if (fileName == "RunSuspendCatching.kt") return
-  if (fileName in runCatchingBaseline) return
   if (!suspendPattern.containsMatchIn(content)) return
 
   lines.forEachIndexed { index, line ->

--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -28,13 +28,7 @@ val suspendPattern = Regex("""\bsuspend\b""")
 
 // Baseline: existing files with raw runCatching that will be migrated in follow-up PRs.
 // Remove entries as files are migrated to runSuspendCatching.
-val runCatchingBaseline = setOf(
-  "SaveDailyHabitMemoUseCase.kt",
-  "OnlineMemosRepository.kt",
-  "ConnectionTesterImpl.kt",
-  "CreateFirstHabitUseCase.kt",
-  "CreateFirstCheckInUseCase.kt",
-)
+val runCatchingBaseline = emptySet<String>()
 
 val coreModulePrefix = ":core:"
 val featureModulePrefix = ":feature:"

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.extractCompletedHabits
@@ -52,7 +53,7 @@ class SaveDailyHabitMemoUseCase(
 
       Log.d(TAG, "Saving daily memo for date: $date")
 
-      runCatching {
+      runSuspendCatching {
         // Get current cached memos to check for existing daily memo
         val cachedMemos = memosRepository.cachedMemos()
         val existingMemo =
@@ -95,7 +96,7 @@ class SaveDailyHabitMemoUseCase(
     mutex.withLock {
       Log.d(TAG, "Toggling habit $habitTag for date $date")
 
-      runCatching {
+      runSuspendCatching {
         // Get current cached memos
         val cachedMemos = memosRepository.cachedMemos()
         val existingMemoInfo =

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
@@ -12,6 +13,7 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.feature.memos.domain.test.FakeMemosRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SaveDailyHabitMemoUseCaseTest {
@@ -243,6 +245,42 @@ class SaveDailyHabitMemoUseCaseTest {
 
       assertTrue(result is SaveDailyMemoResult.Deleted)
       assertEquals(0, repository.memos.size)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when invoke cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          cachedMemosResult = emptyList()
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val useCase = SaveDailyHabitMemoUseCase(repository)
+
+      assertFailsWith<CancellationException> {
+        useCase("#habits/daily 2026-01-30\n\nexercise")
+      }
+    }
+
+  @Test
+  fun `when toggleHabit cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          cachedMemosResult = emptyList()
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val useCase = SaveDailyHabitMemoUseCase(repository)
+      val config =
+        listOf(
+          HabitConfig(tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF000000)),
+        )
+
+      assertFailsWith<CancellationException> {
+        useCase.toggleHabit(LocalDate(2026, 1, 30), "#habits/exercise", config)
+      }
     }
 
   @Test

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandler.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.habits.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.model.SaveDailyMemoResult
 import space.be1ski.vibits.feature.habits.domain.usecase.SaveDailyHabitMemoUseCase
@@ -51,7 +52,7 @@ class HabitsMemoEffectHandler(
     actions {
       if (effect.content.isConfigTag()) {
         Log.d(TAG, "Creating config memo")
-        runCatching { memosRepository.createMemo(effect.content) }
+        runSuspendCatching { memosRepository.createMemo(effect.content) }
           .onSuccess { memo ->
             Log.d(TAG, "Config memo created: ${memo.name}")
             emit(HabitsAction.Response.MemoCreated(memo))
@@ -86,7 +87,7 @@ class HabitsMemoEffectHandler(
   private fun handleUpdateMemo(effect: HabitsEffect.UpdateMemo): Flow<HabitsAction> =
     actions {
       Log.d(TAG, "Updating habit memo: ${effect.name}")
-      runCatching { memosRepository.updateMemo(effect.name, effect.content) }
+      runSuspendCatching { memosRepository.updateMemo(effect.name, effect.content) }
         .onSuccess { memo -> emit(HabitsAction.Response.MemoUpdated(memo)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to update habit memo", error)
@@ -97,7 +98,7 @@ class HabitsMemoEffectHandler(
   private fun handleDeleteMemo(effect: HabitsEffect.DeleteMemo): Flow<HabitsAction> =
     actions {
       Log.d(TAG, "Deleting habit memo: ${effect.name}")
-      runCatching { memosRepository.deleteMemo(effect.name) }
+      runSuspendCatching { memosRepository.deleteMemo(effect.name) }
         .onSuccess { emit(HabitsAction.Response.MemoDeleted(effect.name)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to delete habit memo", error)

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandlerTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/effect/HabitsMemoEffectHandlerTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.habits.presentation.effect
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
@@ -12,6 +13,7 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.feature.memos.domain.test.FakeMemosRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 
 class HabitsMemoEffectHandlerTest {
@@ -279,6 +281,50 @@ class HabitsMemoEffectHandlerTest {
       val action = actions[0]
       assertIs<HabitsAction.Response.MemoOperationFailed>(action)
       assertEquals("Delete failed", action.error)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when CreateMemo config cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val handler = createHandler(repository)
+
+      assertFailsWith<CancellationException> {
+        handler(HabitsEffect.CreateMemo("#habits/config\ntest")).toList()
+      }
+    }
+
+  @Test
+  fun `when UpdateMemo cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          updateMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val handler = createHandler(repository)
+
+      assertFailsWith<CancellationException> {
+        handler(HabitsEffect.UpdateMemo("memos/1", "updated")).toList()
+      }
+    }
+
+  @Test
+  fun `when DeleteMemo cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          deleteMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val handler = createHandler(repository)
+
+      assertFailsWith<CancellationException> {
+        handler(HabitsEffect.DeleteMemo("memos/1")).toList()
+      }
     }
 
   // ========== Helper Classes ==========

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
@@ -9,6 +9,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import space.be1ski.vibits.core.platform.app.AppDetailsProvider
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.env.LocalConfigProvider
@@ -79,6 +80,7 @@ abstract class AppGraph {
     fun getAppScope(): CoroutineScope = getGraph().appCoroutineScope
 
     fun resetGraph() {
+      instance?.appCoroutineScope?.cancel()
       instance = null
     }
   }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
@@ -19,7 +20,7 @@ class ConnectionTesterImpl(
     token: String,
   ): Result<Unit> {
     Log.d(TAG, "Testing connection...")
-    return runCatching {
+    return runSuspendCatching {
       memosApi.listMemos(
         baseUrl = baseUrl,
         token = token,

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.requireFilled
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
@@ -49,7 +50,7 @@ class OnlineMemosRepository(
     } while (nextPageToken != null && pages < MemosPagination.MAX_PAGES && allMemos.isNotEmpty())
 
     Log.i(TAG, "Loaded ${allMemos.size} memos in $pages pages")
-    runCatching { memoCache.replaceMemos(allMemos) }
+    runSuspendCatching { memoCache.replaceMemos(allMemos) }
       .onSuccess { Log.d(TAG, "Cache updated") }
       .onFailure { Log.e(TAG, "Cache update failed", it) }
     return allMemos
@@ -74,7 +75,7 @@ class OnlineMemosRepository(
         content = content,
       )
     val updated = MemoMapper.toDomain(dto)
-    runCatching { memoCache.upsertMemo(updated) }
+    runSuspendCatching { memoCache.upsertMemo(updated) }
     Log.i(TAG, "Updated memo: $name")
     return updated
   }
@@ -89,7 +90,7 @@ class OnlineMemosRepository(
         content = content,
       )
     val created = MemoMapper.toDomain(dto)
-    runCatching { memoCache.upsertMemo(created) }
+    runSuspendCatching { memoCache.upsertMemo(created) }
     Log.i(TAG, "Created memo: ${created.name}")
     return created
   }
@@ -102,7 +103,7 @@ class OnlineMemosRepository(
       token = token,
       name = name,
     )
-    runCatching { memoCache.deleteMemo(name) }
+    runSuspendCatching { memoCache.deleteMemo(name) }
     Log.i(TAG, "Deleted memo: $name")
   }
 }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
@@ -14,8 +14,8 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
-import kotlinx.coroutines.CancellationException
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.dto.CreateMemoRequestDto
 import space.be1ski.vibits.feature.memos.data.remote.dto.ListMemosResponseDto
@@ -28,7 +28,6 @@ private fun String.normalizeBaseUrl(): String = trim().trimEnd('/')
 
 @Inject
 @SingleIn(AppScope::class)
-@Suppress("TooGenericExceptionCaught")
 class MemosApi(
   private val httpClient: HttpClient,
 ) {
@@ -40,7 +39,7 @@ class MemosApi(
   ): ListMemosResponseDto {
     val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/memos"
     Log.i(TAG, "GET $fullUrl")
-    return try {
+    return runSuspendCatching {
       val response: ListMemosResponseDto =
         httpClient
           .get(fullUrl) {
@@ -53,12 +52,9 @@ class MemosApi(
           }.body()
       Log.i(TAG, "GET $fullUrl -> OK, ${response.memos.size} memos")
       response
-    } catch (ce: CancellationException) {
-      throw ce
-    } catch (e: Exception) {
+    }.onFailure { e ->
       Log.e(TAG, "GET $fullUrl -> FAILED", e)
-      throw e
-    }
+    }.getOrThrow()
   }
 
   suspend fun updateMemo(
@@ -69,7 +65,7 @@ class MemosApi(
   ): MemoDto {
     val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/$name"
     Log.i(TAG, "PATCH $fullUrl")
-    return try {
+    return runSuspendCatching {
       val response: MemoDto =
         httpClient
           .patch(fullUrl) {
@@ -80,12 +76,9 @@ class MemosApi(
           }.body()
       Log.i(TAG, "PATCH $fullUrl -> OK")
       response
-    } catch (ce: CancellationException) {
-      throw ce
-    } catch (e: Exception) {
+    }.onFailure { e ->
       Log.e(TAG, "PATCH $fullUrl -> FAILED", e)
-      throw e
-    }
+    }.getOrThrow()
   }
 
   suspend fun createMemo(
@@ -95,7 +88,7 @@ class MemosApi(
   ): MemoDto {
     val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/memos"
     Log.i(TAG, "POST $fullUrl")
-    return try {
+    return runSuspendCatching {
       val response: MemoDto =
         httpClient
           .post(fullUrl) {
@@ -105,12 +98,9 @@ class MemosApi(
           }.body()
       Log.i(TAG, "POST $fullUrl -> OK")
       response
-    } catch (ce: CancellationException) {
-      throw ce
-    } catch (e: Exception) {
+    }.onFailure { e ->
       Log.e(TAG, "POST $fullUrl -> FAILED", e)
-      throw e
-    }
+    }.getOrThrow()
   }
 
   suspend fun deleteMemo(
@@ -120,16 +110,13 @@ class MemosApi(
   ) {
     val fullUrl = "${baseUrl.normalizeBaseUrl()}/api/v1/$name"
     Log.i(TAG, "DELETE $fullUrl")
-    try {
+    runSuspendCatching {
       httpClient.delete(fullUrl) {
         header(HttpHeaders.Authorization, "Bearer $token")
       }
       Log.i(TAG, "DELETE $fullUrl -> OK")
-    } catch (ce: CancellationException) {
-      throw ce
-    } catch (e: Exception) {
+    }.onFailure { e ->
       Log.e(TAG, "DELETE $fullUrl -> FAILED", e)
-      throw e
-    }
+    }.getOrThrow()
   }
 }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
@@ -14,6 +14,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.dto.CreateMemoRequestDto
@@ -52,6 +53,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "GET $fullUrl -> OK, ${response.memos.size} memos")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "GET $fullUrl -> FAILED", e)
       throw e
@@ -77,6 +80,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "PATCH $fullUrl -> OK")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "PATCH $fullUrl -> FAILED", e)
       throw e
@@ -100,6 +105,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "POST $fullUrl -> OK")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "POST $fullUrl -> FAILED", e)
       throw e
@@ -118,6 +125,8 @@ class MemosApi(
         header(HttpHeaders.Authorization, "Bearer $token")
       }
       Log.i(TAG, "DELETE $fullUrl -> OK")
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "DELETE $fullUrl -> FAILED", e)
       throw e

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImplTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImplTest.kt
@@ -10,10 +10,12 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ConnectionTesterImplTest {
@@ -37,6 +39,17 @@ class ConnectionTesterImplTest {
       val result = tester("https://example.com", "token")
 
       assertTrue(result.isFailure)
+    }
+
+  @Test
+  fun `when api cancelled then CancellationException propagates`() =
+    runTest {
+      val client = createMockClient { throw CancellationException("cancelled") }
+      val tester = ConnectionTesterImpl(MemosApi(client))
+
+      assertFailsWith<CancellationException> {
+        tester("https://example.com", "token")
+      }
     }
 
   private fun createMockClient(

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepositoryTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepositoryTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.test.FakeCredentialsRepository
@@ -159,6 +160,21 @@ class OnlineMemosRepositoryTest {
       repository.deleteMemo("memos/3")
 
       assertEquals("memos/3", cache.deletedName)
+    }
+
+  @Test
+  fun `when listMemos cancelled then CancellationException propagates`() =
+    runRepositoryTest(
+      handler = { throw CancellationException("cancelled") },
+    ) { client ->
+      val repository =
+        OnlineMemosRepository(
+          memosApi = MemosApi(client),
+          credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
+          memoCache = FakeMemoCache(),
+        )
+
+      assertFailsWith<CancellationException> { repository.listMemos() }
     }
 
   @Test

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandler.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadCachedMemosUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadMemosUseCase
@@ -24,14 +25,14 @@ class MemosLoadEffectHandler(
   private fun handleLoadCachedMemos(): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Loading cached memos")
-      runCatching { loadCachedMemos() }
+      runSuspendCatching { loadCachedMemos() }
         .onSuccess { memos -> emit(MemosAction.Loading.CachedMemosLoaded(memos)) }
     }
 
   private fun handleRefreshMemos(): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Refreshing memos from cache")
-      runCatching { loadCachedMemos() }
+      runSuspendCatching { loadCachedMemos() }
         .onSuccess { memos ->
           Log.d(TAG, "Refreshed ${memos.size} memos")
           emit(MemosAction.Loading.MemosLoaded(memos))
@@ -41,7 +42,7 @@ class MemosLoadEffectHandler(
   private fun handleLoadRemoteMemos(): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Loading memos")
-      runCatching { loadMemos() }
+      runSuspendCatching { loadMemos() }
         .onSuccess { memos -> emit(MemosAction.Loading.MemosLoaded(memos)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to load memos", error)

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandler.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.presentation.effect
 import kotlinx.coroutines.flow.Flow
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.usecase.CreateMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.DeleteMemoUseCase
@@ -26,7 +27,7 @@ class MemosWriteEffectHandler(
   private fun handleCreateMemo(effect: MemosEffect.CreateMemo): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Creating memo")
-      runCatching { createMemo(effect.content) }
+      runSuspendCatching { createMemo(effect.content) }
         .onSuccess { memo -> emit(MemosAction.Crud.MemoCreated(memo)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to create memo", error)
@@ -37,7 +38,7 @@ class MemosWriteEffectHandler(
   private fun handleUpdateMemo(effect: MemosEffect.UpdateMemo): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Updating memo: ${effect.name}")
-      runCatching { updateMemo(effect.name, effect.content) }
+      runSuspendCatching { updateMemo(effect.name, effect.content) }
         .onSuccess { memo -> emit(MemosAction.Crud.MemoUpdated(memo)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to update memo", error)
@@ -48,7 +49,7 @@ class MemosWriteEffectHandler(
   private fun handleDeleteMemo(effect: MemosEffect.DeleteMemo): Flow<MemosAction> =
     actions {
       Log.d(TAG, "Deleting memo: ${effect.name}")
-      runCatching { deleteMemo(effect.name) }
+      runSuspendCatching { deleteMemo(effect.name) }
         .onSuccess { emit(MemosAction.Crud.MemoDeleted(effect.name)) }
         .onFailure { error ->
           Log.e(TAG, "Failed to delete memo", error)

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandlerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosLoadEffectHandlerTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.memos.presentation.effect
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -9,6 +10,7 @@ import space.be1ski.vibits.feature.memos.domain.usecase.LoadMemosUseCase
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.time.Clock
 
@@ -181,6 +183,18 @@ class MemosLoadEffectHandlerTest {
       assertEquals(1, actions.size)
       val action = actions[0] as MemosAction.Loading.MemosLoaded
       assertEquals(2, action.memos.size)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when LoadRemoteMemos cancelled then CancellationException propagates`() =
+    runTest {
+      val handler = createHandler(listMemosResult = Result.failure(CancellationException("cancelled")))
+
+      assertFailsWith<CancellationException> {
+        handler(MemosEffect.LoadRemoteMemos).toList()
+      }
     }
 
   // ========== Effect Routing Tests ==========

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandlerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosWriteEffectHandlerTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.memos.presentation.effect
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.feature.memos.domain.model.Memo
@@ -10,6 +11,7 @@ import space.be1ski.vibits.feature.memos.domain.usecase.UpdateMemoUseCase
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertIs
 import kotlin.time.Clock
 
@@ -164,6 +166,38 @@ class MemosWriteEffectHandlerTest {
       assertIs<MemosAction.Crud.OperationFailed>(actions[0])
       val action = actions[0] as MemosAction.Crud.OperationFailed
       assertEquals("Failed to delete memo", action.error)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when CreateMemo cancelled then CancellationException propagates`() =
+    runTest {
+      val handler = createHandler(createMemoResult = Result.failure(CancellationException("cancelled")))
+
+      assertFailsWith<CancellationException> {
+        handler(MemosEffect.CreateMemo("content")).toList()
+      }
+    }
+
+  @Test
+  fun `when UpdateMemo cancelled then CancellationException propagates`() =
+    runTest {
+      val handler = createHandler(updateMemoResult = Result.failure(CancellationException("cancelled")))
+
+      assertFailsWith<CancellationException> {
+        handler(MemosEffect.UpdateMemo("memos/1", "content")).toList()
+      }
+    }
+
+  @Test
+  fun `when DeleteMemo cancelled then CancellationException propagates`() =
+    runTest {
+      val handler = createHandler(deleteMemoResult = Result.failure(CancellationException("cancelled")))
+
+      assertFailsWith<CancellationException> {
+        handler(MemosEffect.DeleteMemo("memos/1")).toList()
+      }
     }
 
   // ========== Effect Routing Tests ==========

--- a/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstCheckInUseCase.kt
+++ b/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstCheckInUseCase.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.onboarding.domain.usecase
 import dev.zacsweers.metro.Inject
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
@@ -14,7 +15,7 @@ class CreateFirstCheckInUseCase(
   private val createMemo: CreateMemoUseCase,
 ) {
   suspend operator fun invoke(date: LocalDate): Result<Unit> =
-    runCatching {
+    runSuspendCatching {
       val memos = memosRepository.cachedMemos()
       val timeZone = TimeZone.currentSystemDefault()
       val configEntries = ExtractHabitsConfigUseCase(memos, timeZone)

--- a/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
+++ b/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.onboarding.domain.usecase
 
 import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.feature.habits.domain.formatHexColor
 import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
@@ -14,7 +15,7 @@ class CreateFirstHabitUseCase(
     name: String,
     color: HabitColor,
   ): Result<Unit> =
-    runCatching {
+    runSuspendCatching {
       val habitTag = name.lowercase().replace(" ", "_")
       val hexColor = formatHexColor(color)
       val content =

--- a/feature/onboarding/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/OnboardingUseCasesTest.kt
+++ b/feature/onboarding/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/OnboardingUseCasesTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.onboarding.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -14,6 +15,7 @@ import space.be1ski.vibits.feature.onboarding.data.OnboardingRepositoryImpl
 import space.be1ski.vibits.feature.onboarding.domain.test.FakeOnboardingStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -234,6 +236,48 @@ class OnboardingUseCasesTest {
       val result = useCase()
 
       assertTrue(result)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when CreateFirstHabitUseCase cancelled then CancellationException propagates`() =
+    runTest {
+      val memosRepository =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val createMemo = CreateMemoUseCase(memosRepository)
+      val useCase = CreateFirstHabitUseCase(createMemo)
+
+      assertFailsWith<CancellationException> {
+        useCase("Exercise", DefaultHabitColor)
+      }
+    }
+
+  @Test
+  fun `when CreateFirstCheckInUseCase cancelled then CancellationException propagates`() =
+    runTest {
+      val habitConfigContent = "#habits/config\nWater | #habits/water"
+      val configCreateTime = LocalDate(2026, 1, 28).atStartOfDayIn(TimeZone.UTC)
+      val memosRepository =
+        FakeMemosRepository().apply {
+          cachedMemosResult =
+            listOf(
+              Memo(
+                name = "memos/1",
+                content = habitConfigContent,
+                createTime = configCreateTime,
+              ),
+            )
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val createMemo = CreateMemoUseCase(memosRepository)
+      val useCase = CreateFirstCheckInUseCase(memosRepository, createMemo)
+
+      assertFailsWith<CancellationException> {
+        useCase(LocalDate(2026, 1, 29))
+      }
     }
 
   @Test

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImpl.kt
@@ -6,6 +6,7 @@ import kotlinx.atomicfu.atomic
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.isFilled
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
@@ -63,7 +64,7 @@ class SyncEngineImpl(
     // Reset any IN_PROGRESS operations from previous crash/kill
     syncQueue.resetInProgressToPending()
 
-    return runCatching {
+    return runSuspendCatching {
       Log.i(TAG, "Starting sync...")
       executeSyncFlow()
     }.getOrElse { e ->
@@ -133,7 +134,7 @@ class SyncEngineImpl(
       return SyncResult.NoCredentials
     }
 
-    return runCatching {
+    return runSuspendCatching {
       Log.i(TAG, "Forcing server sync...")
       val serverMemos = fetchServerMemos()
 
@@ -156,7 +157,7 @@ class SyncEngineImpl(
       return SyncResult.NoCredentials
     }
 
-    return runCatching {
+    return runSuspendCatching {
       Log.i(TAG, "Forcing local sync...")
       val pendingOperations = syncQueue.getPendingOperations()
 

--- a/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
+++ b/feature/sync/data/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplier.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.sync.data
 
 import kotlinx.coroutines.delay
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRemoteSource
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags
@@ -49,7 +50,7 @@ internal class SyncOperationApplier(
 
     for (attempt in 0..retryConfig.maxRetries) {
       val result =
-        runCatching {
+        runSuspendCatching {
           when (operation.type) {
             SyncOperationType.CREATE -> applyCreateOperation(operation)
             SyncOperationType.UPDATE -> applyUpdateOperation(operation)

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImplTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncEngineImplTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.sync.data
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -17,6 +18,7 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncStatus
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertIs
 import kotlin.test.assertTrue
@@ -378,6 +380,44 @@ class SyncEngineImplTest {
       assertTrue(remoteSource.updateCalls > 0)
     }
 
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when performSync cancelled then CancellationException propagates`() =
+    runTest {
+      val cancellingSource =
+        FakeMemosRemoteSource(exceptionToThrow = CancellationException("cancelled"))
+      val (engine, _, _) = createEngine(remoteSource = cancellingSource)
+
+      assertFailsWith<CancellationException> {
+        engine.performSync()
+      }
+    }
+
+  @Test
+  fun `when forceServerSync cancelled then CancellationException propagates`() =
+    runTest {
+      val cancellingSource =
+        FakeMemosRemoteSource(exceptionToThrow = CancellationException("cancelled"))
+      val (engine, _, _) = createEngine(remoteSource = cancellingSource)
+
+      assertFailsWith<CancellationException> {
+        engine.forceServerSync()
+      }
+    }
+
+  @Test
+  fun `when forceLocalSync cancelled then CancellationException propagates`() =
+    runTest {
+      val cancellingSource =
+        FakeMemosRemoteSource(exceptionToThrow = CancellationException("cancelled"))
+      val (engine, _, _) = createEngine(remoteSource = cancellingSource)
+
+      assertFailsWith<CancellationException> {
+        engine.forceLocalSync()
+      }
+    }
+
   // ========== Pagination Tests ==========
 
   @Test
@@ -401,6 +441,7 @@ class SyncEngineImplTest {
     private val memos: List<Memo> = emptyList(),
     private val pages: List<List<Memo>>? = null,
     private val shouldFail: Boolean = false,
+    private val exceptionToThrow: Exception? = null,
   ) : MemosRemoteSource {
     var createCalls = 0
       private set
@@ -417,6 +458,7 @@ class SyncEngineImplTest {
       pageToken: String?,
     ): MemosPage {
       listCalls++
+      exceptionToThrow?.let { throw it }
       if (shouldFail) throw RuntimeException("Remote source error")
 
       if (pages != null) {

--- a/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
+++ b/feature/sync/data/src/commonTest/kotlin/space/be1ski/vibits/feature/sync/data/SyncOperationApplierTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.sync.data
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
@@ -14,6 +15,7 @@ import space.be1ski.vibits.feature.sync.domain.model.SyncStatus
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Clock
 import kotlin.time.Duration.Companion.milliseconds
@@ -482,11 +484,42 @@ class SyncOperationApplierTest {
       assertEquals(SyncOperationStatus.FAILED, fakeQueue.statusHistory["op-1"]?.last())
     }
 
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when operation cancelled then CancellationException propagates without FAILED status`() =
+    runTest {
+      val remoteSource = FakeMemosRemoteSource(exceptionToThrow = CancellationException("cancelled"))
+      val retryConfig = RetryConfig(maxRetries = 3, initialDelay = 1.milliseconds, maxDelay = 10.milliseconds)
+      val (applier, fakeQueue, _) = createApplierWithRetry(retryConfig, remoteSource)
+      val operation =
+        SyncOperation(
+          id = "op-1",
+          type = SyncOperationType.CREATE,
+          memoName = "local_123_456",
+          content = "content",
+          createdAt = Clock.System.now(),
+          status = SyncOperationStatus.PENDING,
+        )
+      fakeQueue.operations.add(operation)
+
+      assertFailsWith<CancellationException> {
+        applier.applyOperations(listOf(operation))
+      }
+
+      // Should not be marked as FAILED — cancellation exits immediately
+      val lastStatus = fakeQueue.statusHistory["op-1"]?.last()
+      assertEquals(SyncOperationStatus.IN_PROGRESS, lastStatus)
+      // Only one attempt — no retries on cancellation
+      assertEquals(1, remoteSource.createCalls)
+    }
+
   // ========== Helper Classes ==========
 
   private class FakeMemosRemoteSource(
     private val shouldFail: Boolean = false,
     private val failUntilCall: Int = 0,
+    private val exceptionToThrow: Exception? = null,
   ) : MemosRemoteSource {
     var createCalls = 0
       private set
@@ -498,6 +531,7 @@ class SyncOperationApplierTest {
 
     private fun checkFail() {
       totalCalls++
+      exceptionToThrow?.let { throw it }
       if (shouldFail || totalCalls < failUntilCall) {
         throw RuntimeException("Remote source error")
       }


### PR DESCRIPTION
## Summary

- Migrate all `runCatching` and `try/catch` patterns to `runSuspendCatching` across the entire codebase
- Cancel app coroutine scope on graph reset to prevent orphaned background jobs
- Remove `runCatchingBaseline` — convention check now enforces policy with zero exceptions

## Changes

**Presentation layer**
- `HabitsMemoEffectHandler` — 3 `runCatching` calls migrated
- `MemosLoadEffectHandler` — 3 calls migrated
- `MemosWriteEffectHandler` — 3 calls migrated

**Domain layer**
- `SaveDailyHabitMemoUseCase` — 2 calls migrated
- `CreateFirstHabitUseCase`, `CreateFirstCheckInUseCase` — 1 call each migrated

**Data layer**
- `SyncEngineImpl` — 3 calls migrated
- `SyncOperationApplier` — 1 call migrated
- `ConnectionTesterImpl` — 1 call migrated
- `OnlineMemosRepository` — 4 cache calls migrated
- `MemosApi` — refactored 4 `try/catch` blocks to `runSuspendCatching`

**Lifecycle**
- `AppGraph.resetGraph()` — cancels `appCoroutineScope` before nulling the instance

**Convention checks**
- Deleted `runCatchingBaseline` variable and its usage

**Tests** — 19 new cancellation tests verifying `CancellationException` propagates correctly

## Test plan

- [x] `checkJvm` passes
- [x] All new tests verify cancellation propagation instead of swallowing
- [x] `SyncOperationApplier` test verifies no FAILED status and no retries on cancel
- [x] Zero remaining baseline entries — convention check enforces policy across entire codebase