### PR TITLE
Unify dialog button ordering and improve warning text clarity

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">إنشاء مذكرة</string>
     <string name="action_continue">متابعة</string>
     <string name="action_delete">حذف</string>
+    <string name="action_details">التفاصيل</string>
     <string name="action_add_first_habit">إضافة أول عادة</string>
     <string name="action_go_to_dashboard">الانتقال إلى لوحة التحكم</string>
     <string name="action_hide_details">إخفاء التفاصيل</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">تم اكتشاف %1$d تعارض</string>
     <string name="format_active_since">نشط منذ %1$s</string>
     <string name="msg_connection_failed">فشل الاتصال</string>
-    <string name="msg_edit_config_warning">أنت على وشك تعديل تكوين موجود. سيؤثر ذلك على جميع البيانات التاريخية.
-
-لا يُنصح بتعديل تكوين قديم لأنه يغيّر كيفية ظهور بياناتك السابقة. على سبيل المثال، إذا أضفت عادة جديدة فستظهر جميع الأيام السابقة على أنها «غير مكتملة» رغم أنها لم تكن موجودة حينها.
-
-أفضل ممارسة: أنشئ تكوينًا جديدًا. ستبقى بياناتك التاريخية على التكوين القديم، وستستخدم البيانات الجديدة التكوين الجديد.</string>
+    <string name="msg_edit_config_warning">تعديل هذا التكوين سيؤثر على جميع البيانات التاريخية. ستظهر العادات الجديدة على أنها «غير مكتملة» للأيام السابقة.</string>
+    <string name="msg_edit_config_warning_detail">أفضل ممارسة: أنشئ تكوينًا جديدًا. ستبقى البيانات التاريخية على التكوين القديم، والبيانات الجديدة ستستخدم التكوين الجديد.</string>
     <string name="msg_delete_config_warning">هل أنت متأكد من حذف هذه الإعدادات؟ سيتم حذف منشور التكوين من مذكراتك نهائيًا.</string>
     <string name="msg_delete_day_confirm">لم يتم اختيار عادات. سيتم حذف إدخال اليوم.</string>
     <string name="msg_delete_day_warning">هل أنت متأكد من رغبتك في حذف إدخال هذا اليوم؟ سيؤدي هذا إلى إزالة منشور التتبع من مذكراتك بشكل دائم.</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Qeyd yarat</string>
     <string name="action_continue">Davam et</string>
     <string name="action_delete">Sil</string>
+    <string name="action_details">Təfərrüatlar</string>
     <string name="action_add_first_habit">İlk vərdişi əlavə et</string>
     <string name="action_go_to_dashboard">Panelə get</string>
     <string name="action_hide_details">Detalları gizlət</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d münaqişə aşkarlandı</string>
     <string name="format_active_since">%1$s-dən aktiv</string>
     <string name="msg_connection_failed">Əlaqə xətası</string>
-    <string name="msg_edit_config_warning">Mövcud konfiqurasiyanı redaktə etmək üzrəsiniz. Bu, bütün tarixi məlumatlara təsir edəcək.
-
-Köhnə konfiqurasiyanı redaktə etmək tövsiyə olunmur, çünki bu, əvvəlki məlumatların görünüşünü dəyişir. Məsələn, yeni bir vərdiş əlavə etsəniz, keçmiş günlərin hamısında o, «tamamlanmayıb» kimi görünəcək, halbuki o vaxt mövcud deyildi.
-
-Ən yaxşı təcrübə: yeni konfiqurasiya yaradın. Tarixi məlumatlar köhnə konfiqurasiyada qalacaq, yeni məlumatlar isə yenisini istifadə edəcək.</string>
+    <string name="msg_edit_config_warning">Bu konfiqurasiyanı redaktə etmək bütün tarixi məlumatlara təsir edəcək. Yeni vərdişlər əvvəlki günlər üçün «tamamlanmayıb» kimi görünəcək.</string>
+    <string name="msg_edit_config_warning_detail">Ən yaxşı təcrübə: yeni konfiqurasiya yaradın. Tarixi məlumatlar köhnə konfiqurasiyada qalar, yeni məlumatlar isə yenisini istifadə edər.</string>
     <string name="msg_delete_config_warning">Bu konfiqurasiyanı silmək istədiyinizə əminsiniz? Bu, konfiqurasiya yazısını qeydlərinizdən birdəfəlik siləcək.</string>
     <string name="msg_delete_day_confirm">Vərdiş seçilməyib. Günlük qeyd silinəcək.</string>
     <string name="msg_delete_day_warning">Bu günün qeydini silmək istədiyinizdən əminsiniz? Bu, izləmə yazısını qeydlərinizdən birdəfəlik siləcək.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Стварыць нататку</string>
     <string name="action_continue">Працягнуць</string>
     <string name="action_delete">Выдаліць</string>
+    <string name="action_details">Падрабязнасці</string>
     <string name="action_add_first_habit">Дадаць першую звычку</string>
     <string name="action_go_to_dashboard">Перайсці да панэлі</string>
     <string name="action_hide_details">Схаваць дэталі</string>
@@ -126,11 +127,8 @@
     <string name="format_conflicts_detected">Выяўлена канфліктаў: %1$d</string>
     <string name="format_active_since">Актыўна з %1$s</string>
     <string name="msg_connection_failed">Памылка падключэння</string>
-    <string name="msg_edit_config_warning">Вы збіраецеся рэдагаваць існуючую канфігурацыю. Гэта паўплывае на ўсе гістарычныя даныя.
-
-Рэдагаваць старую канфігурацыю не рэкамендуецца, бо гэта змяняе адлюстраванне вашых мінулых даных. Напрыклад, калі дадаць новую звычку, усе мінулыя дні пакажуць яе як «не выканана», хоць тады яе яшчэ не існавала.
-
-Лепшая практыка: стварыце новую канфігурацыю. Вашы гістарычныя даныя захаваюць старую канфігурацыю, а новыя даныя будуць выкарыстоўваць новую.</string>
+    <string name="msg_edit_config_warning">Рэдагаванне гэтай канфігурацыі паўплывае на ўсе гістарычныя даныя. Новыя звычкі будуць паказвацца як «не выканана» для мінулых дзён.</string>
+    <string name="msg_edit_config_warning_detail">Лепшая практыка: стварыце новую канфігурацыю. Гістарычныя даныя захаваюць старую канфігурацыю, а новыя даныя будуць выкарыстоўваць новую.</string>
     <string name="msg_delete_config_warning">Вы ўпэўненыя, што хочаце выдаліць гэты канфіг? Допіс з канфігурацыяй будзе выдалены з вашых нататак назаўжды.</string>
     <string name="msg_delete_day_confirm">Звычкі не абраны. Запіс за гэты дзень будзе выдалены.</string>
     <string name="msg_delete_day_warning">Вы ўпэўнены, што жадаеце выдаліць запіс за гэты дзень? Допіс з адзнакамі будзе выдалены з вашых нататак назаўсёды.</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Notiz erstellen</string>
     <string name="action_continue">Weiter</string>
     <string name="action_delete">Löschen</string>
+    <string name="action_details">Details</string>
     <string name="action_add_first_habit">Fügen Sie Ihre erste Gewohnheit hinzu</string>
     <string name="action_go_to_dashboard">Zum Dashboard</string>
     <string name="action_hide_details">Details ausblenden</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d Konflikt(e) erkannt</string>
     <string name="format_active_since">Aktiv seit %1$s</string>
     <string name="msg_connection_failed">Verbindung fehlgeschlagen</string>
-    <string name="msg_edit_config_warning">Du bist dabei, eine bestehende Konfiguration zu bearbeiten. Das wirkt sich auf alle historischen Daten aus.
-
-Das Bearbeiten einer alten Konfiguration wird nicht empfohlen, weil es die Darstellung früherer Daten verändert. Wenn du zum Beispiel eine neue Gewohnheit hinzufügst, werden alle vergangenen Tage sie als „nicht erledigt“ anzeigen, obwohl sie damals noch nicht existierte.
-
-Empfehlung: Erstelle stattdessen eine neue Konfiguration. Deine historischen Daten behalten die alte Konfiguration, und neue Daten verwenden die neue.</string>
+    <string name="msg_edit_config_warning">Das Bearbeiten dieser Konfiguration wirkt sich auf alle historischen Daten aus. Neue Gewohnheiten werden für vergangene Tage als „nicht erledigt" angezeigt.</string>
+    <string name="msg_edit_config_warning_detail">Empfehlung: Erstelle stattdessen eine neue Konfiguration. Historische Daten behalten die alte Konfiguration, neue Daten verwenden die neue.</string>
     <string name="msg_delete_config_warning">Sind Sie sicher, dass Sie diese Konfiguration löschen möchten? Der Konfigurationsbeitrag wird dauerhaft aus Ihren Notizen entfernt.</string>
     <string name="msg_delete_day_confirm">Keine Gewohnheiten ausgewählt. Der Tageseintrag wird gelöscht.</string>
     <string name="msg_delete_day_warning">Sind Sie sicher, dass Sie den Eintrag für diesen Tag löschen möchten? Der Tracking-Beitrag wird dauerhaft aus Ihren Notizen entfernt.</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Crear nota</string>
     <string name="action_continue">Continuar</string>
     <string name="action_delete">Eliminar</string>
+    <string name="action_details">Detalles</string>
     <string name="action_add_first_habit">Añadir tu primer hábito</string>
     <string name="action_go_to_dashboard">Ir al panel</string>
     <string name="action_hide_details">Ocultar detalles</string>
@@ -127,7 +128,8 @@
     <string name="format_conflicts_detected">%1$d conflicto(s) detectado(s)</string>
     <string name="format_active_since">Activo desde %1$s</string>
     <string name="msg_connection_failed">Error de conexión</string>
-    <string name="msg_edit_config_warning">Está a punto de editar una configuración existente. Esto afectará a todos los datos históricos.\n\nNo se recomienda editar una configuración antigua porque cambia la apariencia de sus datos pasados. Por ejemplo, si agrega un nuevo hábito, todos los días pasados lo mostrarán como "no completado" aunque no existiera en ese momento.\n\nMejor práctica: Cree una nueva configuración en su lugar. Sus datos históricos mantendrán la configuración antigua, y los nuevos datos usarán la nueva configuración.</string>
+    <string name="msg_edit_config_warning">Editar esta configuración afectará a todos los datos históricos. Los nuevos hábitos aparecerán como "no completado" en los días pasados.</string>
+    <string name="msg_edit_config_warning_detail">Mejor práctica: cree una nueva configuración en su lugar. Los datos históricos mantendrán la configuración antigua, y los nuevos datos usarán la nueva.</string>
     <string name="msg_delete_config_warning">¿Estás seguro de que quieres eliminar esta configuración? Esto eliminará permanentemente la publicación de configuración de tus notas.</string>
     <string name="msg_delete_day_confirm">No hay hábitos seleccionados. Se eliminará la entrada del día.</string>
     <string name="msg_delete_day_warning">¿Estás seguro de que quieres eliminar la entrada de este día? Esto eliminará permanentemente la publicación de seguimiento de tus notas.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Créer une note</string>
     <string name="action_continue">Continuer</string>
     <string name="action_delete">Supprimer</string>
+    <string name="action_details">Détails</string>
     <string name="action_add_first_habit">Ajoutez votre première habitude</string>
     <string name="action_go_to_dashboard">Aller au tableau de bord</string>
     <string name="action_hide_details">Masquer les détails</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d conflit(s) détecté(s)</string>
     <string name="format_active_since">Actif depuis %1$s</string>
     <string name="msg_connection_failed">Échec de la connexion</string>
-    <string name="msg_edit_config_warning">Vous êtes sur le point de modifier une configuration existante. Cela affectera toutes les données historiques.
-
-Modifier une ancienne configuration n’est pas recommandé, car cela change l’affichage de vos données passées. Par exemple, si vous ajoutez une nouvelle habitude, tous les jours passés l’afficheront comme « non effectuée », même si elle n’existait pas à l’époque.
-
-Bonne pratique : créez une nouvelle configuration. Vos données historiques conserveront l’ancienne configuration et les nouvelles données utiliseront la nouvelle.</string>
+    <string name="msg_edit_config_warning">Modifier cette configuration affectera toutes les données historiques. Les nouvelles habitudes apparaîtront comme « non effectuée » pour les jours passés.</string>
+    <string name="msg_edit_config_warning_detail">Bonne pratique : créez une nouvelle configuration. Les données historiques conserveront l\'ancienne configuration et les nouvelles données utiliseront la nouvelle.</string>
     <string name="msg_delete_config_warning">Êtes-vous sûr de vouloir supprimer cette configuration ? Cela supprimera définitivement la publication de configuration de vos notes.</string>
     <string name="msg_delete_day_confirm">Aucune habitude sélectionnée. L\'entrée du jour sera supprimée.</string>
     <string name="msg_delete_day_warning">Êtes-vous sûr de vouloir supprimer l\'entrée de ce jour ? Cela supprimera définitivement la publication de suivi de vos notes.</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">मेमो बनाएं</string>
     <string name="action_continue">जारी रखें</string>
     <string name="action_delete">हटाएं</string>
+    <string name="action_details">विवरण</string>
     <string name="action_add_first_habit">पहली आदत जोड़ें</string>
     <string name="action_go_to_dashboard">डैशबोर्ड पर जाएं</string>
     <string name="action_hide_details">विवरण छुपाएं</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d विरोध पाया गया</string>
     <string name="format_active_since">%1$s से सक्रिय</string>
     <string name="msg_connection_failed">कनेक्शन विफल</string>
-    <string name="msg_edit_config_warning">आप एक मौजूदा कॉन्फ़िगरेशन संपादित करने वाले हैं। इससे सभी ऐतिहासिक डेटा प्रभावित होगा।
-
-पुरानी कॉन्फ़िगरेशन संपादित करना अनुशंसित नहीं है, क्योंकि इससे आपके पुराने डेटा का दिखना बदल जाता है। उदाहरण के लिए, यदि आप एक नया habit जोड़ते हैं, तो सभी पुराने दिनों में वह "पूरा नहीं" दिखेगा, जबकि उस समय वह मौजूद नहीं था।
-
-बेहतर तरीका: नई कॉन्फ़िगरेशन बनाएँ। आपका ऐतिहासिक डेटा पुरानी कॉन्फ़िगरेशन के साथ रहेगा और नया डेटा नई कॉन्फ़िगरेशन का उपयोग करेगा।</string>
+    <string name="msg_edit_config_warning">इस कॉन्फ़िगरेशन को संपादित करने से सभी ऐतिहासिक डेटा प्रभावित होगा। नई आदतें पुराने दिनों के लिए "पूरा नहीं" दिखेंगी।</string>
+    <string name="msg_edit_config_warning_detail">बेहतर तरीका: नई कॉन्फ़िगरेशन बनाएँ। ऐतिहासिक डेटा पुरानी कॉन्फ़िगरेशन के साथ रहेगा और नया डेटा नई कॉन्फ़िगरेशन का उपयोग करेगा।</string>
     <string name="msg_delete_config_warning">क्या आप वाकई इस कॉन्फ़िग को हटाना चाहते हैं? यह आपके मेमो से कॉन्फ़िगरेशन पोस्ट को स्थायी रूप से हटा देगा।</string>
     <string name="msg_delete_day_confirm">कोई आदत चयनित नहीं। दैनिक प्रविष्टि हटा दी जाएगी।</string>
     <string name="msg_delete_day_warning">क्या आप वाकई इस दिन की प्रविष्टि को हटाना चाहते हैं? यह ट्रैकिंग पोस्ट को आपके मेमो से स्थायी रूप से हटा देगा।</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">メモを作成</string>
     <string name="action_continue">続ける</string>
     <string name="action_delete">削除</string>
+    <string name="action_details">詳細</string>
     <string name="action_add_first_habit">最初の習慣を追加</string>
     <string name="action_go_to_dashboard">ダッシュボードへ</string>
     <string name="action_hide_details">詳細を隠す</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d 件の競合を検出</string>
     <string name="format_active_since">%1$s からアクティブ</string>
     <string name="msg_connection_failed">接続に失敗しました</string>
-    <string name="msg_edit_config_warning">既存の設定を編集しようとしています。これは過去のすべてのデータに影響します。
-
-古い設定の編集はおすすめしません。過去のデータの見え方が変わってしまうためです。たとえば新しい習慣を追加すると、当時存在しなかったにもかかわらず過去の日付が「未完了」と表示されます。
-
-推奨: 新しい設定を作成してください。過去データは古い設定のまま保持され、新しいデータは新しい設定を使用します。</string>
+    <string name="msg_edit_config_warning">この設定を編集すると、すべての過去データに影響します。新しい習慣は過去の日付で「未完了」と表示されます。</string>
+    <string name="msg_edit_config_warning_detail">推奨: 新しい設定を作成してください。過去データは古い設定のまま保持され、新しいデータは新しい設定を使用します。</string>
     <string name="msg_delete_config_warning">この設定を削除してもよろしいですか？これにより、メモから設定投稿が完全に削除されます。</string>
     <string name="msg_delete_day_confirm">習慣が選択されていません。この日のエントリは削除されます。</string>
     <string name="msg_delete_day_warning">この日のエントリーを削除してもよろしいですか？トラッキング投稿がメモから完全に削除されます。</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">ჩანაწერის შექმნა</string>
     <string name="action_continue">გაგრძელება</string>
     <string name="action_delete">წაშლა</string>
+    <string name="action_details">დეტალები</string>
     <string name="action_add_first_habit">პირველი ჩვევის დამატება</string>
     <string name="action_go_to_dashboard">პანელზე გადასვლა</string>
     <string name="action_hide_details">დეტალების დამალვა</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">აღმოჩენილია %1$d კონფლიქტი</string>
     <string name="format_active_since">აქტიური %1$s-დან</string>
     <string name="msg_connection_failed">კავშირის შეცდომა</string>
-    <string name="msg_edit_config_warning">თქვენ აპირებთ არსებული კონფიგურაციის რედაქტირებას. ეს ყველა ისტორიულ მონაცემზე იმოქმედებს.
-
-ძველი კონფიგურაციის რედაქტირება არ არის რეკომენდებული, რადგან ეს ცვლის წარსული მონაცემების ჩვენებას. მაგალითად, თუ დაამატებთ ახალ ჩვევას, ყველა წარსული დღე მას «შეუსრულებლად» აჩვენებს, მიუხედავად იმისა, რომ მაშინ ის არ არსებობდა.
-
-საუკეთესო პრაქტიკა: შექმენით ახალი კონფიგურაცია. ისტორიული მონაცემები დარჩება ძველ კონფიგურაციაზე, ხოლო ახალი მონაცემები გამოიყენებს ახალს.</string>
+    <string name="msg_edit_config_warning">ამ კონფიგურაციის რედაქტირება ყველა ისტორიულ მონაცემზე იმოქმედებს. ახალი ჩვევები წარსულ დღეებში «შეუსრულებლად» გამოჩნდება.</string>
+    <string name="msg_edit_config_warning_detail">საუკეთესო პრაქტიკა: შექმენით ახალი კონფიგურაცია. ისტორიული მონაცემები დარჩება ძველ კონფიგურაციაზე, ხოლო ახალი მონაცემები გამოიყენებს ახალს.</string>
     <string name="msg_delete_config_warning">დარწმუნებული ხართ, რომ გსურთ ამ კონფიგურაციის წაშლა? ეს სამუდამოდ წაშლის კონფიგურაციის ჩანაწერს თქვენი შენიშვნებიდან.</string>
     <string name="msg_delete_day_confirm">ჩვევები არ არის არჩეული. დღიური ჩანაწერი წაიშლება.</string>
     <string name="msg_delete_day_warning">დარწმუნებული ხართ, რომ გსურთ ამ დღის ჩანაწერის წაშლა? ეს სამუდამოდ წაშლის თვალთვალის ჩანაწერს თქვენი შენიშვნებიდან.</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Жазба жасау</string>
     <string name="action_continue">Жалғастыру</string>
     <string name="action_delete">Жою</string>
+    <string name="action_details">Толығырақ</string>
     <string name="action_add_first_habit">Бірінші әдетті қосу</string>
     <string name="action_go_to_dashboard">Панельге өту</string>
     <string name="action_hide_details">Мәліметтерді жасыру</string>
@@ -126,11 +127,8 @@
     <string name="format_conflicts_detected">%1$d қақтығыс анықталды</string>
     <string name="format_active_since">%1$s бастап белсенді</string>
     <string name="msg_connection_failed">Қосылу қатесі</string>
-    <string name="msg_edit_config_warning">Сіз қолданыстағы конфигурацияны өңдемекшісіз. Бұл барлық тарихи деректерге әсер етеді.
-
-Ескі конфигурацияны өңдеу ұсынылмайды, өйткені бұл өткен деректердің көрінісін өзгертеді. Мысалы, жаңа әдет қоссanız, өткен күндердің бәрі оны «орындалмаған» деп көрсетеді, ол кезде ол әлі жоқ еді.
-
-Ең дұрыс тәсіл: жаңа конфигурация жасаңыз. Тарихи деректер ескі конфигурацияда қалады, ал жаңа деректер жаңасын қолданады.</string>
+    <string name="msg_edit_config_warning">Бұл конфигурацияны өңдеу барлық тарихи деректерге әсер етеді. Жаңа әдеттер өткен күндер үшін «орындалмаған» деп көрінеді.</string>
+    <string name="msg_edit_config_warning_detail">Ең дұрыс тәсіл: жаңа конфигурация жасаңыз. Тарихи деректер ескі конфигурацияда қалады, ал жаңа деректер жаңасын қолданады.</string>
     <string name="msg_delete_config_warning">Бұл конфигті жойғыңыз келетініне сенімдісіз бе? Бұл конфигурация жазбасын жазбаларыңыздан біржола жояды.</string>
     <string name="msg_delete_day_confirm">Әдеттер таңдалмаған. Күндік жазба жойылады.</string>
     <string name="msg_delete_day_warning">Осы күннің жазбасын жоюға сенімдісіз бе? Бұл бақылау жазбасын жазбаларыңыздан біржола жояды.</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_create_first_habit">Биринчи адатты түзүү</string>
     <string name="action_create_memo">Жазуу түзүү</string>
     <string name="action_delete">Өчүрүү</string>
+    <string name="action_details">Кеңири</string>
     <string name="action_hide_details">Деталдарды жашыруу</string>
     <string name="action_mark_first_checkin">Биринчи белгини коюу</string>
     <string name="action_maybe_later">Кийинчерээк</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d чыр-чатак аныкталды</string>
     <string name="format_active_since">%1$sдөн бери активдүү</string>
     <string name="msg_connection_failed">Байланыш катасы</string>
-    <string name="msg_edit_config_warning">Сиз бар болгон конфигурацияны түзөтүүгө баратасыз. Бул бардык тарыхый маалыматтарга таасир этет.
-
-Эски конфигурацияны түзөтүү сунушталбайт, анткени бул мурунку маалыматтардын көрүнүшүн өзгөртөт. Мисалы, жаңы адат кошсоңуз, өткөн күндөрдүн баары аны «аткарылган жок» деп көрсөтөт, ал убакта ал жок болчу.
-
-Эң туурасы: жаңы конфигурация түзүңүз. Тарыхый маалыматтар эски конфигурацияда калат, ал эми жаңы маалыматтар жаңысын колдонушат.</string>
+    <string name="msg_edit_config_warning">Бул конфигурацияны түзөтүү бардык тарыхый маалыматтарга таасир этет. Жаңы адаттар өткөн күндөр үчүн «аткарылган жок» деп көрүнөт.</string>
+    <string name="msg_edit_config_warning_detail">Эң туурасы: жаңы конфигурация түзүңүз. Тарыхый маалыматтар эски конфигурацияда калат, ал жаңы маалыматтар жаңысын колдонот.</string>
     <string name="msg_delete_config_warning">Бул конфигди өчүргүңүз келгеніне ишенесизби? Бул конфигурация постун жазууларыңыздан биротоло өчүрөт.</string>
     <string name="msg_delete_day_confirm">Адаттар тандалган эмес. Күндүк жазуу өчүрүлөт.</string>
     <string name="msg_delete_day_warning">Бул күндүн жазуусун өчүргүңүз келгенине ишенесизби? Бул көзөмөл постун эстеликтериңизден биротоло өчүрөт.</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Criar nota</string>
     <string name="action_continue">Continuar</string>
     <string name="action_delete">Excluir</string>
+    <string name="action_details">Detalhes</string>
     <string name="action_add_first_habit">Adicione seu primeiro hábito</string>
     <string name="action_go_to_dashboard">Ir para painel</string>
     <string name="action_hide_details">Ocultar detalhes</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d conflito(s) detectado(s)</string>
     <string name="format_active_since">Ativo desde %1$s</string>
     <string name="msg_connection_failed">Falha na conexão</string>
-    <string name="msg_edit_config_warning">Você está prestes a editar uma configuração existente. Isso afetará todos os dados históricos.
-
-Editar uma configuração antiga não é recomendado, pois altera a forma como seus dados anteriores aparecem. Por exemplo, se você adicionar um novo hábito, todos os dias anteriores o mostrarão como "não concluído", mesmo que ele não existisse na época.
-
-Melhor prática: crie uma nova configuração. Seus dados históricos manterão a configuração antiga, e os dados novos usarão a nova.</string>
+    <string name="msg_edit_config_warning">Editar esta configuração afetará todos os dados históricos. Novos hábitos aparecerão como "não concluído" nos dias anteriores.</string>
+    <string name="msg_edit_config_warning_detail">Melhor prática: crie uma nova configuração. Os dados históricos manterão a configuração antiga, e os dados novos usarão a nova.</string>
     <string name="msg_delete_config_warning">Tem certeza de que deseja excluir esta configuração? Isso removerá permanentemente a publicação de configuração de suas notas.</string>
     <string name="msg_delete_day_confirm">Nenhum hábito selecionado. A entrada diária será excluída.</string>
     <string name="msg_delete_day_warning">Tem certeza de que deseja excluir a entrada deste dia? Isso removerá permanentemente a publicação de rastreamento das suas notas.</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_create_first_habit">Creează primul tău obicei</string>
     <string name="action_create_memo">Creează notă</string>
     <string name="action_delete">Șterge</string>
+    <string name="action_details">Detalii</string>
     <string name="action_hide_details">Ascunde detalii</string>
     <string name="action_mark_first_checkin">Marchează prima verificare</string>
     <string name="action_maybe_later">Poate mai târziu</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d conflict(e) detectat(e)</string>
     <string name="format_active_since">Activ din %1$s</string>
     <string name="msg_connection_failed">Conexiune eșuată</string>
-    <string name="msg_edit_config_warning">Ești pe cale să editezi o configurație existentă. Acest lucru va afecta toate datele istorice.
-
-Editarea unei configurații vechi nu este recomandată, deoarece schimbă modul în care apar datele tale anterioare. De exemplu, dacă adaugi un obicei nou, toate zilele trecute îl vor arăta ca «nefinalizat», deși atunci nu exista.
-
-Cea mai bună practică: creează o configurație nouă. Datele tale istorice vor păstra configurația veche, iar datele noi vor folosi configurația nouă.</string>
+    <string name="msg_edit_config_warning">Editarea acestei configurații va afecta toate datele istorice. Obiceiurile noi vor apărea ca «nefinalizat» pentru zilele trecute.</string>
+    <string name="msg_edit_config_warning_detail">Cea mai bună practică: creează o configurație nouă. Datele istorice vor păstra configurația veche, iar datele noi vor folosi configurația nouă.</string>
     <string name="msg_delete_config_warning">Sigur doriți să ștergeți această configurație? Aceasta va elimina definitiv postarea de configurare din notele dvs.</string>
     <string name="msg_delete_day_confirm">Niciun obicei selectat. Înregistrarea zilnică va fi ștearsă.</string>
     <string name="msg_delete_day_warning">Sunteți sigur că doriți să ștergeți înregistrarea acestei zile? Aceasta va elimina definitiv postarea de urmărire din notițele dumneavoastră.</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_create_new_config">Создать новую конфигурацию (рекомендуется)</string>
     <string name="action_continue">Продолжить</string>
     <string name="action_delete">Удалить</string>
+    <string name="action_details">Подробности</string>
     <string name="action_add_first_habit">Добавить первую привычку</string>
     <string name="action_edit_anyway">Всё равно редактировать</string>
     <string name="action_go_to_dashboard">Перейти на главную</string>
@@ -129,7 +130,8 @@
     <string name="msg_delete_config_warning">Точно удалить эту конфигурацию? Запись с конфигурацией будет навсегда удалена из твоих воспоминаний.</string>
     <string name="msg_delete_day_confirm">Привычки не выбраны. Запись за день будет удалена.</string>
     <string name="msg_delete_day_warning">Точно удалить день? Запись с отметками будет навсегда удалена из твоих воспоминаний.</string>
-    <string name="msg_edit_config_warning">Ты собираешься отредактировать существующую конфигурацию. Это повлияет на все исторические данные.\n\nРедактировать старую конфигурацию не рекомендуется, потому что это меняет отображение прошлых данных. Например, если добавить новую привычку, прошлые дни покажут её как «не выполнено», хотя тогда её ещё не существовало.\n\nЛучшее решение: создай новую конфигурацию. Исторические данные сохранят старую конфигурацию, а новые данные будут использовать новую.</string>
+    <string name="msg_edit_config_warning">Редактирование этой конфигурации повлияет на все исторические данные. Новые привычки будут отображаться как «не выполнено» для прошлых дней.</string>
+    <string name="msg_edit_config_warning_detail">Лучшее решение: создай новую конфигурацию. Исторические данные сохранят старую конфигурацию, а новые данные будут использовать новую.</string>
     <string name="msg_empty_state_no_habits">Создай привычку, чтобы начать отслеживание офлайн.</string>
     <string name="msg_fill_all_fields">Заполни все поля</string>
     <string name="msg_habit_name_required">Нужно название привычки</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_create_first_habit">Одати аввалро эҷод кунед</string>
     <string name="action_create_memo">Эҷоди ёддошт</string>
     <string name="action_delete">Нест кардан</string>
+    <string name="action_details">Тафсилот</string>
     <string name="action_hide_details">Пинҳон кардани тафсилот</string>
     <string name="action_mark_first_checkin">Аввалин қайдро гузоштан</string>
     <string name="action_maybe_later">Баъдтар</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d мухолифат ошкор шуд</string>
     <string name="format_active_since">Фаъол аз %1$s</string>
     <string name="msg_connection_failed">Хатои пайвастшавӣ</string>
-    <string name="msg_edit_config_warning">Шумо мехоҳед конфигуратсияи мавҷударо таҳрир кунед. Ин ба ҳамаи маълумоти таърихӣ таъсир мерасонад.
-
-Таҳрири конфигуратсияи кӯҳна тавсия намешавад, зеро он намуди маълумоти гузаштаатонро тағйир медиҳад. Масалан, агар одати нав илова кунед, ҳамаи рӯзҳои гузашта онро ҳамчун «иҷро нашудааст» нишон медиҳанд, гарчанде он вақт вуҷуд надошт.
-
-Амали беҳтарин: конфигуратсияи нав эҷод кунед. Маълумоти таърихӣ бо конфигуратсияи кӯҳна мемонад, маълумоти нав бошад конфигуратсияи навро истифода мебарад.</string>
+    <string name="msg_edit_config_warning">Таҳрири ин конфигуратсия ба ҳамаи маълумоти таърихӣ таъсир мерасонад. Одатҳои нав барои рӯзҳои гузашта ҳамчун «иҷро нашудааст» нишон дода мешаванд.</string>
+    <string name="msg_edit_config_warning_detail">Амали беҳтарин: конфигуратсияи нав эҷод кунед. Маълумоти таърихӣ бо конфигуратсияи кӯҳна мемонад, маълумоти нав бошад конфигуратсияи навро истифода мебарад.</string>
     <string name="msg_delete_config_warning">Шумо мутмаин ҳастед, ки мехоҳед ин конфигро нест кунед? Ин постро аз хотиротҳои шумо назди ҳамеша нест мекунад.</string>
     <string name="msg_delete_day_confirm">Одат интихоб нашудааст. Сабти рӯзона нест мешавад.</string>
     <string name="msg_delete_day_warning">Оё шумо мутмаин ҳастед, ки мехоҳед сабти ин рӯзро нест кунед? Ин постро аз ёддоштҳои шумо ҳамешагӣ нест мекунад.</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -14,6 +14,7 @@
     <string name="action_create_first_habit">Ilkinji endigi döret</string>
     <string name="action_create_memo">Bellik döret</string>
     <string name="action_delete">Poz</string>
+    <string name="action_details">Jikme-jiklik</string>
     <string name="action_hide_details">Jikme-jiklikleri gizle</string>
     <string name="action_mark_first_checkin">Ilkinji belligi goý</string>
     <string name="action_maybe_later">Soň bolsa</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d gapma-garşylyk ýüze çykaryldy</string>
     <string name="format_active_since">%1$s-den bäri işjeň</string>
     <string name="msg_connection_failed">Baglanşyk ýalňyşlygy</string>
-    <string name="msg_edit_config_warning">Bar bolan konfigurasiýany redaktirlemekçi bolýarsyňyz. Bu ähli taryhy maglumatlara täsir eder.
-
-Köne konfigurasiýany redaktirlemek maslahat berilmeýär, sebäbi bu geçmişdäki maglumatlaryň görünüşini üýtgedýär. Mysal üçin, täze endik goşsaňyz, öňki günleriň hemmesi ony «tamamlanmady» diýip görkezer, ol wagtda bolsa ol ýokdy.
-
-Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigurasiýada galar, täze maglumatlar bolsa täzesini ulanar.</string>
+    <string name="msg_edit_config_warning">Bu konfigurasiýany redaktirlemek ähli taryhy maglumatlara täsir eder. Täze endikler öňki günler üçin «tamamlanmady» diýip görkeziler.</string>
+    <string name="msg_edit_config_warning_detail">Iň gowy usul: täze konfigurasiýa dörediň. Taryhy maglumatlar köne konfigurasiýada galar, täze maglumatlar bolsa täzesini ulanar.</string>
     <string name="msg_delete_config_warning">Bu konfigurasiýany öçürmek isleýärsiňizmi? Bu ýazgy postyny ýazgylardan hemişelik aýyrar.</string>
     <string name="msg_delete_day_confirm">Endik saýlanmady. Gündelik ýazgy öçüriler.</string>
     <string name="msg_delete_day_warning">Bu günüň ýazgysyny öçürmek isleýärsiňizmi? Bu yzarlamak ýazgysyny belliklerňizden hemişelik aýyrar.</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Створити нотатку</string>
     <string name="action_continue">Продовжити</string>
     <string name="action_delete">Видалити</string>
+    <string name="action_details">Деталі</string>
     <string name="action_add_first_habit">Додати першу звичку</string>
     <string name="action_go_to_dashboard">Перейти до панелі</string>
     <string name="action_hide_details">Сховати деталі</string>
@@ -126,11 +127,8 @@
     <string name="format_conflicts_detected">Виявлено конфліктів: %1$d</string>
     <string name="format_active_since">Активно з %1$s</string>
     <string name="msg_connection_failed">Помилка підключення</string>
-    <string name="msg_edit_config_warning">Ви збираєтеся редагувати наявну конфігурацію. Це вплине на всі історичні дані.
-
-Редагувати стару конфігурацію не рекомендується, бо це змінює відображення ваших минулих даних. Наприклад, якщо додати нову звичку, усі минулі дні покажуть її як «не виконано», хоча тоді її ще не існувало.
-
-Найкраща практика: створіть нову конфігурацію. Історичні дані збережуть стару конфігурацію, а нові дані використовуватимуть нову.</string>
+    <string name="msg_edit_config_warning">Редагування цієї конфігурації вплине на всі історичні дані. Нові звички відображатимуться як «не виконано» для минулих днів.</string>
+    <string name="msg_edit_config_warning_detail">Найкраща практика: створіть нову конфігурацію. Історичні дані збережуть стару конфігурацію, а нові дані використовуватимуть нову.</string>
     <string name="msg_delete_config_warning">Ви впевнені, що хочете видалити цей конфіг? Пост з конфігурацією буде видалено з ваших нотаток назавжди.</string>
     <string name="msg_delete_day_confirm">Звички не обрано. Запис за цей день буде видалено.</string>
     <string name="msg_delete_day_warning">Ви впевнені, що хочете видалити запис за цей день? Пост з відмітками буде видалено з ваших нотаток назавжди.</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">Eslatma yaratish</string>
     <string name="action_continue">Davom etish</string>
     <string name="action_delete">O'chirish</string>
+    <string name="action_details">Tafsilotlar</string>
     <string name="action_add_first_habit">Birinchi odatni qo'shish</string>
     <string name="action_go_to_dashboard">Boshqaruv paneliga o'tish</string>
     <string name="action_hide_details">Tafsilotlarni yashirish</string>
@@ -127,11 +128,8 @@
     <string name="format_conflicts_detected">%1$d ziddiyat aniqlandi</string>
     <string name="format_active_since">%1$s dan beri faol</string>
     <string name="msg_connection_failed">Ulanish xatosi</string>
-    <string name="msg_edit_config_warning">Siz mavjud konfiguratsiyani tahrirlash arafasidiz. Bu barcha tarixiy ma'lumotlarga ta'sir qiladi.
-
-Eski konfiguratsiyani tahrirlash tavsiya etilmaydi, chunki bu o'tgan ma'lumotlarning ko'rinishini o'zgartiradi. Masalan, yangi odat qo'shsangiz, o'tgan kunlarning barchasi uni «bajarilmagan» deb ko'rsatadi, garchi u o'shanda mavjud bo'lmagan.
-
-Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfiguratsiyada qoladi, yangi ma'lumotlar esa yangisini ishlatadi.</string>
+    <string name="msg_edit_config_warning">Bu konfiguratsiyani tahrirlash barcha tarixiy ma'lumotlarga ta'sir qiladi. Yangi odatlar o'tgan kunlar uchun «bajarilmagan» deb ko'rsatiladi.</string>
+    <string name="msg_edit_config_warning_detail">Eng yaxshi yechim: yangi konfiguratsiya yarating. Tarixiy ma'lumotlar eski konfiguratsiyada qoladi, yangi ma'lumotlar esa yangisini ishlatadi.</string>
     <string name="msg_delete_config_warning">Ushbu konfigni o'chirishga ishonchingiz komilmi? Bu konfiguratsiya postini eslatmalaringizdan butunlay o'chiradi.</string>
     <string name="msg_delete_day_confirm">Odatlar tanlanmagan. Kunlik yozuv o\'chiriladi.</string>
     <string name="msg_delete_day_warning">Ushbu kunning yozuvini o\'chirishga aminmisiz? Bu kuzatuv postini eslatmalaringizdan butunlay olib tashlaydi.</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -13,6 +13,7 @@
     <string name="action_create_memo">创建备忘</string>
     <string name="action_continue">继续</string>
     <string name="action_delete">删除</string>
+    <string name="action_details">详情</string>
     <string name="action_add_first_habit">添加第一个习惯</string>
     <string name="action_go_to_dashboard">前往仪表板</string>
     <string name="action_hide_details">隐藏详情</string>
@@ -127,7 +128,8 @@
     <string name="format_conflicts_detected">检测到 %1$d 个冲突</string>
     <string name="format_active_since">自 %1$s 起生效</string>
     <string name="msg_connection_failed">连接失败</string>
-    <string name="msg_edit_config_warning">您即将编辑现有配置。这将影响所有历史数据。\n\n不建议编辑旧配置，因为它会改变过去数据的显示方式。例如，如果您添加新习惯，所有过去的日期都会显示为"未完成"，即使当时它还不存在。\n\n最佳实践：创建新配置。您的历史数据将保留旧配置，新数据将使用新配置。</string>
+    <string name="msg_edit_config_warning">编辑此配置将影响所有历史数据。新习惯在过去的日期中将显示为"未完成"。</string>
+    <string name="msg_edit_config_warning_detail">最佳实践：创建新配置。历史数据将保留旧配置，新数据将使用新配置。</string>
     <string name="msg_delete_config_warning">您确定要删除此配置吗？这将永久删除您备忘录中的配置帖子。</string>
     <string name="msg_delete_day_confirm">未选择任何习惯。该日记录将被删除。</string>
     <string name="msg_delete_day_warning">您确定要删除这一天的条目吗？这将永久删除您备忘录中的跟踪帖子。</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -12,6 +12,7 @@
     <string name="action_create_new_config">Create new config (recommended)</string>
     <string name="action_continue">Continue</string>
     <string name="action_delete">Delete</string>
+    <string name="action_details">Details</string>
     <string name="action_add_first_habit">Add your first habit</string>
     <string name="action_edit_anyway">Edit anyway</string>
     <string name="action_go_to_dashboard">Go to dashboard</string>
@@ -130,7 +131,8 @@
     <string name="msg_empty_state_no_habits">Create one to start tracking offline.</string>
     <string name="msg_delete_day_confirm">No habits selected. The daily entry will be deleted.</string>
     <string name="msg_delete_day_warning">Are you sure you want to delete this day's entry? This will permanently remove the tracking post from your memos.</string>
-    <string name="msg_edit_config_warning">You're about to edit an existing config. This will affect all historical data.\n\nEditing an old config is not recommended because it changes how your past data appears. For example, if you add a new habit, all past days will show it as "not completed" even though it didn't exist back then.\n\nBest practice: Create a new config instead. Your historical data will keep the old config, and new data will use the new config.</string>
+    <string name="msg_edit_config_warning">Editing this config will affect all historical data. New habits will appear as "not completed" for past days.</string>
+    <string name="msg_edit_config_warning_detail">Best practice: create a new config instead. Historical data keeps the old config, new data uses the new one.</string>
     <string name="msg_fill_all_fields">Please fill in all fields</string>
     <string name="msg_habit_name_required">Habit name is required</string>
     <string name="msg_habit_setup">Give your habit a meaningful name.</string>

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/ExpandableDetails.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/ExpandableDetails.kt
@@ -1,0 +1,33 @@
+package space.be1ski.vibits.core.ui
+
+import androidx.compose.animation.AnimatedVisibility
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+
+@Composable
+fun ExpandableDetails(
+  toggleLabel: String,
+  modifier: Modifier = Modifier,
+  content: @Composable () -> Unit,
+) {
+  var expanded by remember { mutableStateOf(false) }
+  Column(modifier = modifier) {
+    Text(
+      text = toggleLabel,
+      style = MaterialTheme.typography.labelMedium,
+      color = MaterialTheme.colorScheme.primary,
+      modifier = Modifier.clickable { expanded = !expanded },
+    )
+    AnimatedVisibility(visible = expanded) {
+      content()
+    }
+  }
+}

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/EditConfigWarningDialog.kt
@@ -1,13 +1,8 @@
 package space.be1ski.vibits.feature.habits.presentation.view.components
 
-import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -15,18 +10,18 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
-import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
 import space.be1ski.vibits.core.strings.generated.action_create_new_config
+import space.be1ski.vibits.core.strings.generated.action_details
 import space.be1ski.vibits.core.strings.generated.action_edit_anyway
 import space.be1ski.vibits.core.strings.generated.msg_edit_config_warning
+import space.be1ski.vibits.core.strings.generated.msg_edit_config_warning_detail
 import space.be1ski.vibits.core.strings.generated.title_edit_config_warning
+import space.be1ski.vibits.core.ui.ExpandableDetails
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
@@ -44,55 +39,38 @@ fun EditConfigWarningDialog(
     modifier = Modifier.testTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG),
     title = { Text(stringResource(Res.string.title_edit_config_warning), style = MaterialTheme.typography.headlineSmall) },
     text = {
-      val paragraphs = stringResource(Res.string.msg_edit_config_warning).let { remember(it) { it.split("\n\n") } }
       Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
-        paragraphs.forEachIndexed { index, paragraph ->
-          if (index == 0) {
-            Text(
-              text = paragraph,
-              style = MaterialTheme.typography.bodyMedium.copy(fontWeight = FontWeight.SemiBold),
-              color = MaterialTheme.colorScheme.onSurface,
-            )
-          } else {
-            Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
-              Box(
-                modifier =
-                  Modifier
-                    .padding(top = BULLET_TOP_OFFSET)
-                    .size(BULLET_SIZE)
-                    .background(MaterialTheme.colorScheme.onSurfaceVariant, CircleShape),
-              )
-              Text(
-                text = paragraph,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant,
-                modifier = Modifier.weight(1f),
-              )
-            }
-          }
+        Text(
+          text = stringResource(Res.string.msg_edit_config_warning),
+          style = MaterialTheme.typography.bodyMedium,
+          color = MaterialTheme.colorScheme.onSurface,
+        )
+        ExpandableDetails(toggleLabel = stringResource(Res.string.action_details)) {
+          Text(
+            text = stringResource(Res.string.msg_edit_config_warning_detail),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.onSurfaceVariant,
+          )
         }
       }
     },
     confirmButton = {
-      Button(onClick = { dispatch(HabitsAction.ConfigWarning.CreateNewConfigInstead) }) {
-        Text(stringResource(Res.string.action_create_new_config))
-      }
-    },
-    dismissButton = {
       Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
-        TextButton(onClick = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) }) {
-          Text(stringResource(Res.string.action_cancel))
-        }
         TextButton(
           onClick = { dispatch(HabitsAction.ConfigWarning.ConfirmEditExistingConfig) },
           colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
         ) {
           Text(stringResource(Res.string.action_edit_anyway))
         }
+        Button(onClick = { dispatch(HabitsAction.ConfigWarning.CreateNewConfigInstead) }) {
+          Text(stringResource(Res.string.action_create_new_config))
+        }
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = { dispatch(HabitsAction.ConfigWarning.DismissEditConfigWarning) }) {
+        Text(stringResource(Res.string.action_cancel))
       }
     },
   )
 }
-
-private val BULLET_SIZE = 5.dp
-private val BULLET_TOP_OFFSET = 7.dp

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitsConfigDialog.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitsConfigDialog.kt
@@ -71,11 +71,6 @@ fun HabitsConfigDialog(
     title = { Text(stringResource(Res.string.label_habits_config)) },
     text = { HabitsConfigDialogContent(habitsState, demoMode, dispatch) },
     confirmButton = {
-      Button(onClick = { dispatch(HabitsAction.Config.SaveConfigDialog) }) {
-        Text(stringResource(Res.string.action_save))
-      }
-    },
-    dismissButton = {
       Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
         if (habitsState.editingConfigMemo != null) {
           TextButton(
@@ -88,9 +83,14 @@ fun HabitsConfigDialog(
             Text(stringResource(Res.string.action_delete))
           }
         }
-        TextButton(onClick = { dispatch(HabitsAction.Config.CloseConfigDialog) }) {
-          Text(stringResource(Res.string.action_cancel))
+        Button(onClick = { dispatch(HabitsAction.Config.SaveConfigDialog) }) {
+          Text(stringResource(Res.string.action_save))
         }
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = { dispatch(HabitsAction.Config.CloseConfigDialog) }) {
+        Text(stringResource(Res.string.action_cancel))
       }
     },
   )

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
@@ -66,7 +66,7 @@ private fun HabitEditorDialog(
     },
     text = { HabitEditorContent(habitsState, demoMode, dispatch) },
     confirmButton = { HabitEditorConfirmButton(habitsState, dispatch) },
-    dismissButton = { HabitEditorDismissButton(habitsState, dispatch) },
+    dismissButton = { HabitEditorDismissButton(dispatch) },
   )
 }
 
@@ -120,26 +120,26 @@ private fun HabitEditorConfirmButton(
   habitsState: HabitsState,
   dispatch: (HabitsAction) -> Unit,
 ) {
-  Button(onClick = { dispatch(HabitsAction.Editor.ConfirmEditor) }) {
-    val actionRes = if (habitsState.isEditing) Res.string.action_update else Res.string.action_create
-    Text(stringResource(actionRes))
+  Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
+    if (habitsState.isEditing) {
+      TextButton(
+        onClick = { dispatch(HabitsAction.Editor.RequestDelete) },
+        colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.error),
+      ) {
+        Text(stringResource(Res.string.action_delete))
+      }
+    }
+    Button(onClick = { dispatch(HabitsAction.Editor.ConfirmEditor) }) {
+      val actionRes = if (habitsState.isEditing) Res.string.action_update else Res.string.action_create
+      Text(stringResource(actionRes))
+    }
   }
 }
 
 @Composable
-private fun HabitEditorDismissButton(
-  habitsState: HabitsState,
-  dispatch: (HabitsAction) -> Unit,
-) {
-  Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
-    if (habitsState.isEditing) {
-      TextButton(onClick = { dispatch(HabitsAction.Editor.RequestDelete) }) {
-        Text(stringResource(Res.string.action_delete))
-      }
-    }
-    TextButton(onClick = { dispatch(HabitsAction.Editor.CloseEditor) }) {
-      Text(stringResource(Res.string.action_cancel))
-    }
+private fun HabitEditorDismissButton(dispatch: (HabitsAction) -> Unit) {
+  TextButton(onClick = { dispatch(HabitsAction.Editor.CloseEditor) }) {
+    Text(stringResource(Res.string.action_cancel))
   }
 }
 

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
@@ -19,6 +19,8 @@ import androidx.compose.material.pullrefresh.PullRefreshIndicator
 import androidx.compose.material.pullrefresh.pullRefresh
 import androidx.compose.material.pullrefresh.rememberPullRefreshState
 import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -179,10 +181,16 @@ fun FeedScreen(
       onDismissRequest = { memoToDelete = null },
       title = { Text(stringResource(Res.string.title_delete_memo)) },
       confirmButton = {
-        TextButton(onClick = {
-          onDeleteMemo?.invoke(memo)
-          memoToDelete = null
-        }) {
+        Button(
+          onClick = {
+            onDeleteMemo?.invoke(memo)
+            memoToDelete = null
+          },
+          colors =
+            ButtonDefaults.buttonColors(
+              containerColor = MaterialTheme.colorScheme.error,
+            ),
+        ) {
           Text(stringResource(Res.string.action_delete))
         }
       },

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/SyncConflictDialog.kt
@@ -4,15 +4,13 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -57,27 +55,18 @@ fun SyncConflictDialog(
       }
     },
     confirmButton = {
-      Row(
-        modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.End,
-      ) {
-        OutlinedButton(onClick = onDismiss) {
-          Text(stringResource(Res.string.action_cancel))
-        }
-        Spacer(modifier = Modifier.width(Indent.s))
+      Row(horizontalArrangement = Arrangement.spacedBy(Indent.s)) {
         OutlinedButton(onClick = onKeepServer) {
           Text(stringResource(Res.string.action_keep_server))
         }
-        Spacer(modifier = Modifier.width(Indent.s))
-        Button(
-          onClick = onKeepLocal,
-          colors =
-            ButtonDefaults.buttonColors(
-              containerColor = MaterialTheme.colorScheme.primary,
-            ),
-        ) {
+        Button(onClick = onKeepLocal) {
           Text(stringResource(Res.string.action_keep_local))
         }
+      }
+    },
+    dismissButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(Res.string.action_cancel))
       }
     },
   )


### PR DESCRIPTION
## Summary
- Standardize button placement across 5 dialogs: Cancel always in dismiss slot (left), primary action in confirm slot (right), destructive actions styled with error color
- Add `ExpandableDetails` composable to `core/ui` for collapsible detail sections
- Shorten EditConfigWarningDialog text with expandable "Details" toggle
- Update string resources across all 20 locales

## Changes
- **HabitsDialogs.kt**: Move Delete to confirm slot with error color styling
- **HabitsConfigDialog.kt**: Move Delete to confirm slot, Cancel alone in dismiss
- **FeedScreen.kt**: Change Delete from plain TextButton to filled error Button
- **SyncConflictDialog.kt**: Move Cancel to dismiss slot
- **EditConfigWarningDialog.kt**: Shorten warning text, add ExpandableDetails, reorder buttons
- **ExpandableDetails.kt**: New shared composable for collapsible content sections
- **20 locale strings.xml**: Add `action_details`, shorten `msg_edit_config_warning`, add `msg_edit_config_warning_detail`

## Test plan
- [x] `checkJvm` passes (ktlint, detekt, compile, tests)
- [x] Screenshot tests generate correctly
- [x] Visual verification of dialog screenshots via reg-actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)