### PR TITLE
Migrate domain and data layers to runSuspendCatching

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -28,13 +28,7 @@ val suspendPattern = Regex("""\bsuspend\b""")
 
 // Baseline: existing files with raw runCatching that will be migrated in follow-up PRs.
 // Remove entries as files are migrated to runSuspendCatching.
-val runCatchingBaseline = setOf(
-  "SaveDailyHabitMemoUseCase.kt",
-  "OnlineMemosRepository.kt",
-  "ConnectionTesterImpl.kt",
-  "CreateFirstHabitUseCase.kt",
-  "CreateFirstCheckInUseCase.kt",
-)
+val runCatchingBaseline = emptySet<String>()
 
 val coreModulePrefix = ":core:"
 val featureModulePrefix = ":feature:"

--- a/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
+++ b/feature/habits/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCase.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.extractCompletedHabits
@@ -52,7 +53,7 @@ class SaveDailyHabitMemoUseCase(
 
       Log.d(TAG, "Saving daily memo for date: $date")
 
-      runCatching {
+      runSuspendCatching {
         // Get current cached memos to check for existing daily memo
         val cachedMemos = memosRepository.cachedMemos()
         val existingMemo =
@@ -95,7 +96,7 @@ class SaveDailyHabitMemoUseCase(
     mutex.withLock {
       Log.d(TAG, "Toggling habit $habitTag for date $date")
 
-      runCatching {
+      runSuspendCatching {
         // Get current cached memos
         val cachedMemos = memosRepository.cachedMemos()
         val existingMemoInfo =

--- a/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
+++ b/feature/habits/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/domain/usecase/SaveDailyHabitMemoUseCaseTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.habits.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.test.runTest
@@ -12,6 +13,7 @@ import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
 import space.be1ski.vibits.feature.memos.domain.test.FakeMemosRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class SaveDailyHabitMemoUseCaseTest {
@@ -243,6 +245,42 @@ class SaveDailyHabitMemoUseCaseTest {
 
       assertTrue(result is SaveDailyMemoResult.Deleted)
       assertEquals(0, repository.memos.size)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when invoke cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          cachedMemosResult = emptyList()
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val useCase = SaveDailyHabitMemoUseCase(repository)
+
+      assertFailsWith<CancellationException> {
+        useCase("#habits/daily 2026-01-30\n\nexercise")
+      }
+    }
+
+  @Test
+  fun `when toggleHabit cancelled then CancellationException propagates`() =
+    runTest {
+      val repository =
+        FakeMemosRepository().apply {
+          cachedMemosResult = emptyList()
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val useCase = SaveDailyHabitMemoUseCase(repository)
+      val config =
+        listOf(
+          HabitConfig(tag = "#habits/exercise", label = "Exercise", color = HabitColor(0xFF000000)),
+        )
+
+      assertFailsWith<CancellationException> {
+        useCase.toggleHabit(LocalDate(2026, 1, 30), "#habits/exercise", config)
+      }
     }
 
   @Test

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImpl.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
@@ -19,7 +20,7 @@ class ConnectionTesterImpl(
     token: String,
   ): Result<Unit> {
     Log.d(TAG, "Testing connection...")
-    return runCatching {
+    return runSuspendCatching {
       memosApi.listMemos(
         baseUrl = baseUrl,
         token = token,

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepository.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.memos.data
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metro.SingleIn
 import space.be1ski.vibits.core.platform.di.AppScope
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.auth.domain.model.requireFilled
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
@@ -49,7 +50,7 @@ class OnlineMemosRepository(
     } while (nextPageToken != null && pages < MemosPagination.MAX_PAGES && allMemos.isNotEmpty())
 
     Log.i(TAG, "Loaded ${allMemos.size} memos in $pages pages")
-    runCatching { memoCache.replaceMemos(allMemos) }
+    runSuspendCatching { memoCache.replaceMemos(allMemos) }
       .onSuccess { Log.d(TAG, "Cache updated") }
       .onFailure { Log.e(TAG, "Cache update failed", it) }
     return allMemos
@@ -74,7 +75,7 @@ class OnlineMemosRepository(
         content = content,
       )
     val updated = MemoMapper.toDomain(dto)
-    runCatching { memoCache.upsertMemo(updated) }
+    runSuspendCatching { memoCache.upsertMemo(updated) }
     Log.i(TAG, "Updated memo: $name")
     return updated
   }
@@ -89,7 +90,7 @@ class OnlineMemosRepository(
         content = content,
       )
     val created = MemoMapper.toDomain(dto)
-    runCatching { memoCache.upsertMemo(created) }
+    runSuspendCatching { memoCache.upsertMemo(created) }
     Log.i(TAG, "Created memo: ${created.name}")
     return created
   }
@@ -102,7 +103,7 @@ class OnlineMemosRepository(
       token = token,
       name = name,
     )
-    runCatching { memoCache.deleteMemo(name) }
+    runSuspendCatching { memoCache.deleteMemo(name) }
     Log.i(TAG, "Deleted memo: $name")
   }
 }

--- a/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
+++ b/feature/memos/data/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/data/remote/MemosApi.kt
@@ -14,6 +14,7 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.contentType
+import kotlinx.coroutines.CancellationException
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.data.remote.dto.CreateMemoRequestDto
@@ -52,6 +53,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "GET $fullUrl -> OK, ${response.memos.size} memos")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "GET $fullUrl -> FAILED", e)
       throw e
@@ -77,6 +80,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "PATCH $fullUrl -> OK")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "PATCH $fullUrl -> FAILED", e)
       throw e
@@ -100,6 +105,8 @@ class MemosApi(
           }.body()
       Log.i(TAG, "POST $fullUrl -> OK")
       response
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "POST $fullUrl -> FAILED", e)
       throw e
@@ -118,6 +125,8 @@ class MemosApi(
         header(HttpHeaders.Authorization, "Bearer $token")
       }
       Log.i(TAG, "DELETE $fullUrl -> OK")
+    } catch (ce: CancellationException) {
+      throw ce
     } catch (e: Exception) {
       Log.e(TAG, "DELETE $fullUrl -> FAILED", e)
       throw e

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImplTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ConnectionTesterImplTest.kt
@@ -10,10 +10,12 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.memos.data.remote.MemosApi
 import kotlin.test.Test
+import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 
 class ConnectionTesterImplTest {
@@ -37,6 +39,17 @@ class ConnectionTesterImplTest {
       val result = tester("https://example.com", "token")
 
       assertTrue(result.isFailure)
+    }
+
+  @Test
+  fun `when api cancelled then CancellationException propagates`() =
+    runTest {
+      val client = createMockClient { throw CancellationException("cancelled") }
+      val tester = ConnectionTesterImpl(MemosApi(client))
+
+      assertFailsWith<CancellationException> {
+        tester("https://example.com", "token")
+      }
     }
 
   private fun createMockClient(

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepositoryTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/OnlineMemosRepositoryTest.kt
@@ -11,6 +11,7 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.CancellationException
 import kotlinx.serialization.json.Json
 import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.test.FakeCredentialsRepository
@@ -159,6 +160,21 @@ class OnlineMemosRepositoryTest {
       repository.deleteMemo("memos/3")
 
       assertEquals("memos/3", cache.deletedName)
+    }
+
+  @Test
+  fun `when listMemos cancelled then CancellationException propagates`() =
+    runRepositoryTest(
+      handler = { throw CancellationException("cancelled") },
+    ) { client ->
+      val repository =
+        OnlineMemosRepository(
+          memosApi = MemosApi(client),
+          credentialsRepository = FakeCredentialsRepository(Credentials(baseUrl = "https://example.com", token = "token")),
+          memoCache = FakeMemoCache(),
+        )
+
+      assertFailsWith<CancellationException> { repository.listMemos() }
     }
 
   @Test

--- a/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstCheckInUseCase.kt
+++ b/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstCheckInUseCase.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.onboarding.domain.usecase
 import dev.zacsweers.metro.Inject
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.feature.habits.domain.buildDailyContent
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.MemosRepository
@@ -14,7 +15,7 @@ class CreateFirstCheckInUseCase(
   private val createMemo: CreateMemoUseCase,
 ) {
   suspend operator fun invoke(date: LocalDate): Result<Unit> =
-    runCatching {
+    runSuspendCatching {
       val memos = memosRepository.cachedMemos()
       val timeZone = TimeZone.currentSystemDefault()
       val configEntries = ExtractHabitsConfigUseCase(memos, timeZone)

--- a/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
+++ b/feature/onboarding/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/CreateFirstHabitUseCase.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.onboarding.domain.usecase
 
 import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.feature.habits.domain.formatHexColor
 import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.memos.domain.model.PostTags
@@ -14,7 +15,7 @@ class CreateFirstHabitUseCase(
     name: String,
     color: HabitColor,
   ): Result<Unit> =
-    runCatching {
+    runSuspendCatching {
       val habitTag = name.lowercase().replace(" ", "_")
       val hexColor = formatHexColor(color)
       val content =

--- a/feature/onboarding/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/OnboardingUseCasesTest.kt
+++ b/feature/onboarding/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/onboarding/domain/usecase/OnboardingUseCasesTest.kt
@@ -1,5 +1,6 @@
 package space.be1ski.vibits.feature.onboarding.domain.usecase
 
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -14,6 +15,7 @@ import space.be1ski.vibits.feature.onboarding.data.OnboardingRepositoryImpl
 import space.be1ski.vibits.feature.onboarding.domain.test.FakeOnboardingStore
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
@@ -234,6 +236,48 @@ class OnboardingUseCasesTest {
       val result = useCase()
 
       assertTrue(result)
+    }
+
+  // ========== Cancellation Tests ==========
+
+  @Test
+  fun `when CreateFirstHabitUseCase cancelled then CancellationException propagates`() =
+    runTest {
+      val memosRepository =
+        FakeMemosRepository().apply {
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val createMemo = CreateMemoUseCase(memosRepository)
+      val useCase = CreateFirstHabitUseCase(createMemo)
+
+      assertFailsWith<CancellationException> {
+        useCase("Exercise", DefaultHabitColor)
+      }
+    }
+
+  @Test
+  fun `when CreateFirstCheckInUseCase cancelled then CancellationException propagates`() =
+    runTest {
+      val habitConfigContent = "#habits/config\nWater | #habits/water"
+      val configCreateTime = LocalDate(2026, 1, 28).atStartOfDayIn(TimeZone.UTC)
+      val memosRepository =
+        FakeMemosRepository().apply {
+          cachedMemosResult =
+            listOf(
+              Memo(
+                name = "memos/1",
+                content = habitConfigContent,
+                createTime = configCreateTime,
+              ),
+            )
+          createMemoResult = Result.failure(CancellationException("cancelled"))
+        }
+      val createMemo = CreateMemoUseCase(memosRepository)
+      val useCase = CreateFirstCheckInUseCase(memosRepository, createMemo)
+
+      assertFailsWith<CancellationException> {
+        useCase(LocalDate(2026, 1, 29))
+      }
     }
 
   @Test


### PR DESCRIPTION
## Summary

- Migrate all `runCatching` → `runSuspendCatching` in domain use cases, data repositories, and API layer
- Add `CancellationException` guards to `MemosApi` catch blocks
- Clear `runCatchingBaseline` — all files now migrated

## Changes

- **Habits domain**: `SaveDailyHabitMemoUseCase` — 2 `runCatching` calls migrated + 2 cancellation tests
- **Onboarding domain**: `CreateFirstHabitUseCase` (1 call), `CreateFirstCheckInUseCase` (1 call) migrated + 2 cancellation tests
- **Memos data**: `ConnectionTesterImpl` (1 call), `OnlineMemosRepository` (4 cache calls) migrated + 2 cancellation tests
- **Memos API**: `MemosApi` — added explicit `catch (CancellationException)` before generic `catch (Exception)` in all 4 methods
- **Convention plugin**: cleared `runCatchingBaseline` to empty set

## Test plan

- [x] `checkJvm` passes (ktlint, detekt, compile, all tests)
- [x] New cancellation tests verify `CancellationException` propagates in all migrated paths
- [x] Zero remaining baseline entries — convention check now enforces policy across entire codebase