### PR TITLE
Add patch/minor/major version bump choice to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,16 @@ name: Release
 
 on:
   workflow_dispatch:
+    inputs:
+      bump:
+        description: "Version bump"
+        required: true
+        default: "patch"
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
   release:
     types: [created]
 
@@ -31,7 +41,13 @@ jobs:
 
           VERSION=${LATEST_TAG#v}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
-          PATCH=$((PATCH + 1))
+
+          case "${{ inputs.bump }}" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
           NEW_TAG="v${MAJOR}.${MINOR}.${PATCH}"
 
           echo "New tag: $NEW_TAG"


### PR DESCRIPTION
## Summary
- Release workflow now lets you choose between patch, minor, and major version bumps when triggering manually
- Default remains `patch` for safety

## Changes
- Added `inputs.bump` choice parameter to `workflow_dispatch`
- Updated version calculation to use `case` statement based on selected bump type