### PR TITLE
Add slow test to verify benchmark tracking

### DIFF
--- a/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/utils/SlowBenchmarkTest.kt
+++ b/core/utils/src/commonTest/kotlin/space/be1ski/vibits/core/utils/SlowBenchmarkTest.kt
@@ -1,0 +1,15 @@
+package space.be1ski.vibits.core.utils
+
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class SlowBenchmarkTest {
+  @Test
+  fun `slow test to verify benchmark tracking`() =
+    runTest {
+      delay(10_000)
+      assertTrue(true)
+    }
+}


### PR DESCRIPTION
Temporary: adds a 10s delay test to spike benchmark metrics. Will be reverted immediately.