### PR TITLE
Minimize outdated screenshot comments and fix screenshotTests task

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,7 @@ jobs:
           image-directory-path: "./build/ui-screenshots"
           artifact-name: "ui-screenshots"
           comment-report-format: "summarized"
+          outdated-comment-action: "minimize"
           enable-antialias: "true"
           retention-days: "7"
 

--- a/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
@@ -7,6 +7,7 @@ val outputDir: File = rootProject.layout.buildDirectory.dir("ui-screenshots").ge
 tasks.register("screenshotTests") {
   group = "verification"
   description = "Runs screenshot tests and collects screenshots into build/ui-screenshots"
+  notCompatibleWithConfigurationCache("walks subproject build directories at execution time")
 
   subprojects {
     plugins.withId("org.jetbrains.kotlin.multiplatform") {


### PR DESCRIPTION
## Summary

- Collapse old reg-actions screenshot comments on PRs to reduce spam
- Fix `screenshotTests` task failing due to configuration cache incompatibility

## Changes

- **ci.yml**: added `outdated-comment-action: "minimize"` to reg-actions step
- **vibits.checks.screenshots.gradle.kts**: added `notCompatibleWithConfigurationCache` to `screenshotTests` task