### PR TITLE
Fix macOS VPN breaking local network access for desktop app

### DIFF
--- a/core/platform/build.gradle.kts
+++ b/core/platform/build.gradle.kts
@@ -27,7 +27,7 @@ kotlin {
     desktopMain {
       dependencies {
         implementation(libs.kotlinx.coroutines.swing)
-        implementation(libs.ktor.client.cio)
+        implementation(libs.ktor.client.okhttp)
         implementation(libs.slf4j.simple)
       }
     }

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/network/HttpClientProvider.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/network/HttpClientProvider.kt
@@ -1,7 +1,7 @@
 package space.be1ski.vibits.core.platform.network
 
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.okhttp.OkHttp
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
 import io.ktor.client.plugins.logging.LogLevel
 import io.ktor.client.plugins.logging.Logger
@@ -10,11 +10,8 @@ import io.ktor.http.HttpHeaders
 import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
-/**
- * Desktop-specific HTTP client configuration.
- */
 actual fun createHttpClient(): HttpClient =
-  HttpClient(CIO) {
+  HttpClient(OkHttp) {
     install(ContentNegotiation) {
       json(
         Json {
@@ -32,5 +29,8 @@ actual fun createHttpClient(): HttpClient =
         }
       level = LogLevel.INFO
       sanitizeHeader { it == HttpHeaders.Authorization }
+    }
+    engine {
+      PhysicalNetworkSocketFactory.create()?.let { config { socketFactory(it) } }
     }
   }

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/network/PhysicalNetworkSocketFactory.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/network/PhysicalNetworkSocketFactory.kt
@@ -1,0 +1,107 @@
+package space.be1ski.vibits.core.platform.network
+
+import java.io.IOException
+import java.net.InetAddress
+import java.net.InetSocketAddress
+import java.net.NetworkInterface
+import java.net.Socket
+import javax.net.SocketFactory
+
+/**
+ * A [SocketFactory] that binds sockets to a physical network interface (e.g., WiFi)
+ * when connecting to local/private network addresses.
+ *
+ * On macOS, when the app runs as a .app bundle, VPN Network Extensions can intercept
+ * Java's BSD socket traffic, causing [java.net.NoRouteToHostException] for local addresses.
+ * Binding to the physical interface bypasses VPN routing for local connections only.
+ *
+ * Connections to public/external addresses use default routing (unaffected by this factory).
+ */
+internal class PhysicalNetworkSocketFactory private constructor(
+  private val localAddress: InetAddress,
+) : SocketFactory() {
+  override fun createSocket(): Socket = Socket().apply { bind(InetSocketAddress(localAddress, 0)) }
+
+  override fun createSocket(
+    host: String,
+    port: Int,
+  ): Socket = createBoundSocket(InetAddress.getByName(host), port)
+
+  override fun createSocket(
+    host: InetAddress,
+    port: Int,
+  ): Socket = createBoundSocket(host, port)
+
+  override fun createSocket(
+    host: String,
+    port: Int,
+    localHost: InetAddress,
+    localPort: Int,
+  ): Socket = Socket(host, port, localHost, localPort)
+
+  override fun createSocket(
+    address: InetAddress,
+    port: Int,
+    localAddress: InetAddress,
+    localPort: Int,
+  ): Socket = Socket(address, port, localAddress, localPort)
+
+  private fun createBoundSocket(
+    address: InetAddress,
+    port: Int,
+  ): Socket {
+    val socket = Socket()
+    if (address.isPrivateNetwork()) {
+      socket.bind(InetSocketAddress(localAddress, 0))
+    }
+    socket.connect(InetSocketAddress(address, port))
+    return socket
+  }
+
+  companion object {
+    fun create(): SocketFactory? {
+      if (!isMacOs()) return null
+      return findPhysicalInterfaceAddress()?.let(::PhysicalNetworkSocketFactory)
+    }
+
+    private fun isMacOs(): Boolean = System.getProperty("os.name")?.contains("Mac", ignoreCase = true) == true
+
+    private fun findPhysicalInterfaceAddress(): InetAddress? =
+      try {
+        NetworkInterface
+          .getNetworkInterfaces()
+          ?.toList()
+          .orEmpty()
+          .filter { it.isUp && !it.isLoopback && !it.isPointToPoint }
+          .flatMap { it.inetAddresses.toList() }
+          .firstOrNull { it is java.net.Inet4Address && !it.isLoopbackAddress }
+      } catch (_: IOException) {
+        null
+      }
+  }
+}
+
+private const val IPV4_BYTES = 4
+private const val OCTET_MASK = 0xFF
+private const val PRIVATE_CLASS_A = 10
+private const val PRIVATE_CLASS_B_FIRST = 172
+private const val PRIVATE_CLASS_B_SECOND_MIN = 16
+private const val PRIVATE_CLASS_B_SECOND_MAX = 31
+private const val PRIVATE_CLASS_C_FIRST = 192
+private const val PRIVATE_CLASS_C_SECOND = 168
+private const val LINK_LOCAL_FIRST = 169
+private const val LINK_LOCAL_SECOND = 254
+
+private fun InetAddress.isPrivateNetwork(): Boolean {
+  val bytes = address
+  if (bytes.size != IPV4_BYTES) return false
+  val b0 = bytes[0].toInt() and OCTET_MASK
+  val b1 = bytes[1].toInt() and OCTET_MASK
+  return when {
+    b0 == PRIVATE_CLASS_A -> true
+    b0 == PRIVATE_CLASS_B_FIRST && b1 in PRIVATE_CLASS_B_SECOND_MIN..PRIVATE_CLASS_B_SECOND_MAX -> true
+    b0 == PRIVATE_CLASS_C_FIRST && b1 == PRIVATE_CLASS_C_SECOND -> true
+    b0 == LINK_LOCAL_FIRST && b1 == LINK_LOCAL_SECOND -> true
+    else -> false
+  }
+}

--- a/feature/homescreen/build.gradle.kts
+++ b/feature/homescreen/build.gradle.kts
@@ -76,7 +76,7 @@ kotlin {
     desktopMain {
       dependencies {
         implementation(libs.kotlinx.coroutines.swing)
-        implementation(libs.ktor.client.cio)
+        implementation(libs.ktor.client.okhttp)
         implementation(libs.slf4j.simple)
       }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -65,7 +65,6 @@ kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime",
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "serialization" }
 ktlint-plugin = { group = "org.jlleitschuh.gradle", name = "ktlint-gradle", version.ref = "ktlint" }
 ksp-plugin = { group = "com.google.devtools.ksp", name = "symbol-processing-gradle-plugin", version.ref = "ksp" }
-ktor-client-cio = { group = "io.ktor", name = "ktor-client-cio", version.ref = "ktor" }
 ktor-client-content-negotiation = { group = "io.ktor", name = "ktor-client-content-negotiation", version.ref = "ktor" }
 ktor-client-core = { group = "io.ktor", name = "ktor-client-core", version.ref = "ktor" }
 ktor-client-darwin = { group = "io.ktor", name = "ktor-client-darwin", version.ref = "ktor" }


### PR DESCRIPTION
## Summary

- macOS VPN Network Extensions intercept Java BSD sockets when the app runs as a `.app` bundle, causing `NoRouteToHostException` for local network addresses (e.g., self-hosted Memos at `192.168.x.x`)
- Switch desktop Ktor engine from CIO to OkHttp and add a `PhysicalNetworkSocketFactory` that binds sockets to the physical network interface (WiFi/Ethernet) on macOS for private addresses only

## Changes

- **`core/platform/build.gradle.kts`** / **`feature/homescreen/build.gradle.kts`** — Replace `ktor-client-cio` with `ktor-client-okhttp` for desktop
- **`gradle/libs.versions.toml`** — Remove unused `ktor-client-cio` entry
- **`PhysicalNetworkSocketFactory.kt`** (new) — macOS-only `SocketFactory` that detects physical network interface and binds sockets to it for RFC 1918 + link-local addresses; public addresses use default routing
- **`HttpClientProvider.kt`** — Switch from `HttpClient(CIO)` to `HttpClient(OkHttp)`, configure custom socket factory on macOS

## Test plan

- [x] `checkJvm` passes (ktlint, detekt, compile, tests)
- [ ] Launch via `open -a /Applications/Vibits.app` with VPN active, verify local Memos loads
- [ ] Verify non-local Memos servers still work normally