### PR TITLE
Remove runCatchingBaseline from convention checks

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -26,10 +26,6 @@ val featureDependencyPattern = Regex("""projects\.feature\.|project\(":feature:"
 val rawRunCatchingPattern = Regex("""\brunCatching\s*[\(\{]""")
 val suspendPattern = Regex("""\bsuspend\b""")
 
-// Baseline: existing files with raw runCatching that will be migrated in follow-up PRs.
-// Remove entries as files are migrated to runSuspendCatching.
-val runCatchingBaseline = emptySet<String>()
-
 val coreModulePrefix = ":core:"
 val featureModulePrefix = ":feature:"
 val composableAnnotation = "@Composable"
@@ -94,7 +90,6 @@ fun checkRawRunCatching(
 ) {
   if (!sourceSet.endsWith("Main")) return
   if (fileName == "RunSuspendCatching.kt") return
-  if (fileName in runCatchingBaseline) return
   if (!suspendPattern.containsMatchIn(content)) return
 
   lines.forEachIndexed { index, line ->


### PR DESCRIPTION
## Summary

- Remove the `runCatchingBaseline` variable and its usage from convention checks
- All files have been migrated, so the baseline mechanism is no longer needed

## Changes

- **vibits.checks.structure.gradle.kts**: deleted `runCatchingBaseline` set and its check in `checkRawRunCatching`

## Test plan

- [x] `checkJvm` passes