### PR TITLE
Fix screenshotTests task not collecting screenshots

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
@@ -1,8 +1,17 @@
-val screenshotDirs: List<File> = subprojects
-  .filter { it.plugins.hasPlugin("org.jetbrains.kotlin.multiplatform") }
-  .map { it.layout.buildDirectory.dir("ui-screenshots").get().asFile }
-
 val outputDir: File = rootProject.layout.buildDirectory.dir("ui-screenshots").get().asFile
+
+// Screenshot PNGs are side-effects of desktopTest not declared as task outputs,
+// so Gradle's build cache doesn't restore them. Force re-execution when collecting screenshots.
+if (gradle.startParameter.taskNames.any { it.contains("screenshotTests") }) {
+  subprojects {
+    plugins.withId("org.jetbrains.kotlin.multiplatform") {
+      tasks.matching { it.name == "desktopTest" }.configureEach {
+        outputs.cacheIf { false }
+        outputs.upToDateWhen { false }
+      }
+    }
+  }
+}
 
 tasks.register("screenshotTests") {
   group = "verification"
@@ -18,7 +27,8 @@ tasks.register("screenshotTests") {
   doLast {
     outputDir.deleteRecursively()
     outputDir.mkdirs()
-    screenshotDirs.forEach { dir ->
+    subprojects.forEach { subproject ->
+      val dir = subproject.layout.buildDirectory.dir("ui-screenshots").get().asFile
       if (dir.exists()) {
         dir.walkTopDown().filter { it.isFile && it.extension == "png" }.forEach { file ->
           file.copyTo(File(outputDir, file.name), overwrite = true)


### PR DESCRIPTION
## Summary
- `screenshotTests` task succeeded but `build/ui-screenshots/` was always empty

## Changes
- **Lazy directory lookup**: `screenshotDirs` was computed eagerly before subproject plugins were applied, so the filtered list was always empty. Moved lookup into `doLast`
- **Build cache bypass**: Screenshot PNGs are side-effects not declared as `desktopTest` outputs, so Gradle's build cache restored test results without re-running tests. Now disables cache for `desktopTest` when `screenshotTests` is requested (normal `checkJvm`/`checkAll` runs unaffected)

## Test plan
- [x] `./gradlew screenshotTests` produces 56 PNGs in `build/ui-screenshots/`
- [x] Pre-commit hook passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)