### PR TITLE
Cancel app coroutine scope on graph reset

### DIFF
--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
@@ -9,6 +9,7 @@ import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import space.be1ski.vibits.core.platform.app.AppDetailsProvider
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.env.LocalConfigProvider
@@ -79,6 +80,7 @@ abstract class AppGraph {
     fun getAppScope(): CoroutineScope = getGraph().appCoroutineScope
 
     fun resetGraph() {
+      instance?.appCoroutineScope?.cancel()
       instance = null
     }
   }


### PR DESCRIPTION
## Summary

- Cancel the `appCoroutineScope` before nulling the graph instance in `resetGraph()`
- Prevents orphaned background jobs from the old graph surviving a mode switch or app reset

## Changes

- **AppGraph.kt**: `resetGraph()` now calls `instance?.appCoroutineScope?.cancel()` before `instance = null`

## Test plan

- [x] `checkJvm` passes
- [x] `AppGraph` lives in `di/` package (excluded from unit test coverage by design)
- [x] Behavior verified through existing app reset flow in `AppRoot`