### PR TITLE
Add sync debounce settings UI

### DIFF
--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">محدد</string>
     <string name="label_storage">التخزين</string>
     <string name="label_success_rate">معدل النجاح</string>
+    <string name="label_sync_debounce">تأخير المزامنة التلقائية</string>
     <string name="label_theme">السمة</string>
     <string name="label_time_day">نهار</string>
     <string name="label_time_evening">مساء</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">الاحتفاظ بالمحلي</string>
     <string name="action_keep_server">الاحتفاظ بالخادم</string>
     <string name="format_pending_sync">%1$d تغييرات معلقة</string>
+    <string name="format_sync_debounce_seconds">%1$d ثانية</string>
     <string name="msg_sync_conflict">تتعارض تغييراتك المحلية مع الخادم. اختر الإصدار الذي تريد الاحتفاظ به.</string>
     <string name="msg_sync_failed">فشلت المزامنة: %1$s</string>
     <string name="msg_syncing">جارٍ المزامنة...</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Seçilmiş</string>
     <string name="label_storage">Yaddaş</string>
     <string name="label_success_rate">Uğur dərəcəsi</string>
+    <string name="label_sync_debounce">Avtomatik sinxronizasiya gecikmәsi</string>
     <string name="label_theme">Tema</string>
     <string name="label_time_day">Gündüz</string>
     <string name="label_time_evening">Axşam</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Yerli saxla</string>
     <string name="action_keep_server">Server saxla</string>
     <string name="format_pending_sync">%1$d gözləyən dəyişiklik</string>
+    <string name="format_sync_debounce_seconds">%1$d san</string>
     <string name="msg_sync_conflict">Yerli dəyişiklikləriniz serverlə ziddiyyət təşkil edir. Hansı versiyanı saxlamaq istədiyinizi seçin.</string>
     <string name="msg_sync_failed">Sinxronizasiya uğursuz oldu: %1$s</string>
     <string name="msg_syncing">Sinxronizasiya edilir...</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Выбрана</string>
     <string name="label_storage">Сховішча</string>
     <string name="label_success_rate">Паспяховасць</string>
+    <string name="label_sync_debounce">Затрымка аўтасінхранізацыі</string>
     <string name="label_time_day">Дзень</string>
     <string name="label_time_evening">Вечар</string>
     <string name="label_time_morning">Раніца</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Пакінуць лакальныя</string>
     <string name="action_keep_server">Пакінуць серверныя</string>
     <string name="format_pending_sync">%1$d змяненняў чакае сінхранізацыі</string>
+    <string name="format_sync_debounce_seconds">%1$d сек</string>
     <string name="msg_sync_conflict">Вашы лакальныя змены канфліктуюць з серверам. Выберыце, якую версію захаваць.</string>
     <string name="msg_sync_failed">Памылка сінхранізацыі: %1$s</string>
     <string name="msg_syncing">Сінхранізацыя...</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Ausgewählt</string>
     <string name="label_storage">Speicher</string>
     <string name="label_success_rate">Erfolgsrate</string>
+    <string name="label_sync_debounce">Auto-Sync-Verzögerung</string>
     <string name="label_theme">Design</string>
     <string name="label_time_day">Tag</string>
     <string name="label_time_evening">Abend</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Lokal behalten</string>
     <string name="action_keep_server">Server behalten</string>
     <string name="format_pending_sync">%1$d ausstehende Änderungen</string>
+    <string name="format_sync_debounce_seconds">%1$d Sek.</string>
     <string name="msg_sync_conflict">Ihre lokalen Änderungen stehen im Konflikt mit dem Server. Wählen Sie, welche Version behalten werden soll.</string>
     <string name="msg_sync_failed">Synchronisierung fehlgeschlagen: %1$s</string>
     <string name="msg_syncing">Synchronisiere...</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Seleccionado</string>
     <string name="label_storage">Almacenamiento</string>
     <string name="label_success_rate">Tasa de éxito</string>
+    <string name="label_sync_debounce">Retardo de sincronización</string>
     <string name="label_theme">Tema</string>
     <string name="label_time_day">Día</string>
     <string name="label_time_evening">Tarde</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Mantener local</string>
     <string name="action_keep_server">Mantener servidor</string>
     <string name="format_pending_sync">%1$d cambios pendientes</string>
+    <string name="format_sync_debounce_seconds">%1$d seg</string>
     <string name="msg_sync_conflict">Sus cambios locales están en conflicto con el servidor. Elija qué versión mantener.</string>
     <string name="msg_sync_failed">Error de sincronización: %1$s</string>
     <string name="msg_syncing">Sincronizando...</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Sélectionné</string>
     <string name="label_storage">Stockage</string>
     <string name="label_success_rate">Taux de réussite</string>
+    <string name="label_sync_debounce">Délai de synchronisation</string>
     <string name="label_theme">Thème</string>
     <string name="label_time_day">Jour</string>
     <string name="label_time_evening">Soir</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Garder local</string>
     <string name="action_keep_server">Garder serveur</string>
     <string name="format_pending_sync">%1$d modifications en attente</string>
+    <string name="format_sync_debounce_seconds">%1$d sec</string>
     <string name="msg_sync_conflict">Vos modifications locales sont en conflit avec le serveur. Choisissez quelle version conserver.</string>
     <string name="msg_sync_failed">Échec de la synchronisation : %1$s</string>
     <string name="msg_syncing">Synchronisation...</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">चयनित</string>
     <string name="label_storage">स्टोरेज</string>
     <string name="label_success_rate">सफलता दर</string>
+    <string name="label_sync_debounce">स्वतः-सिंक विलंब</string>
     <string name="label_theme">थीम</string>
     <string name="label_time_day">दिन</string>
     <string name="label_time_evening">शाम</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">स्थानीय रखें</string>
     <string name="action_keep_server">सर्वर रखें</string>
     <string name="format_pending_sync">%1$d लंबित परिवर्तन</string>
+    <string name="format_sync_debounce_seconds">%1$d सेकंड</string>
     <string name="msg_sync_conflict">आपके स्थानीय परिवर्तन सर्वर के साथ विरोध में हैं। कौन सा संस्करण रखना है चुनें।</string>
     <string name="msg_sync_failed">सिंक विफल: %1$s</string>
     <string name="msg_syncing">सिंक हो रहा है...</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">選択済み</string>
     <string name="label_storage">ストレージ</string>
     <string name="label_success_rate">成功率</string>
+    <string name="label_sync_debounce">自動同期遅延</string>
     <string name="label_theme">テーマ</string>
     <string name="label_time_day">昼</string>
     <string name="label_time_evening">夕方</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">ローカルを保持</string>
     <string name="action_keep_server">サーバーを保持</string>
     <string name="format_pending_sync">%1$d件の保留中の変更</string>
+    <string name="format_sync_debounce_seconds">%1$d 秒</string>
     <string name="msg_sync_conflict">ローカルの変更がサーバーと競合しています。どちらのバージョンを保持するか選択してください。</string>
     <string name="msg_sync_failed">同期に失敗しました：%1$s</string>
     <string name="msg_syncing">同期中...</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">არჩეული</string>
     <string name="label_storage">საცავი</string>
     <string name="label_success_rate">წარმატების მაჩვენებელი</string>
+    <string name="label_sync_debounce">ავტო-სინქრონიზაციის შეყოვნება</string>
     <string name="label_theme">თემა</string>
     <string name="label_time_day">დღე</string>
     <string name="label_time_evening">საღამო</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">ლოკალური შენარჩუნება</string>
     <string name="action_keep_server">სერვერის შენარჩუნება</string>
     <string name="format_pending_sync">%1$d მომლოდინე ცვლილება</string>
+    <string name="format_sync_debounce_seconds">%1$d წმ</string>
     <string name="msg_sync_conflict">თქვენი ლოკალური ცვლილებები კონფლიქტშია სერვერთან. აირჩიეთ რომელი ვერსია შეინარჩუნოთ.</string>
     <string name="msg_sync_failed">სინქრონიზაცია ვერ მოხერხდა: %1$s</string>
     <string name="msg_syncing">მიმდინარეობს სინქრონიზაცია...</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Таңдалған</string>
     <string name="label_storage">Сақтау орны</string>
     <string name="label_success_rate">Сәттілік деңгейі</string>
+    <string name="label_sync_debounce">Автосинхрондау кешігуі</string>
     <string name="label_time_day">Күн</string>
     <string name="label_time_evening">Кеш</string>
     <string name="label_time_morning">Таң</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Жергілікті сақтау</string>
     <string name="action_keep_server">Серверді сақтау</string>
     <string name="format_pending_sync">%1$d күтудегі өзгеріс</string>
+    <string name="format_sync_debounce_seconds">%1$d сек</string>
     <string name="msg_sync_conflict">Жергілікті өзгерістеріңіз сервермен қайшы келеді. Қай нұсқаны сақтау керектігін таңдаңыз.</string>
     <string name="msg_sync_failed">Синхрондау сәтсіз аяқталды: %1$s</string>
     <string name="msg_syncing">Синхрондалуда...</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Тандалган</string>
     <string name="label_storage">Сактагыч</string>
     <string name="label_success_rate">Ийгилик деңгээли</string>
+    <string name="label_sync_debounce">Авто-синхрондоштуруу кечигүүсү</string>
     <string name="label_theme">Тема</string>
     <string name="label_time_day">Күн</string>
     <string name="label_time_evening">Кеч</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Жергиликтүү сактоо</string>
     <string name="action_keep_server">Серверди сактоо</string>
     <string name="format_pending_sync">%1$d күтүүдөгү өзгөртүү</string>
+    <string name="format_sync_debounce_seconds">%1$d сек</string>
     <string name="msg_sync_conflict">Жергиликтүү өзгөртүүлөрүңүз сервер менен карама-каршы келет. Кайсы версияны сактоо керектигин тандаңыз.</string>
     <string name="msg_sync_failed">Шайкештирүү ийгиликсиз: %1$s</string>
     <string name="msg_syncing">Шайкештирүүдө...</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Selecionado</string>
     <string name="label_storage">Armazenamento</string>
     <string name="label_success_rate">Taxa de sucesso</string>
+    <string name="label_sync_debounce">Atraso de sincronização</string>
     <string name="label_theme">Tema</string>
     <string name="label_time_day">Dia</string>
     <string name="label_time_evening">Tarde</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Manter local</string>
     <string name="action_keep_server">Manter servidor</string>
     <string name="format_pending_sync">%1$d alterações pendentes</string>
+    <string name="format_sync_debounce_seconds">%1$d seg</string>
     <string name="msg_sync_conflict">Suas alterações locais conflitam com o servidor. Escolha qual versão manter.</string>
     <string name="msg_sync_failed">Falha na sincronização: %1$s</string>
     <string name="msg_syncing">Sincronizando...</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Selectat</string>
     <string name="label_storage">Stocare</string>
     <string name="label_success_rate">Rată de succes</string>
+    <string name="label_sync_debounce">Întârziere sincronizare automată</string>
     <string name="label_theme">Temă</string>
     <string name="label_time_day">Zi</string>
     <string name="label_time_evening">Seară</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Păstrează local</string>
     <string name="action_keep_server">Păstrează server</string>
     <string name="format_pending_sync">%1$d modificări în așteptare</string>
+    <string name="format_sync_debounce_seconds">%1$d sec</string>
     <string name="msg_sync_conflict">Modificările locale sunt în conflict cu serverul. Alegeți ce versiune să păstrați.</string>
     <string name="msg_sync_failed">Sincronizare eșuată: %1$s</string>
     <string name="msg_syncing">Sincronizare...</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -112,6 +112,7 @@
     <string name="label_selected">Выбрано</string>
     <string name="label_storage">Хранилище</string>
     <string name="label_success_rate">Процент выполнения</string>
+    <string name="label_sync_debounce">Задержка автосинхронизации</string>
     <string name="label_time_day">День</string>
     <string name="label_time_evening">Вечер</string>
     <string name="label_time_morning">Утро</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Оставить локальные</string>
     <string name="action_keep_server">Оставить серверные</string>
     <string name="format_pending_sync">В очереди синхронизации: %1$d</string>
+    <string name="format_sync_debounce_seconds">%1$d сек</string>
     <string name="msg_sync_conflict">Твои локальные изменения конфликтуют с сервером. Выбери, какую версию сохранить.</string>
     <string name="msg_sync_failed">Ошибка синхронизации: %1$s</string>
     <string name="msg_syncing">Синхронизация...</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Интихобшуда</string>
     <string name="label_storage">Анбор</string>
     <string name="label_success_rate">Дараҷаи муваффақият</string>
+    <string name="label_sync_debounce">Таъхири ҳамоҳангсозии худкор</string>
     <string name="label_theme">Мавзуъ</string>
     <string name="label_time_day">Рӯз</string>
     <string name="label_time_evening">Бегоҳ</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Маҳаллӣ нигоҳ доред</string>
     <string name="action_keep_server">Серверро нигоҳ доред</string>
     <string name="format_pending_sync">%1$d тағйирот интизор аст</string>
+    <string name="format_sync_debounce_seconds">%1$d сония</string>
     <string name="msg_sync_conflict">Тағйироти маҳаллии шумо бо сервер ихтилоф дорад. Интихоб кунед, ки кадом версияро нигоҳ доред.</string>
     <string name="msg_sync_failed">Ҳамоҳангсозӣ ноком шуд: %1$s</string>
     <string name="msg_syncing">Ҳамоҳангсозӣ...</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Saýlanan</string>
     <string name="label_storage">Ammar</string>
     <string name="label_success_rate">Üstünlik derejesi</string>
+    <string name="label_sync_debounce">Awtomatik sinhronlaşdyrma gijikdirmesi</string>
     <string name="label_theme">Tema</string>
     <string name="label_time_day">Gündiz</string>
     <string name="label_time_evening">Agşam</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Ýerli sakla</string>
     <string name="action_keep_server">Serveri sakla</string>
     <string name="format_pending_sync">%1$d garaşýan üýtgeşme</string>
+    <string name="format_sync_debounce_seconds">%1$d sek</string>
     <string name="msg_sync_conflict">Ýerli üýtgeşmeleriňiz server bilen gapma-garşy. Haýsy wersiýany saklamalydygyny saýlaň.</string>
     <string name="msg_sync_failed">Sinhronizasiýa şowsuz: %1$s</string>
     <string name="msg_syncing">Sinhronizasiýa edilýär...</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Обрано</string>
     <string name="label_storage">Сховище</string>
     <string name="label_success_rate">Успішність</string>
+    <string name="label_sync_debounce">Затримка автосинхронізації</string>
     <string name="label_time_day">День</string>
     <string name="label_time_evening">Вечір</string>
     <string name="label_time_morning">Ранок</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Залишити локальні</string>
     <string name="action_keep_server">Залишити серверні</string>
     <string name="format_pending_sync">%1$d змін очікує синхронізації</string>
+    <string name="format_sync_debounce_seconds">%1$d сек</string>
     <string name="msg_sync_conflict">Ваші локальні зміни конфліктують із сервером. Виберіть, яку версію зберегти.</string>
     <string name="msg_sync_failed">Помилка синхронізації: %1$s</string>
     <string name="msg_syncing">Синхронізація...</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">Tanlangan</string>
     <string name="label_storage">Saqlash joyi</string>
     <string name="label_success_rate">Muvaffaqiyat darajasi</string>
+    <string name="label_sync_debounce">Avtosinxronlash kechikishi</string>
     <string name="label_theme">Mavzu</string>
     <string name="label_time_day">Kun</string>
     <string name="label_time_evening">Kechqurun</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Mahalliyni saqlash</string>
     <string name="action_keep_server">Serverni saqlash</string>
     <string name="format_pending_sync">%1$d ta kutilayotgan o\'zgarish</string>
+    <string name="format_sync_debounce_seconds">%1$d soniya</string>
     <string name="msg_sync_conflict">Mahalliy o\'zgarishlaringiz server bilan ziddiyatda. Qaysi versiyani saqlash kerakligini tanlang.</string>
     <string name="msg_sync_failed">Sinxronlash muvaffaqiyatsiz: %1$s</string>
     <string name="msg_syncing">Sinxronlanmoqda...</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -110,6 +110,7 @@
     <string name="label_selected">已选择</string>
     <string name="label_storage">存储</string>
     <string name="label_success_rate">成功率</string>
+    <string name="label_sync_debounce">自动同步延迟</string>
     <string name="label_theme">主题</string>
     <string name="label_time_day">白天</string>
     <string name="label_time_evening">傍晚</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">保留本地</string>
     <string name="action_keep_server">保留服务器</string>
     <string name="format_pending_sync">%1$d 个待同步更改</string>
+    <string name="format_sync_debounce_seconds">%1$d 秒</string>
     <string name="msg_sync_conflict">您的本地更改与服务器冲突。请选择保留哪个版本。</string>
     <string name="msg_sync_failed">同步失败：%1$s</string>
     <string name="msg_syncing">同步中...</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -112,6 +112,7 @@
     <string name="label_selected">Selected</string>
     <string name="label_storage">Storage</string>
     <string name="label_success_rate">Success rate</string>
+    <string name="label_sync_debounce">Auto-sync delay</string>
     <string name="label_time_day">Day</string>
     <string name="label_time_evening">Evening</string>
     <string name="label_time_morning">Morning</string>
@@ -256,6 +257,7 @@
     <string name="action_keep_local">Keep local</string>
     <string name="action_keep_server">Keep server</string>
     <string name="format_pending_sync">%1$d pending changes</string>
+    <string name="format_sync_debounce_seconds">%1$d sec</string>
     <string name="msg_sync_conflict">Your local changes conflict with the server. Choose which version to keep.</string>
     <string name="msg_sync_failed">Sync failed: %1$s</string>
     <string name="msg_syncing">Syncing...</string>

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppFeaturesFactory.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppFeaturesFactory.kt
@@ -1,4 +1,5 @@
 package space.be1ski.vibits.feature.homescreen.di
+
 import dev.zacsweers.metro.Inject
 import kotlinx.coroutines.CoroutineScope
 import space.be1ski.vibits.core.platform.date.currentLocalDate
@@ -46,7 +47,11 @@ class AppFeaturesFactory(
       )
 
     val skipCredentials = initialMode == AppMode.OFFLINE || initialMode == AppMode.DEMO
-    val memosFeature = createMemosFeature(memosDependencies, isOfflineMode = skipCredentials)
+    val memosFeature =
+      createMemosFeature(
+        dependencies = memosDependencies,
+        isOfflineMode = skipCredentials,
+      )
 
     val habitsFeature =
       createHabitsFeature(
@@ -62,6 +67,7 @@ class AppFeaturesFactory(
         dependencies = settingsDependencies,
         initialMode = initialMode,
         appDetails = appDetails,
+        initialSyncDebounceSeconds = initialPrefs.memosAutoSyncDebounceDuration.inWholeSeconds.toInt(),
       )
 
     appFeature.launchIn(scope)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
@@ -33,7 +33,18 @@ internal fun FeatureCoordinator(
   // Cross-feature coordination via Settings notifications
   LaunchedEffect(features.settings) {
     features.settings.notifications.collect { notification ->
-      handleNotification(notification, dispatchApp, dispatchMemos, dispatchHabits, onResetApp, onThemeChanged, onLanguageChanged)
+      val currentMemosState = features.memos.state.value
+      handleNotification(
+        notification,
+        currentMemosState.baseUrl,
+        currentMemosState.token,
+        dispatchApp,
+        dispatchMemos,
+        dispatchHabits,
+        onResetApp,
+        onThemeChanged,
+        onLanguageChanged,
+      )
     }
   }
 
@@ -48,6 +59,7 @@ internal fun FeatureCoordinator(
           appMode = appState.appMode,
           language = currentLanguage,
           theme = currentTheme,
+          syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
         ),
       )
     }
@@ -71,6 +83,8 @@ internal fun FeatureCoordinator(
 @Suppress("LongParameterList")
 private fun handleNotification(
   effect: SettingsEffect.Notification,
+  currentMemosBaseUrl: String,
+  currentMemosToken: String,
   dispatchApp: (AppAction) -> Unit,
   dispatchMemos: (MemosAction) -> Unit,
   dispatchHabits: (HabitsAction) -> Unit,
@@ -87,9 +101,12 @@ private fun handleNotification(
     }
     is SettingsEffect.Notification.ResetCompleted -> onResetApp()
     is SettingsEffect.Notification.CredentialsSaved -> {
+      val credentialsChanged = effect.baseUrl != currentMemosBaseUrl || effect.token != currentMemosToken
       dispatchMemos(MemosAction.Credentials.UpdateBaseUrl(effect.baseUrl))
       dispatchMemos(MemosAction.Credentials.UpdateToken(effect.token))
-      dispatchMemos(MemosAction.Loading.LoadMemos)
+      if (credentialsChanged) {
+        dispatchMemos(MemosAction.Loading.LoadMemos)
+      }
     }
     is SettingsEffect.Notification.ThemeChanged -> onThemeChanged(effect.theme)
     is SettingsEffect.Notification.LanguageChanged -> onLanguageChanged(effect.language)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -43,6 +43,7 @@ internal fun VibitsApp(
     habitsState = habitsState,
     currentLanguage = currentLanguage,
     currentTheme = currentTheme,
+    syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
   )
 
   SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
@@ -50,6 +50,7 @@ internal fun MemosHeader(
   dispatchSettings: (SettingsAction) -> Unit,
   language: AppLanguage,
   theme: AppTheme,
+  syncDebounceSeconds: Int,
 ) {
   Row(
     modifier = Modifier.fillMaxWidth(),
@@ -94,6 +95,7 @@ internal fun MemosHeader(
               appMode = appState.appMode,
               language = language,
               theme = theme,
+              syncDebounceSeconds = syncDebounceSeconds,
             ),
           )
         },

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppScaffold.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppScaffold.kt
@@ -60,6 +60,7 @@ internal fun VibitsAppScaffold(
   habitsState: HabitsState,
   currentLanguage: AppLanguage,
   currentTheme: AppTheme,
+  syncDebounceSeconds: Int,
 ) {
   val timeZone = remember { TimeZone.currentSystemDefault() }
   val today = currentLocalDate()
@@ -133,6 +134,7 @@ internal fun VibitsAppScaffold(
       callbacks = callbacks,
       currentLanguage = currentLanguage,
       currentTheme = currentTheme,
+      syncDebounceSeconds = syncDebounceSeconds,
       feedListState = feedListState,
       dateFormatter = dateFormatter,
     )
@@ -175,6 +177,7 @@ private fun ScaffoldContent(
   callbacks: ScaffoldCallbacks,
   currentLanguage: AppLanguage,
   currentTheme: AppTheme,
+  syncDebounceSeconds: Int,
   feedListState: LazyListState,
   dateFormatter: DateFormatter,
 ) {
@@ -196,6 +199,7 @@ private fun ScaffoldContent(
       features.settings::send,
       currentLanguage,
       currentTheme,
+      syncDebounceSeconds,
     )
     val errorText =
       memosState.errorMessage

--- a/feature/memos/presentation/build.gradle.kts
+++ b/feature/memos/presentation/build.gradle.kts
@@ -9,6 +9,7 @@ kotlin {
         implementation(projects.feature.auth.domain)
         implementation(projects.feature.habits.domain)
         implementation(projects.feature.memos.domain)
+        implementation(projects.feature.settings.domain)
         implementation(projects.feature.sync.domain)
         implementation(libs.compose.material)
         implementation(libs.kotlinx.datetime)
@@ -18,6 +19,7 @@ kotlin {
       dependencies {
         implementation(projects.feature.auth.domain.testing)
         implementation(projects.feature.memos.domain.testing)
+        implementation(projects.feature.settings.domain.testing)
         implementation(projects.feature.sync.domain.testing)
       }
     }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/di/MemosDependencies.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/di/MemosDependencies.kt
@@ -8,6 +8,7 @@ import space.be1ski.vibits.feature.memos.domain.usecase.DeleteMemoUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadCachedMemosUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.LoadMemosUseCase
 import space.be1ski.vibits.feature.memos.domain.usecase.UpdateMemoUseCase
+import space.be1ski.vibits.feature.settings.domain.usecase.LoadSyncDebounceDurationUseCase
 import space.be1ski.vibits.feature.sync.domain.SyncEngine
 import space.be1ski.vibits.feature.sync.domain.repository.SyncQueueRepository
 
@@ -21,6 +22,7 @@ class MemosDependencies(
   val createMemo: CreateMemoUseCase,
   val updateMemo: UpdateMemoUseCase,
   val deleteMemo: DeleteMemoUseCase,
+  val loadSyncDebounceDuration: LoadSyncDebounceDurationUseCase,
   val syncEngine: SyncEngine,
   val syncQueueRepository: SyncQueueRepository,
 )

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/di/MemosFeatureFactory.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/di/MemosFeatureFactory.kt
@@ -52,8 +52,13 @@ fun createMemosFeature(
           MemosSyncEffectHandler(
             syncEngine = dependencies.syncEngine,
             syncQueueRepository = dependencies.syncQueueRepository,
+            loadSyncDebounceDuration = dependencies.loadSyncDebounceDuration,
           ),
       ),
-    initialCommands = if (!needsCredentials) listOf(MemosEffect.LoadCachedMemos) else emptyList(),
+    initialCommands =
+      buildList {
+        if (!needsCredentials) add(MemosEffect.LoadCachedMemos)
+        if (!isOfflineMode) add(MemosEffect.ObserveSyncStatus)
+      },
   )
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/action/MemosAction.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/action/MemosAction.kt
@@ -110,6 +110,8 @@ sealed interface MemosAction : Action {
   sealed interface Sync : MemosAction {
     data object StartSync : Sync
 
+    data object SyncStarted : Sync
+
     data class SyncCompleted(
       val memos: List<Memo>,
     ) : Sync

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandler.kt
@@ -1,11 +1,15 @@
 package space.be1ski.vibits.feature.memos.presentation.effect
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.actions
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.settings.domain.usecase.LoadSyncDebounceDurationUseCase
 import space.be1ski.vibits.feature.sync.domain.SyncEngine
 import space.be1ski.vibits.feature.sync.domain.SyncLogTags
 import space.be1ski.vibits.feature.sync.domain.model.SyncResult
@@ -16,7 +20,11 @@ private const val TAG = SyncLogTags.MEMOS_SYNC_EFFECT
 class MemosSyncEffectHandler(
   private val syncEngine: SyncEngine,
   private val syncQueueRepository: SyncQueueRepository,
+  private val loadSyncDebounceDuration: LoadSyncDebounceDurationUseCase,
 ) : EffectHandler<MemosEffect.Sync, MemosAction> {
+  private val debounceMutex = Mutex()
+  private var latestPerformSyncRequestId = 0L
+
   override fun invoke(effect: MemosEffect.Sync): Flow<MemosAction> =
     when (effect) {
       is MemosEffect.PerformSync -> handlePerformSync()
@@ -28,7 +36,15 @@ class MemosSyncEffectHandler(
 
   private fun handlePerformSync(): Flow<MemosAction> =
     actions {
+      val requestId = registerPerformSyncRequest()
+      delay(loadSyncDebounceDuration())
+      if (!isLatestPerformSyncRequest(requestId)) {
+        Log.d(TAG, "Skipping stale sync request")
+        return@actions
+      }
+
       Log.d(TAG, "Performing sync")
+      emit(MemosAction.Sync.SyncStarted)
       when (val result = syncEngine.performSync()) {
         is SyncResult.Success -> {
           Log.i(TAG, "Sync completed: ${result.syncedMemos.size} memos")
@@ -102,5 +118,16 @@ class MemosSyncEffectHandler(
   private fun handleObserveSyncStatus(): Flow<MemosAction> =
     syncQueueRepository.observeSyncStatus().map { status ->
       MemosAction.Sync.SyncStatusUpdated(status)
+    }
+
+  private suspend fun registerPerformSyncRequest(): Long =
+    debounceMutex.withLock {
+      latestPerformSyncRequestId += 1
+      latestPerformSyncRequestId
+    }
+
+  private suspend fun isLatestPerformSyncRequest(requestId: Long): Boolean =
+    debounceMutex.withLock {
+      requestId == latestPerformSyncRequestId
     }
 }

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/reducer/MemosSyncReducer.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/reducer/MemosSyncReducer.kt
@@ -19,8 +19,11 @@ internal val syncReducer: Reducer<MemosAction.Sync, MemosState, MemosEffect, Not
 
     when (action) {
       is MemosAction.Sync.StartSync -> {
-        state { state.copy(isSyncing = true, errorMessage = null) }
         command(MemosEffect.PerformSync)
+      }
+
+      is MemosAction.Sync.SyncStarted -> {
+        state { state.copy(isSyncing = true, errorMessage = null) }
       }
 
       is MemosAction.Sync.SyncCompleted -> {

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosEffectHandlerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosEffectHandlerTest.kt
@@ -20,6 +20,8 @@ import space.be1ski.vibits.feature.memos.presentation.effect.MemosEffectHandler
 import space.be1ski.vibits.feature.memos.presentation.effect.MemosLoadEffectHandler
 import space.be1ski.vibits.feature.memos.presentation.effect.MemosSyncEffectHandler
 import space.be1ski.vibits.feature.memos.presentation.effect.MemosWriteEffectHandler
+import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
+import space.be1ski.vibits.feature.settings.domain.usecase.LoadSyncDebounceDurationUseCase
 import space.be1ski.vibits.feature.sync.domain.test.FakeSyncEngine
 import space.be1ski.vibits.feature.sync.domain.test.FakeSyncQueueRepository
 import kotlin.test.Test
@@ -222,6 +224,7 @@ class MemosEffectHandlerTest {
         MemosSyncEffectHandler(
           syncEngine = FakeSyncEngine(),
           syncQueueRepository = FakeSyncQueueRepository(),
+          loadSyncDebounceDuration = LoadSyncDebounceDurationUseCase(FakePreferencesRepository()),
         ),
     )
   }

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosReducerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosReducerTest.kt
@@ -435,11 +435,11 @@ class MemosReducerTest {
   // ============ Sync Reducer Tests ============
 
   @Test
-  fun `when StartSync in online mode then sets isSyncing and emits PerformSync`() =
+  fun `when StartSync in online mode then emits PerformSync without setting isSyncing`() =
     memosReducer.test(MemosState(isOfflineMode = false, errorMessage = "old error")) {
       send(MemosAction.Sync.StartSync)
 
-      assertState { isSyncing && errorMessage == null }
+      assertState { !isSyncing && errorMessage == "old error" }
       assertCommands(MemosEffect.PerformSync)
     }
 

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosSyncReducerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/MemosSyncReducerTest.kt
@@ -44,12 +44,21 @@ class MemosSyncReducerTest {
   // ========== Sync Actions in Online Mode ==========
 
   @Test
-  fun `when StartSync in online mode then starts syncing and emits PerformSync`() =
+  fun `when StartSync in online mode then emits PerformSync without setting isSyncing`() =
     memosReducer.test(MemosState(isOfflineMode = false)) {
       send(MemosAction.Sync.StartSync)
 
-      assertState { isSyncing && errorMessage == null }
+      assertState { !isSyncing }
       assertCommands(MemosEffect.PerformSync)
+    }
+
+  @Test
+  fun `when SyncStarted then sets isSyncing to true`() =
+    memosReducer.test(MemosState(isOfflineMode = false)) {
+      send(MemosAction.Sync.SyncStarted)
+
+      assertState { isSyncing && errorMessage == null }
+      assertNoEffects()
     }
 
   @Test

--- a/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandlerTest.kt
+++ b/feature/memos/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/presentation/effect/MemosSyncEffectHandlerTest.kt
@@ -1,9 +1,18 @@
 package space.be1ski.vibits.feature.memos.presentation.effect
 
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.settings.domain.model.DEFAULT_MEMOS_AUTO_SYNC_DEBOUNCE_DURATION
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
+import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
+import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
+import space.be1ski.vibits.feature.settings.domain.usecase.LoadSyncDebounceDurationUseCase
 import space.be1ski.vibits.feature.sync.domain.model.ConflictType
 import space.be1ski.vibits.feature.sync.domain.model.SyncConflict
 import space.be1ski.vibits.feature.sync.domain.model.SyncOperation
@@ -16,11 +25,17 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 import kotlin.time.Clock
+import kotlin.time.Duration.Companion.seconds
 
 class MemosSyncEffectHandlerTest {
   private val fakeSyncEngine = FakeSyncEngine()
   private val fakeSyncQueue = FakeSyncQueueRepository()
-  private val handler = MemosSyncEffectHandler(fakeSyncEngine, fakeSyncQueue)
+  private val handler =
+    MemosSyncEffectHandler(
+      syncEngine = fakeSyncEngine,
+      syncQueueRepository = fakeSyncQueue,
+      loadSyncDebounceDuration = LoadSyncDebounceDurationUseCase(FakePreferencesRepository()),
+    )
 
   private val testMemo =
     Memo(
@@ -31,19 +46,20 @@ class MemosSyncEffectHandlerTest {
     )
 
   @Test
-  fun `when PerformSync succeeds then emits SyncCompleted`() =
+  fun `when PerformSync succeeds then emits SyncStarted and SyncCompleted`() =
     runTest {
       fakeSyncEngine.performSyncResult = SyncResult.Success(listOf(testMemo))
 
       val actions = handler(MemosEffect.PerformSync).toList()
 
-      assertEquals(1, actions.size)
-      val action = actions[0] as MemosAction.Sync.SyncCompleted
+      assertEquals(2, actions.size)
+      assertTrue(actions[0] is MemosAction.Sync.SyncStarted)
+      val action = actions[1] as MemosAction.Sync.SyncCompleted
       assertEquals(1, action.memos.size)
     }
 
   @Test
-  fun `when PerformSync has conflicts then emits SyncConflictDetected`() =
+  fun `when PerformSync has conflicts then emits SyncStarted and SyncConflictDetected`() =
     runTest {
       val conflict =
         SyncConflict(
@@ -63,32 +79,35 @@ class MemosSyncEffectHandlerTest {
 
       val actions = handler(MemosEffect.PerformSync).toList()
 
-      assertEquals(1, actions.size)
-      val action = actions[0] as MemosAction.Sync.SyncConflictDetected
+      assertEquals(2, actions.size)
+      assertTrue(actions[0] is MemosAction.Sync.SyncStarted)
+      val action = actions[1] as MemosAction.Sync.SyncConflictDetected
       assertEquals(1, action.conflicts.size)
     }
 
   @Test
-  fun `when PerformSync fails then emits SyncFailed`() =
+  fun `when PerformSync fails then emits SyncStarted and SyncFailed`() =
     runTest {
       fakeSyncEngine.performSyncResult = SyncResult.Error("Network error")
 
       val actions = handler(MemosEffect.PerformSync).toList()
 
-      assertEquals(1, actions.size)
-      val action = actions[0] as MemosAction.Sync.SyncFailed
+      assertEquals(2, actions.size)
+      assertTrue(actions[0] is MemosAction.Sync.SyncStarted)
+      val action = actions[1] as MemosAction.Sync.SyncFailed
       assertEquals("Network error", action.error)
     }
 
   @Test
-  fun `when PerformSync has no credentials then emits SyncFailed`() =
+  fun `when PerformSync has no credentials then emits SyncStarted and SyncFailed`() =
     runTest {
       fakeSyncEngine.performSyncResult = SyncResult.NoCredentials
 
       val actions = handler(MemosEffect.PerformSync).toList()
 
-      assertEquals(1, actions.size)
-      assertTrue(actions[0] is MemosAction.Sync.SyncFailed)
+      assertEquals(2, actions.size)
+      assertTrue(actions[0] is MemosAction.Sync.SyncStarted)
+      assertTrue(actions[1] is MemosAction.Sync.SyncFailed)
     }
 
   @Test
@@ -204,5 +223,36 @@ class MemosSyncEffectHandlerTest {
       assertEquals(1, actions.size)
       val action = actions[0] as MemosAction.Sync.SyncStatusUpdated
       assertEquals(3, action.status.pendingCount)
+    }
+
+  @Test
+  @OptIn(ExperimentalCoroutinesApi::class)
+  fun `when PerformSync requested repeatedly within debounce window then only latest request performs sync`() =
+    runTest {
+      val debouncePrefs =
+        FakePreferencesRepository(
+          UserPreferences(TimeRangeTab.WEEKS, TimeRangeTab.WEEKS, memosAutoSyncDebounceDuration = 30.seconds),
+        )
+      val debounceHandler =
+        MemosSyncEffectHandler(
+          syncEngine = fakeSyncEngine,
+          syncQueueRepository = fakeSyncQueue,
+          loadSyncDebounceDuration = LoadSyncDebounceDurationUseCase(debouncePrefs),
+        )
+      fakeSyncEngine.performSyncResult = SyncResult.Success(listOf(testMemo))
+
+      val firstRequest = async { debounceHandler(MemosEffect.PerformSync).toList() }
+      advanceTimeBy(10_000)
+      val secondRequest = async { debounceHandler(MemosEffect.PerformSync).toList() }
+      advanceUntilIdle()
+
+      val firstActions = firstRequest.await()
+      val secondActions = secondRequest.await()
+
+      assertTrue(firstActions.isEmpty())
+      assertEquals(2, secondActions.size)
+      assertTrue(secondActions[0] is MemosAction.Sync.SyncStarted)
+      assertTrue(secondActions[1] is MemosAction.Sync.SyncCompleted)
+      assertEquals(1, fakeSyncEngine.performSyncCallCount)
     }
 }

--- a/feature/mode/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
+++ b/feature/mode/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/SwitchAppModeUseCase.kt
@@ -8,10 +8,12 @@ import space.be1ski.vibits.feature.mode.domain.repository.AppModeRepository
 class SwitchAppModeUseCase(
   private val appModeRepository: AppModeRepository,
 ) {
-  operator fun invoke(mode: AppMode) {
+  operator fun invoke(mode: AppMode): Boolean {
     val currentMode = appModeRepository.loadMode()
     if (currentMode != mode) {
       appModeRepository.saveMode(mode)
+      return true
     }
+    return false
   }
 }

--- a/feature/mode/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/ModeUseCasesTest.kt
+++ b/feature/mode/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/domain/usecase/ModeUseCasesTest.kt
@@ -10,6 +10,8 @@ import space.be1ski.vibits.feature.onboarding.domain.test.FakeOnboardingStore
 import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 
 class LoadAppModeUseCaseTest {
   @Test
@@ -101,45 +103,49 @@ class ResetAppUseCaseTest {
 
 class SwitchAppModeUseCaseTest {
   @Test
-  fun `when mode is different then saves new mode`() {
+  fun `when mode is different then saves and returns true`() {
     val repository = FakeAppModeRepository(initial = AppMode.NOT_SELECTED)
     val useCase = SwitchAppModeUseCase(repository)
 
-    useCase(AppMode.ONLINE)
+    val changed = useCase(AppMode.ONLINE)
 
+    assertTrue(changed)
     assertEquals(AppMode.ONLINE, repository.storedMode)
     assertEquals(1, repository.saveCalls)
   }
 
   @Test
-  fun `when mode is same then does not save`() {
+  fun `when mode is same then does not save and returns false`() {
     val repository = FakeAppModeRepository(initial = AppMode.OFFLINE)
     val useCase = SwitchAppModeUseCase(repository)
 
-    useCase(AppMode.OFFLINE)
+    val changed = useCase(AppMode.OFFLINE)
 
+    assertFalse(changed)
     assertEquals(AppMode.OFFLINE, repository.storedMode)
     assertEquals(0, repository.saveCalls)
   }
 
   @Test
-  fun `when switching from Demo to Online then saves`() {
+  fun `when switching from Demo to Online then saves and returns true`() {
     val repository = FakeAppModeRepository(initial = AppMode.DEMO)
     val useCase = SwitchAppModeUseCase(repository)
 
-    useCase(AppMode.ONLINE)
+    val changed = useCase(AppMode.ONLINE)
 
+    assertTrue(changed)
     assertEquals(AppMode.ONLINE, repository.storedMode)
     assertEquals(1, repository.saveCalls)
   }
 
   @Test
-  fun `when switching from Online to Offline then saves`() {
+  fun `when switching from Online to Offline then saves and returns true`() {
     val repository = FakeAppModeRepository(initial = AppMode.ONLINE)
     val useCase = SwitchAppModeUseCase(repository)
 
-    useCase(AppMode.OFFLINE)
+    val changed = useCase(AppMode.OFFLINE)
 
+    assertTrue(changed)
     assertEquals(AppMode.OFFLINE, repository.storedMode)
     assertEquals(1, repository.saveCalls)
   }

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/LocalUserPreferences.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/LocalUserPreferences.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.feature.settings.data
 
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.DEFAULT_SYNC_DEBOUNCE_SECONDS
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 
 data class LocalUserPreferences(
@@ -9,6 +10,7 @@ data class LocalUserPreferences(
   val postsTimeRangeTab: String,
   val language: String = DEFAULT_LANGUAGE,
   val theme: String = DEFAULT_THEME,
+  val memosAutoSyncDebounceSeconds: Long = DEFAULT_SYNC_DEBOUNCE_SECONDS.toLong(),
 ) {
   companion object {
     val DEFAULT_TIME_RANGE_TAB = TimeRangeTab.WEEKS.name

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImpl.kt
@@ -6,9 +6,12 @@ import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.DEFAULT_MEMOS_AUTO_SYNC_DEBOUNCE_DURATION
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
 import space.be1ski.vibits.feature.settings.domain.repository.PreferencesRepository
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
 
 private const val TAG = "Preferences"
 
@@ -23,23 +26,30 @@ class PreferencesRepositoryImpl(
     val postsTab = parseTimeRangeTab(local.postsTimeRangeTab)
     val language = parseLanguage(local.language)
     val theme = parseTheme(local.theme)
-    Log.d(TAG, "Loaded: theme=$theme, lang=$language")
+    val memosAutoSyncDebounceDuration = parseMemosAutoSyncDebounceDuration(local.memosAutoSyncDebounceSeconds)
+    Log.d(TAG, "Loaded: theme=$theme, lang=$language, syncDebounce=${memosAutoSyncDebounceDuration.inWholeSeconds}s")
     return UserPreferences(
       habitsTimeRangeTab = habitsTab,
       postsTimeRangeTab = postsTab,
       language = language,
       theme = theme,
+      memosAutoSyncDebounceDuration = memosAutoSyncDebounceDuration,
     )
   }
 
   override fun save(preferences: UserPreferences) {
-    Log.i(TAG, "Saving: theme=${preferences.theme}, lang=${preferences.language}")
+    Log.i(
+      TAG,
+      "Saving: theme=${preferences.theme}, lang=${preferences.language}, " +
+        "syncDebounce=${preferences.memosAutoSyncDebounceDuration.inWholeSeconds}s",
+    )
     val local =
       LocalUserPreferences(
         habitsTimeRangeTab = preferences.habitsTimeRangeTab.name,
         postsTimeRangeTab = preferences.postsTimeRangeTab.name,
         language = preferences.language.name,
         theme = preferences.theme.name,
+        memosAutoSyncDebounceSeconds = preferences.memosAutoSyncDebounceDuration.inWholeSeconds,
       )
     preferencesStore.save(local)
   }
@@ -49,4 +59,7 @@ class PreferencesRepositoryImpl(
   private fun parseLanguage(value: String): AppLanguage = runCatching { AppLanguage.valueOf(value) }.getOrDefault(AppLanguage.SYSTEM)
 
   private fun parseTheme(value: String): AppTheme = runCatching { AppTheme.valueOf(value) }.getOrDefault(AppTheme.SYSTEM)
+
+  private fun parseMemosAutoSyncDebounceDuration(value: Long): Duration =
+    if (value > 0) value.seconds else DEFAULT_MEMOS_AUTO_SYNC_DEBOUNCE_DURATION
 }

--- a/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesStore.kt
+++ b/feature/settings/data/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesStore.kt
@@ -1,6 +1,7 @@
 package space.be1ski.vibits.feature.settings.data
 
 import space.be1ski.vibits.core.platform.storage.KeyValueStore
+import space.be1ski.vibits.feature.settings.domain.model.DEFAULT_SYNC_DEBOUNCE_SECONDS
 
 interface PreferencesStore {
   fun load(): LocalUserPreferences
@@ -17,11 +18,17 @@ class PreferencesStoreImpl(
     val defaultTab = LocalUserPreferences.DEFAULT_TIME_RANGE_TAB
     val defaultLanguage = LocalUserPreferences.DEFAULT_LANGUAGE
     val defaultTheme = LocalUserPreferences.DEFAULT_THEME
+    val defaultMemosAutoSyncDebounceSeconds = DEFAULT_SYNC_DEBOUNCE_SECONDS.toLong()
     return LocalUserPreferences(
       habitsTimeRangeTab = store.getString(KEY_HABITS_TAB, defaultTab) ?: defaultTab,
       postsTimeRangeTab = store.getString(KEY_POSTS_TAB, defaultTab) ?: defaultTab,
       language = store.getString(KEY_LANGUAGE, defaultLanguage) ?: defaultLanguage,
       theme = store.getString(KEY_THEME, defaultTheme) ?: defaultTheme,
+      memosAutoSyncDebounceSeconds =
+        store
+          .getString(KEY_MEMOS_AUTO_SYNC_DEBOUNCE_SECONDS, defaultMemosAutoSyncDebounceSeconds.toString())
+          ?.toLongOrNull()
+          ?: defaultMemosAutoSyncDebounceSeconds,
     )
   }
 
@@ -30,6 +37,10 @@ class PreferencesStoreImpl(
     store.putString(KEY_POSTS_TAB, preferences.postsTimeRangeTab)
     store.putString(KEY_LANGUAGE, preferences.language)
     store.putString(KEY_THEME, preferences.theme)
+    store.putString(
+      KEY_MEMOS_AUTO_SYNC_DEBOUNCE_SECONDS,
+      preferences.memosAutoSyncDebounceSeconds.toString(),
+    )
   }
 
   private companion object {
@@ -38,5 +49,6 @@ class PreferencesStoreImpl(
     const val KEY_POSTS_TAB = "ui_posts_time_range_tab"
     const val KEY_LANGUAGE = "ui_language"
     const val KEY_THEME = "ui_theme"
+    const val KEY_MEMOS_AUTO_SYNC_DEBOUNCE_SECONDS = "ui_memos_auto_sync_debounce_seconds"
   }
 }

--- a/feature/settings/data/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImplTest.kt
+++ b/feature/settings/data/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesRepositoryImplTest.kt
@@ -6,6 +6,7 @@ import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
 
 class PreferencesRepositoryImplTest {
   @Test
@@ -17,6 +18,7 @@ class PreferencesRepositoryImplTest {
           postsTimeRangeTab = "QUARTERS",
           language = "ENGLISH",
           theme = "DARK",
+          memosAutoSyncDebounceSeconds = 45,
         ),
       )
     val repository = PreferencesRepositoryImpl(store)
@@ -27,6 +29,7 @@ class PreferencesRepositoryImplTest {
     assertEquals(TimeRangeTab.QUARTERS, result.postsTimeRangeTab)
     assertEquals(AppLanguage.ENGLISH, result.language)
     assertEquals(AppTheme.DARK, result.theme)
+    assertEquals(45.seconds, result.memosAutoSyncDebounceDuration)
   }
 
   @Test
@@ -110,6 +113,7 @@ class PreferencesRepositoryImplTest {
           postsTimeRangeTab = "Y",
           language = "Z",
           theme = "W",
+          memosAutoSyncDebounceSeconds = -1,
         ),
       )
     val repository = PreferencesRepositoryImpl(store)
@@ -120,6 +124,7 @@ class PreferencesRepositoryImplTest {
     assertEquals(TimeRangeTab.WEEKS, result.postsTimeRangeTab)
     assertEquals(AppLanguage.SYSTEM, result.language)
     assertEquals(AppTheme.SYSTEM, result.theme)
+    assertEquals(5.seconds, result.memosAutoSyncDebounceDuration)
   }
 
   @Test
@@ -132,6 +137,7 @@ class PreferencesRepositoryImplTest {
         postsTimeRangeTab = TimeRangeTab.MONTHS,
         language = AppLanguage.RUSSIAN,
         theme = AppTheme.LIGHT,
+        memosAutoSyncDebounceDuration = 90.seconds,
       )
 
     repository.save(preferences)
@@ -140,6 +146,7 @@ class PreferencesRepositoryImplTest {
     assertEquals("MONTHS", store.saved?.postsTimeRangeTab)
     assertEquals("RUSSIAN", store.saved?.language)
     assertEquals("LIGHT", store.saved?.theme)
+    assertEquals(90, store.saved?.memosAutoSyncDebounceSeconds)
   }
 }
 

--- a/feature/settings/data/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesStoreImplTest.kt
+++ b/feature/settings/data/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/data/PreferencesStoreImplTest.kt
@@ -14,6 +14,7 @@ class PreferencesStoreImplTest {
           "ui_posts_time_range_tab" to "QUARTERS",
           "ui_language" to "ENGLISH",
           "ui_theme" to "DARK",
+          "ui_memos_auto_sync_debounce_seconds" to "45",
           "prefs_migrated_v1" to "1",
         ),
       )
@@ -25,6 +26,7 @@ class PreferencesStoreImplTest {
     assertEquals("QUARTERS", result.postsTimeRangeTab)
     assertEquals("ENGLISH", result.language)
     assertEquals("DARK", result.theme)
+    assertEquals(45, result.memosAutoSyncDebounceSeconds)
   }
 
   @Test
@@ -38,6 +40,23 @@ class PreferencesStoreImplTest {
     assertEquals("WEEKS", result.postsTimeRangeTab)
     assertEquals("SYSTEM", result.language)
     assertEquals("SYSTEM", result.theme)
+    assertEquals(5, result.memosAutoSyncDebounceSeconds)
+  }
+
+  @Test
+  fun `when load with invalid debounce value then returns default`() {
+    val store =
+      FakeKeyValueStore(
+        mapOf(
+          "ui_memos_auto_sync_debounce_seconds" to "not_a_number",
+          "prefs_migrated_v1" to "1",
+        ),
+      )
+    val preferencesStore = PreferencesStoreImpl(store)
+
+    val result = preferencesStore.load()
+
+    assertEquals(5, result.memosAutoSyncDebounceSeconds)
   }
 
   @Test
@@ -50,6 +69,7 @@ class PreferencesStoreImplTest {
         postsTimeRangeTab = "MONTHS",
         language = "RUSSIAN",
         theme = "LIGHT",
+        memosAutoSyncDebounceSeconds = 60,
       )
 
     preferencesStore.save(preferences)
@@ -58,6 +78,7 @@ class PreferencesStoreImplTest {
     assertEquals("MONTHS", store.data["ui_posts_time_range_tab"])
     assertEquals("RUSSIAN", store.data["ui_language"])
     assertEquals("LIGHT", store.data["ui_theme"])
+    assertEquals("60", store.data["ui_memos_auto_sync_debounce_seconds"])
   }
 }
 

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/UserPreferences.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/model/UserPreferences.kt
@@ -1,10 +1,19 @@
 package space.be1ski.vibits.feature.settings.domain.model
 
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+const val MIN_SYNC_DEBOUNCE_SECONDS = 1
+const val MAX_SYNC_DEBOUNCE_SECONDS = 30
+const val DEFAULT_SYNC_DEBOUNCE_SECONDS = 5
+
+val DEFAULT_MEMOS_AUTO_SYNC_DEBOUNCE_DURATION: Duration = DEFAULT_SYNC_DEBOUNCE_SECONDS.seconds
 
 data class UserPreferences(
   val habitsTimeRangeTab: TimeRangeTab,
   val postsTimeRangeTab: TimeRangeTab,
   val language: AppLanguage = AppLanguage.SYSTEM,
   val theme: AppTheme = AppTheme.SYSTEM,
+  val memosAutoSyncDebounceDuration: Duration = DEFAULT_MEMOS_AUTO_SYNC_DEBOUNCE_DURATION,
 )

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/LoadSyncDebounceDurationUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/LoadSyncDebounceDurationUseCase.kt
@@ -1,0 +1,12 @@
+package space.be1ski.vibits.feature.settings.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.feature.settings.domain.repository.PreferencesRepository
+import kotlin.time.Duration
+
+@Inject
+class LoadSyncDebounceDurationUseCase(
+  private val preferencesRepository: PreferencesRepository,
+) {
+  operator fun invoke(): Duration = preferencesRepository.load().memosAutoSyncDebounceDuration
+}

--- a/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveSyncDebounceUseCase.kt
+++ b/feature/settings/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveSyncDebounceUseCase.kt
@@ -1,0 +1,18 @@
+package space.be1ski.vibits.feature.settings.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.feature.settings.domain.repository.PreferencesRepository
+import kotlin.time.Duration
+import kotlin.time.Duration.Companion.seconds
+
+@Inject
+class SaveSyncDebounceUseCase(
+  private val preferencesRepository: PreferencesRepository,
+) {
+  operator fun invoke(seconds: Int) {
+    val duration: Duration = seconds.seconds
+    val currentPrefs = preferencesRepository.load()
+    val updatedPrefs = currentPrefs.copy(memosAutoSyncDebounceDuration = duration)
+    preferencesRepository.save(updatedPrefs)
+  }
+}

--- a/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/LoadSyncDebounceDurationUseCaseTest.kt
+++ b/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/LoadSyncDebounceDurationUseCaseTest.kt
@@ -1,0 +1,25 @@
+package space.be1ski.vibits.feature.settings.domain.usecase
+
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
+import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
+import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class LoadSyncDebounceDurationUseCaseTest {
+  @Test
+  fun `when invoked then returns debounce duration from preferences`() {
+    val prefs = UserPreferences(TimeRangeTab.WEEKS, TimeRangeTab.WEEKS, memosAutoSyncDebounceDuration = 15.seconds)
+    val useCase = LoadSyncDebounceDurationUseCase(FakePreferencesRepository(prefs))
+
+    assertEquals(15.seconds, useCase())
+  }
+
+  @Test
+  fun `when default preferences then returns default debounce duration`() {
+    val useCase = LoadSyncDebounceDurationUseCase(FakePreferencesRepository())
+
+    assertEquals(5.seconds, useCase())
+  }
+}

--- a/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveSyncDebounceUseCaseTest.kt
+++ b/feature/settings/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/domain/usecase/SaveSyncDebounceUseCaseTest.kt
@@ -1,0 +1,42 @@
+package space.be1ski.vibits.feature.settings.domain.usecase
+
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
+import space.be1ski.vibits.feature.settings.domain.model.UserPreferences
+import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.time.Duration.Companion.seconds
+
+class SaveSyncDebounceUseCaseTest {
+  @Test
+  fun `when save sync debounce then updates debounce preference`() {
+    val repository = FakePreferencesRepository()
+    val useCase = SaveSyncDebounceUseCase(repository)
+
+    useCase(60)
+
+    assertEquals(60.seconds, repository.stored.memosAutoSyncDebounceDuration)
+  }
+
+  @Test
+  fun `when save sync debounce then preserves other preferences`() {
+    val initialPrefs =
+      UserPreferences(
+        habitsTimeRangeTab = TimeRangeTab.MONTHS,
+        postsTimeRangeTab = TimeRangeTab.QUARTERS,
+        theme = AppTheme.DARK,
+        language = AppLanguage.ENGLISH,
+      )
+    val repository = FakePreferencesRepository(initialPrefs)
+    val useCase = SaveSyncDebounceUseCase(repository)
+
+    useCase(45)
+
+    assertEquals(45.seconds, repository.stored.memosAutoSyncDebounceDuration)
+    assertEquals(TimeRangeTab.MONTHS, repository.stored.habitsTimeRangeTab)
+    assertEquals(AppLanguage.ENGLISH, repository.stored.language)
+    assertEquals(AppTheme.DARK, repository.stored.theme)
+  }
+}

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/di/SettingsDependencies.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/di/SettingsDependencies.kt
@@ -8,6 +8,7 @@ import space.be1ski.vibits.feature.mode.domain.usecase.ResetAppUseCase
 import space.be1ski.vibits.feature.mode.domain.usecase.ResetAppWithMemosUseCase
 import space.be1ski.vibits.feature.mode.domain.usecase.SwitchAppModeUseCase
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveLanguageUseCase
+import space.be1ski.vibits.feature.settings.domain.usecase.SaveSyncDebounceUseCase
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveThemeUseCase
 
 @Inject
@@ -20,5 +21,6 @@ class SettingsDependencies(
   val resetAppWithMemos: ResetAppWithMemosUseCase,
   val saveLanguage: SaveLanguageUseCase,
   val saveTheme: SaveThemeUseCase,
+  val saveSyncDebounce: SaveSyncDebounceUseCase,
   val exportService: ExportService,
 )

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/di/SettingsFeatureFactory.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/di/SettingsFeatureFactory.kt
@@ -17,6 +17,7 @@ fun createSettingsFeature(
   dependencies: SettingsDependencies,
   initialMode: AppMode,
   appDetails: AppDetails,
+  initialSyncDebounceSeconds: Int,
   initialState: SettingsState = SettingsState(),
 ): Feature<SettingsAction, SettingsState, SettingsEffect.Command, SettingsEffect.Notification> =
   FeatureImpl(
@@ -24,6 +25,7 @@ fun createSettingsFeature(
       initialState.copy(
         appMode = initialMode,
         appDetails = appDetails,
+        selectedSyncDebounceSeconds = initialSyncDebounceSeconds,
       ),
     reducer = settingsReducer,
     effectHandler =
@@ -43,6 +45,7 @@ fun createSettingsFeature(
           SettingsPreferencesEffectHandler(
             saveLanguage = dependencies.saveLanguage,
             saveTheme = dependencies.saveTheme,
+            saveSyncDebounce = dependencies.saveSyncDebounce,
           ),
       ),
   )

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/action/SettingsAction.kt
@@ -17,6 +17,7 @@ sealed interface SettingsAction : Action {
       val appMode: AppMode,
       val language: AppLanguage,
       val theme: AppTheme,
+      val syncDebounceSeconds: Int,
     ) : Dialog
 
     data object Close : Dialog
@@ -46,6 +47,10 @@ sealed interface SettingsAction : Action {
 
     data class SelectTheme(
       val theme: AppTheme,
+    ) : Input
+
+    data class SelectSyncDebounce(
+      val seconds: Int,
     ) : Input
 
     data object ModeSwitched : Input

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsEffect.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsEffect.kt
@@ -41,6 +41,10 @@ sealed interface SettingsEffect {
     data class SaveTheme(
       val theme: AppTheme,
     ) : Preferences
+
+    data class SaveSyncDebounce(
+      val seconds: Int,
+    ) : Preferences
   }
 
   /**

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsModeEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsModeEffectHandler.kt
@@ -26,8 +26,10 @@ class SettingsModeEffectHandler(
   private fun handleSwitchMode(command: SettingsEffect.Command.SwitchMode): Flow<SettingsAction> =
     actions {
       Log.i(TAG, "Switching mode to ${command.mode}")
-      switchAppMode(command.mode)
-      emit(SettingsAction.Input.ModeSwitched)
+      val changed = switchAppMode(command.mode)
+      if (changed) {
+        emit(SettingsAction.Input.ModeSwitched)
+      }
     }
 
   private fun handleResetApp(): Flow<SettingsAction> =

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsPreferencesEffectHandler.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/effect/SettingsPreferencesEffectHandler.kt
@@ -5,6 +5,7 @@ import space.be1ski.vibits.core.elm.EffectHandler
 import space.be1ski.vibits.core.elm.sideEffect
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveLanguageUseCase
+import space.be1ski.vibits.feature.settings.domain.usecase.SaveSyncDebounceUseCase
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveThemeUseCase
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 
@@ -13,11 +14,13 @@ private const val TAG = "SettingsPreferencesEffect"
 class SettingsPreferencesEffectHandler(
   private val saveLanguage: SaveLanguageUseCase,
   private val saveTheme: SaveThemeUseCase,
+  private val saveSyncDebounce: SaveSyncDebounceUseCase,
 ) : EffectHandler<SettingsEffect.Command.Preferences, SettingsAction> {
   override fun invoke(command: SettingsEffect.Command.Preferences): Flow<SettingsAction> =
     when (command) {
       is SettingsEffect.Command.SaveLanguage -> handleSaveLanguage(command)
       is SettingsEffect.Command.SaveTheme -> handleSaveTheme(command)
+      is SettingsEffect.Command.SaveSyncDebounce -> handleSaveSyncDebounce(command)
     }
 
   private fun handleSaveLanguage(command: SettingsEffect.Command.SaveLanguage): Flow<SettingsAction> =
@@ -30,5 +33,11 @@ class SettingsPreferencesEffectHandler(
     sideEffect {
       Log.i(TAG, "Theme changed to ${command.theme}")
       saveTheme(command.theme)
+    }
+
+  private fun handleSaveSyncDebounce(command: SettingsEffect.Command.SaveSyncDebounce): Flow<SettingsAction> =
+    sideEffect {
+      Log.i(TAG, "Sync debounce changed to ${command.seconds}s")
+      saveSyncDebounce(command.seconds)
     }
 }

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsDialogReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsDialogReducer.kt
@@ -19,6 +19,7 @@ internal val dialogReducer: Reducer<SettingsAction.Dialog, SettingsState, Settin
             selectedLanguage = action.language,
             languageChanged = false,
             selectedTheme = action.theme,
+            selectedSyncDebounceSeconds = action.syncDebounceSeconds,
             isValidating = false,
             validationError = null,
             showResetConfirmation = false,

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsInputReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsInputReducer.kt
@@ -29,6 +29,10 @@ internal val inputReducer: Reducer<SettingsAction.Input, SettingsState, Settings
         state { state.copy(selectedTheme = action.theme) }
       }
 
+      is SettingsAction.Input.SelectSyncDebounce -> {
+        state { state.copy(selectedSyncDebounceSeconds = action.seconds) }
+      }
+
       is SettingsAction.Input.ModeSwitched -> {
         notify(SettingsEffect.Notification.ModeChanged(state.appMode))
       }

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsSaveAndLogsReducer.kt
@@ -35,6 +35,7 @@ internal val saveAndLogsReducer: Reducer<SettingsAction.SaveAndLogs, SettingsSta
           command(SettingsEffect.Command.SwitchMode(state.appMode))
           command(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
           command(SettingsEffect.Command.SaveTheme(state.selectedTheme))
+          command(SettingsEffect.Command.SaveSyncDebounce(state.selectedSyncDebounceSeconds))
           notify(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
           notify(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
           notify(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsValidationReducer.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/reducer/SettingsValidationReducer.kt
@@ -16,6 +16,7 @@ internal val validationReducer: Reducer<SettingsAction.Validation, SettingsState
         command(SettingsEffect.Command.SwitchMode(AppMode.ONLINE))
         command(SettingsEffect.Command.SaveLanguage(state.selectedLanguage))
         command(SettingsEffect.Command.SaveTheme(state.selectedTheme))
+        command(SettingsEffect.Command.SaveSyncDebounce(state.selectedSyncDebounceSeconds))
         notify(SettingsEffect.Notification.LanguageChanged(state.selectedLanguage))
         notify(SettingsEffect.Notification.ThemeChanged(state.selectedTheme))
         notify(SettingsEffect.Notification.CredentialsSaved(state.editBaseUrl, state.editToken))

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/state/SettingsState.kt
@@ -5,6 +5,7 @@ import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.ui.form.CredentialValidationError
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.DEFAULT_SYNC_DEBOUNCE_SECONDS
 
 data class SettingsState(
   val isOpen: Boolean = false,
@@ -14,6 +15,7 @@ data class SettingsState(
   val selectedLanguage: AppLanguage = AppLanguage.SYSTEM,
   val languageChanged: Boolean = false,
   val selectedTheme: AppTheme = AppTheme.SYSTEM,
+  val selectedSyncDebounceSeconds: Int = DEFAULT_SYNC_DEBOUNCE_SECONDS,
   val isValidating: Boolean = false,
   val validationError: CredentialValidationError? = null,
   val showResetConfirmation: Boolean = false,

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -27,6 +27,7 @@ import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
+import androidx.compose.material3.Slider
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -66,12 +67,14 @@ import space.be1ski.vibits.core.strings.generated.action_reset_settings_only
 import space.be1ski.vibits.core.strings.generated.action_reset_with_memos
 import space.be1ski.vibits.core.strings.generated.action_save
 import space.be1ski.vibits.core.strings.generated.action_view_logs
+import space.be1ski.vibits.core.strings.generated.format_sync_debounce_seconds
 import space.be1ski.vibits.core.strings.generated.label_app_mode
 import space.be1ski.vibits.core.strings.generated.label_credentials
 import space.be1ski.vibits.core.strings.generated.label_environment
 import space.be1ski.vibits.core.strings.generated.label_language
 import space.be1ski.vibits.core.strings.generated.label_memos_db
 import space.be1ski.vibits.core.strings.generated.label_storage
+import space.be1ski.vibits.core.strings.generated.label_sync_debounce
 import space.be1ski.vibits.core.strings.generated.label_theme
 import space.be1ski.vibits.core.strings.generated.label_version
 import space.be1ski.vibits.core.strings.generated.language_arabic
@@ -119,6 +122,8 @@ import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.memos.domain.model.ExportResult
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.domain.model.MAX_SYNC_DEBOUNCE_SECONDS
+import space.be1ski.vibits.feature.settings.domain.model.MIN_SYNC_DEBOUNCE_SECONDS
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
 
@@ -210,6 +215,10 @@ private fun SettingsDialogBody(
         onBaseUrlChange = { dispatch(SettingsAction.Input.UpdateBaseUrl(it)) },
         onTokenChange = { dispatch(SettingsAction.Input.UpdateToken(it)) },
       )
+      SyncDebounceSlider(
+        seconds = state.selectedSyncDebounceSeconds,
+        onSecondsChange = { dispatch(SettingsAction.Input.SelectSyncDebounce(it)) },
+      )
     }
     ActionsRow(
       showMemos = state.appMode == AppMode.OFFLINE,
@@ -261,6 +270,32 @@ private fun AppModeSelector(
         Text(stringResource(Res.string.mode_demo_title))
       }
     }
+  }
+}
+
+@Composable
+private fun SyncDebounceSlider(
+  seconds: Int,
+  onSecondsChange: (Int) -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(Indent.x3s)) {
+    Row(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.SpaceBetween,
+    ) {
+      Text(stringResource(Res.string.label_sync_debounce))
+      Text(
+        stringResource(Res.string.format_sync_debounce_seconds, seconds),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    Slider(
+      value = seconds.toFloat(),
+      onValueChange = { onSecondsChange(it.toInt()) },
+      valueRange = MIN_SYNC_DEBOUNCE_SECONDS.toFloat()..MAX_SYNC_DEBOUNCE_SECONDS.toFloat(),
+      modifier = Modifier.fillMaxWidth(),
+    )
   }
 }
 

--- a/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsEffectHandlerTest.kt
+++ b/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsEffectHandlerTest.kt
@@ -1,4 +1,5 @@
 package space.be1ski.vibits.feature.settings.presentation
+
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.core.platform.locale.AppLanguage
@@ -15,6 +16,7 @@ import space.be1ski.vibits.feature.onboarding.domain.test.FakeOnboardingStore
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.domain.test.FakePreferencesRepository
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveLanguageUseCase
+import space.be1ski.vibits.feature.settings.domain.usecase.SaveSyncDebounceUseCase
 import space.be1ski.vibits.feature.settings.domain.usecase.SaveThemeUseCase
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
 import space.be1ski.vibits.feature.settings.presentation.effect.SettingsCredentialsEffectHandler
@@ -25,6 +27,7 @@ import space.be1ski.vibits.feature.settings.presentation.effect.SettingsPreferen
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.seconds
 
 class SettingsEffectHandlerTest {
   @Test
@@ -63,7 +66,7 @@ class SettingsEffectHandlerTest {
     }
 
   @Test
-  fun `when SwitchMode then saves mode and emits ModeSwitched`() =
+  fun `when SwitchMode to different mode then saves and emits ModeSwitched`() =
     runTest {
       val appModeRepo = FakeAppModeRepository(initial = AppMode.ONLINE)
       val handler = createHandler(appModeRepository = appModeRepo)
@@ -72,6 +75,17 @@ class SettingsEffectHandlerTest {
 
       assertEquals(listOf(SettingsAction.Input.ModeSwitched), actions)
       assertEquals(AppMode.OFFLINE, appModeRepo.storedMode)
+    }
+
+  @Test
+  fun `when SwitchMode to same mode then does not emit ModeSwitched`() =
+    runTest {
+      val appModeRepo = FakeAppModeRepository(initial = AppMode.ONLINE)
+      val handler = createHandler(appModeRepository = appModeRepo)
+
+      val actions = handler(SettingsEffect.Command.SwitchMode(mode = AppMode.ONLINE)).toList()
+
+      assertTrue(actions.isEmpty())
     }
 
   @Test
@@ -136,6 +150,17 @@ class SettingsEffectHandlerTest {
       assertEquals(AppTheme.DARK, prefsRepo.stored.theme)
     }
 
+  @Test
+  fun `when SaveSyncDebounce then saves debounce to repository`() =
+    runTest {
+      val prefsRepo = FakePreferencesRepository()
+      val handler = createHandler(preferencesRepository = prefsRepo)
+
+      handler(SettingsEffect.Command.SaveSyncDebounce(seconds = 60)).toList()
+
+      assertEquals(60.seconds, prefsRepo.stored.memosAutoSyncDebounceDuration)
+    }
+
   private fun createHandler(
     connectionResult: Result<Unit> = Result.success(Unit),
     appModeRepository: FakeAppModeRepository = FakeAppModeRepository(),
@@ -166,6 +191,7 @@ class SettingsEffectHandlerTest {
         SettingsPreferencesEffectHandler(
           saveLanguage = SaveLanguageUseCase(preferencesRepository, LocaleProvider()),
           saveTheme = SaveThemeUseCase(preferencesRepository),
+          saveSyncDebounce = SaveSyncDebounceUseCase(preferencesRepository),
         ),
     )
   }

--- a/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
+++ b/feature/settings/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/settings/presentation/SettingsReducerTest.kt
@@ -23,6 +23,7 @@ class SettingsReducerTest {
           appMode = AppMode.ONLINE,
           language = AppLanguage.SYSTEM,
           theme = AppTheme.SYSTEM,
+          syncDebounceSeconds = 45,
         ),
       )
 
@@ -31,6 +32,7 @@ class SettingsReducerTest {
           editBaseUrl == "https://api.com" &&
           editToken == "secret" &&
           appMode == AppMode.ONLINE &&
+          selectedSyncDebounceSeconds == 45 &&
           !isValidating &&
           validationError == null &&
           !showResetConfirmation &&
@@ -124,6 +126,15 @@ class SettingsReducerTest {
     }
 
   @Test
+  fun `when SelectSyncDebounce then updates sync debounce seconds`() =
+    settingsReducer.test(SettingsState()) {
+      send(SettingsAction.Input.SelectSyncDebounce(60))
+
+      assertState { selectedSyncDebounceSeconds == 60 }
+      assertNoEffects()
+    }
+
+  @Test
   fun `when ValidationSucceeded then saves all settings and closes dialog`() =
     settingsReducer.test(
       SettingsState(
@@ -134,16 +145,18 @@ class SettingsReducerTest {
         editToken = "token123",
         selectedLanguage = AppLanguage.ENGLISH,
         selectedTheme = AppTheme.DARK,
+        selectedSyncDebounceSeconds = 45,
       ),
     ) {
       send(SettingsAction.Validation.ValidationSucceeded)
 
       assertState { !isValidating && !isOpen && !pendingSave && appMode == AppMode.ONLINE }
-      assertCommandCount(4)
+      assertCommandCount(5)
       assertHasCommand<SettingsEffect.Command.SaveCredentials>()
       assertHasCommand<SettingsEffect.Command.SwitchMode>()
       assertHasCommand<SettingsEffect.Command.SaveLanguage>()
       assertHasCommand<SettingsEffect.Command.SaveTheme>()
+      assertHasCommand<SettingsEffect.Command.SaveSyncDebounce> { it.seconds == 45 }
       assertHasNotification<SettingsEffect.Notification.LanguageChanged>()
       assertHasNotification<SettingsEffect.Notification.ThemeChanged>()
       assertHasNotification<SettingsEffect.Notification.CredentialsSaved>()
@@ -248,16 +261,18 @@ class SettingsReducerTest {
         appMode = AppMode.OFFLINE,
         selectedLanguage = AppLanguage.RUSSIAN,
         selectedTheme = AppTheme.LIGHT,
+        selectedSyncDebounceSeconds = 60,
       ),
     ) {
       send(SettingsAction.SaveAndLogs.Save)
 
       assertState { !isOpen }
-      assertCommandCount(4)
+      assertCommandCount(5)
       assertHasCommand<SettingsEffect.Command.SaveCredentials>()
       assertHasCommand<SettingsEffect.Command.SwitchMode>()
       assertHasCommand<SettingsEffect.Command.SaveLanguage>()
       assertHasCommand<SettingsEffect.Command.SaveTheme>()
+      assertHasCommand<SettingsEffect.Command.SaveSyncDebounce> { it.seconds == 60 }
     }
 
   @Test

--- a/feature/sync/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/test/FakeSyncEngine.kt
+++ b/feature/sync/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/sync/domain/test/FakeSyncEngine.kt
@@ -7,11 +7,23 @@ class FakeSyncEngine : SyncEngine {
   var performSyncResult: SyncResult = SyncResult.Success(emptyList())
   var forceLocalSyncResult: SyncResult = SyncResult.Success(emptyList())
   var forceServerSyncResult: SyncResult = SyncResult.Success(emptyList())
+  var performSyncCallCount: Int = 0
+  var forceLocalSyncCallCount: Int = 0
+  var forceServerSyncCallCount: Int = 0
   override var isSyncing: Boolean = false
 
-  override suspend fun performSync(): SyncResult = performSyncResult
+  override suspend fun performSync(): SyncResult {
+    performSyncCallCount += 1
+    return performSyncResult
+  }
 
-  override suspend fun forceLocalSync(): SyncResult = forceLocalSyncResult
+  override suspend fun forceLocalSync(): SyncResult {
+    forceLocalSyncCallCount += 1
+    return forceLocalSyncResult
+  }
 
-  override suspend fun forceServerSync(): SyncResult = forceServerSyncResult
+  override suspend fun forceServerSync(): SyncResult {
+    forceServerSyncCallCount += 1
+    return forceServerSyncResult
+  }
 }


### PR DESCRIPTION
## Summary
- Add a slider (1–30s, default 5s) to the settings dialog for configuring sync debounce duration (ONLINE mode only)
- Sync debounce reads preference dynamically via `LoadSyncDebounceDurationUseCase` so changes apply immediately
- Settings save only triggers reload when credentials or mode actually changed
- Sync dot only pulses when actual sync is in progress (not during debounce wait)
- Sync queue status observed in real-time for immediate pending indicator

## Changes
- **Domain**: `SaveSyncDebounceUseCase`, `LoadSyncDebounceDurationUseCase`, debounce constants in `UserPreferences`
- **Data**: `PreferencesStore` + `PreferencesRepositoryImpl` persistence for debounce seconds
- **Presentation (settings)**: `SelectSyncDebounce` action, slider UI in `SettingsDialogContent`, save/validate reducers emit `SaveSyncDebounce` command
- **Presentation (memos)**: `SyncStarted` action, `LoadSyncDebounceDurationUseCase` in `MemosSyncEffectHandler`, `ObserveSyncStatus` initial command
- **Homescreen**: `SwitchAppModeUseCase` returns `Boolean`, `FeatureCoordinator` credential comparison for `CredentialsSaved`
- **Strings**: `label_sync_debounce` and `format_sync_debounce_seconds` in all 20 locales
- **Tests**: Updated and added reducer, effect handler, use case, and data layer tests

## Test plan
- [x] `checkJvm` passes
- [x] Change sync debounce slider → save → toggle habit → verify debounce applies immediately
- [x] Save settings without changing credentials → verify no full reload
- [x] Toggle habit → verify orange dot appears immediately, green pulse only after debounce
- [x] Verify slider only visible in ONLINE mode settings

🤖 Generated with [Claude Code](https://claude.com/claude-code)