### PR TITLE
Deploy benchmark charts to GitHub Pages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
           tool: 'customSmallerIsBetter'
           output-file-path: benchmark-result.json
           gh-pages-branch: benchmark-data
-          benchmark-data-dir-path: dev/bench
+          benchmark-data-dir-path: bench
           github-token: ${{ secrets.GITHUB_TOKEN }}
           auto-push: true
           summary-always: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -263,6 +263,12 @@ jobs:
           tag_name: ${{ needs.resolve-version.outputs.version }}
           files: webApp/build/dist/wasmJs/Vibits-*-web.tar.gz
 
+      - name: Include benchmark charts
+        run: |
+          git fetch origin benchmark-data
+          git checkout origin/benchmark-data -- bench
+          mv bench webApp/build/dist/wasmJs/productionExecutable/bench
+
       - name: Setup Pages
         uses: actions/configure-pages@v5
 


### PR DESCRIPTION
## Summary

- Include benchmark charts in the Pages deployment so they're accessible at `/bench/`
- Rename data directory from `dev/bench` to `bench`

## Changes

- **`release.yml`** — checkout `bench/` from `benchmark-data` branch and include in Pages artifact
- **`ci.yml`** — change `benchmark-data-dir-path` from `dev/bench` to `bench`

## Test plan

- [ ] CI passes
- [ ] After next release, charts available at `https://be1ski.github.io/vibits/bench/`