### PR TITLE
Add desktop shell with sidebar and responsive layout

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -13,7 +13,9 @@ kotlin {
     val desktopMain by getting {
       dependencies {
         implementation(compose.desktop.currentOs)
+        implementation(compose.components.resources)
         implementation(libs.kotlinx.coroutines.swing)
+        implementation(project(":core:strings"))
         implementation(project(":feature:homescreen"))
       }
     }

--- a/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
+++ b/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
@@ -1,21 +1,64 @@
 package space.be1ski.vibits.desktop
 
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
 import androidx.compose.ui.window.rememberWindowState
+import space.be1ski.vibits.desktop.view.VibitsMenuBar
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.homescreen.presentation.view.AppRoot
+import java.awt.Dimension
+
+private const val MIN_WINDOW_WIDTH = 640
+private const val MIN_WINDOW_HEIGHT = 480
+private val POSTS_LIST_HEIGHT = 200.dp
 
 fun main() =
   application {
     val dependencies = AppGraph.createAppDependencies()
+    var features by remember { mutableStateOf<AppFeatures?>(null) }
+    val windowState =
+      rememberWindowState(
+        width = 900.dp,
+        height = 700.dp,
+      )
+
+    features?.let { f ->
+      val appState by f.app.state.collectAsState()
+      val postsVisible = appState.selectedScreen == Screen.STATS && appState.postsListExpanded
+      var previousPostsVisible by remember { mutableStateOf(postsVisible) }
+      LaunchedEffect(postsVisible) {
+        if (postsVisible != previousPostsVisible) {
+          val delta = if (postsVisible) POSTS_LIST_HEIGHT else -POSTS_LIST_HEIGHT
+          windowState.size =
+            DpSize(
+              width = windowState.size.width,
+              height = (windowState.size.height + delta).coerceAtLeast(MIN_WINDOW_HEIGHT.dp),
+            )
+          previousPostsVisible = postsVisible
+        }
+      }
+    }
 
     Window(
       onCloseRequest = ::exitApplication,
       title = "Vibits",
-      state = rememberWindowState(width = 540.dp, height = 1080.dp),
+      state = windowState,
     ) {
-      AppRoot(dependencies)
+      window.minimumSize = Dimension(MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT)
+      features?.let { VibitsMenuBar(it) }
+      AppRoot(
+        dependencies = dependencies,
+        onFeaturesReady = { features = it },
+      )
     }
   }

--- a/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/view/VibitsMenuBar.kt
+++ b/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/view/VibitsMenuBar.kt
@@ -1,0 +1,80 @@
+package space.be1ski.vibits.desktop.view
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.input.key.Key
+import androidx.compose.ui.input.key.KeyShortcut
+import androidx.compose.ui.window.FrameWindowScope
+import androidx.compose.ui.window.MenuBar
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.menu_file
+import space.be1ski.vibits.core.strings.generated.menu_view
+import space.be1ski.vibits.core.strings.generated.nav_feed
+import space.be1ski.vibits.core.strings.generated.nav_habits
+import space.be1ski.vibits.core.strings.generated.nav_memos
+import space.be1ski.vibits.core.strings.generated.nav_settings
+import space.be1ski.vibits.core.strings.generated.title_new_memo
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
+import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
+
+@Composable
+fun FrameWindowScope.VibitsMenuBar(features: AppFeatures) {
+  val menuFileLabel = stringResource(Res.string.menu_file)
+  val menuViewLabel = stringResource(Res.string.menu_view)
+  val newMemoLabel = stringResource(Res.string.title_new_memo)
+  val settingsLabel = stringResource(Res.string.nav_settings)
+  val habitsLabel = stringResource(Res.string.nav_habits)
+  val memosLabel = stringResource(Res.string.nav_memos)
+  val feedLabel = stringResource(Res.string.nav_feed)
+
+  MenuBar {
+    Menu(menuFileLabel) {
+      Item(
+        newMemoLabel,
+        shortcut = KeyShortcut(Key.N, meta = true),
+        onClick = { features.memos.send(MemosAction.CreateDialog.ShowCreateDialog) },
+      )
+      Item(
+        settingsLabel,
+        shortcut = KeyShortcut(Key.Comma, meta = true),
+        onClick = { openSettings(features) },
+      )
+    }
+    Menu(menuViewLabel) {
+      Item(
+        habitsLabel,
+        shortcut = KeyShortcut(Key.One, meta = true),
+        onClick = { features.app.send(AppAction.Navigation.SelectScreen(Screen.HABITS)) },
+      )
+      Item(
+        memosLabel,
+        shortcut = KeyShortcut(Key.Two, meta = true),
+        onClick = { features.app.send(AppAction.Navigation.SelectScreen(Screen.STATS)) },
+      )
+      Item(
+        feedLabel,
+        shortcut = KeyShortcut(Key.Three, meta = true),
+        onClick = { features.app.send(AppAction.Navigation.SelectScreen(Screen.FEED)) },
+      )
+    }
+  }
+}
+
+private fun openSettings(features: AppFeatures) {
+  val memosState = features.memos.state.value
+  val appState = features.app.state.value
+  val settingsState = features.settings.state.value
+  features.settings.send(
+    SettingsAction.Dialog.Open(
+      baseUrl = memosState.baseUrl,
+      token = memosState.token,
+      appMode = appState.appMode,
+      language = settingsState.selectedLanguage,
+      theme = settingsState.selectedTheme,
+      syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
+    ),
+  )
+}

--- a/app/ios/vibits/vibits.xcodeproj/xcuserdata/be1ski.xcuserdatad/xcschemes/vibits.xcscheme
+++ b/app/ios/vibits/vibits.xcodeproj/xcuserdata/be1ski.xcuserdatad/xcschemes/vibits.xcscheme
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   version = "1.3">
+   <BuildAction>
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForRunning = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "5444D14E2F1579250075CCCE"
+               BuildableName = "vibits.app"
+               BlueprintName = "vibits"
+               ReferencedContainer = "container:vibits.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <LaunchAction
+      useCustomWorkingDirectory = "NO"
+      buildConfiguration = "Debug"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5444D14E2F1579250075CCCE"
+            BuildableName = "vibits.app"
+            BlueprintName = "vibits"
+            ReferencedContainer = "container:vibits.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </LaunchAction>
+</Scheme>

--- a/app/ios/vibits/vibits.xcodeproj/xcuserdata/be1ski.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/app/ios/vibits/vibits.xcodeproj/xcuserdata/be1ski.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -9,10 +9,10 @@
 			<key>orderHint</key>
 			<integer>0</integer>
 		</dict>
-		<key>vibits.xcscheme_^#shared#^_</key>
+		<key>vibits.xcscheme</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/app/web/src/wasmJsMain/resources/index.html
+++ b/app/web/src/wasmJsMain/resources/index.html
@@ -24,15 +24,6 @@
         padding-bottom: env(safe-area-inset-bottom);
         box-sizing: border-box;
       }
-      @media (min-width: 600px) {
-        #root {
-          aspect-ratio: 9 / 19.5;
-          max-height: 100vh;
-          max-width: 100vw;
-          width: auto;
-          margin: 0 auto;
-        }
-      }
     </style>
   </head>
   <body>

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">رمز الوصول</string>
     <string name="label_activity">النشاط</string>
+    <string name="label_all_habits">الكل</string>
     <string name="label_app_mode">وضع التطبيق</string>
     <string name="label_base_url">عنوان URL الأساسي</string>
     <string name="label_credentials">بيانات الاعتماد</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">تم العثور على بيانات الاعتماد</string>
     <string name="mode_quick_online_desc">تم اكتشاف بيانات اعتماد محفوظة. استخدامها للاتصال بسرعة؟</string>
     <string name="action_use_saved">استخدام المحفوظة</string>
+
+    <!-- Menu -->
+    <string name="menu_file">ملف</string>
+    <string name="menu_view">عرض</string>
 
     <!-- Navigation -->
     <string name="nav_feed">الرئيسية</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Giriş tokeni</string>
     <string name="label_activity">Fəaliyyət</string>
+    <string name="label_all_habits">Hamısı</string>
     <string name="label_app_mode">Tətbiq rejimi</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Hesab məlumatları</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Etimadnamələr tapıldı</string>
     <string name="mode_quick_online_desc">Saxlanmış etimadnamələr aşkar edildi. Sürətli qoşulmaq üçün onlardan istifadə edilsin?</string>
     <string name="action_use_saved">Saxlanmışdan istifadə et</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Fayl</string>
+    <string name="menu_view">Görünüş</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lent</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Токен доступу</string>
     <string name="label_activity">Актыўнасць</string>
+    <string name="label_all_habits">Усе</string>
     <string name="label_app_mode">Рэжым праграмы</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Уліковыя даныя</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Знойдзены ўліковыя даныя</string>
     <string name="mode_quick_online_desc">Выяўлены захаваныя ўліковыя даныя. Выкарыстаць іх для хуткага падключэння?</string>
     <string name="action_use_saved">Выкарыстаць</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Выгляд</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Стужка</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Zugriffstoken</string>
     <string name="label_activity">Aktivität</string>
+    <string name="label_all_habits">Alle</string>
     <string name="label_app_mode">App-Modus</string>
     <string name="label_base_url">Basis-URL</string>
     <string name="label_credentials">Anmeldedaten</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Anmeldedaten gefunden</string>
     <string name="mode_quick_online_desc">Gespeicherte Anmeldedaten erkannt. Diese für schnelle Verbindung verwenden?</string>
     <string name="action_use_saved">Gespeicherte verwenden</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Ablage</string>
+    <string name="menu_view">Darstellung</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Token de acceso</string>
     <string name="label_activity">Actividad</string>
+    <string name="label_all_habits">Todos</string>
     <string name="label_app_mode">Modo de app</string>
     <string name="label_base_url">URL base</string>
     <string name="label_credentials">Credenciales</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Credenciales encontradas</string>
     <string name="mode_quick_online_desc">Se detectaron credenciales guardadas. ¿Usarlas para conectarse rápidamente?</string>
     <string name="action_use_saved">Usar guardadas</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Archivo</string>
+    <string name="menu_view">Visualización</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Inicio</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Jeton d\'accès</string>
     <string name="label_activity">Activité</string>
+    <string name="label_all_habits">Tous</string>
     <string name="label_app_mode">Mode de l\'app</string>
     <string name="label_base_url">URL de base</string>
     <string name="label_credentials">Identifiants</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Identifiants trouvés</string>
     <string name="mode_quick_online_desc">Identifiants sauvegardés détectés. Les utiliser pour une connexion rapide ?</string>
     <string name="action_use_saved">Utiliser sauvegardés</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Fichier</string>
+    <string name="menu_view">Présentation</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Fil</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">एक्सेस टोकन</string>
     <string name="label_activity">गतिविधि</string>
+    <string name="label_all_habits">सभी</string>
     <string name="label_app_mode">ऐप मोड</string>
     <string name="label_base_url">बेस URL</string>
     <string name="label_credentials">क्रेडेंशियल</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">क्रेडेंशियल मिले</string>
     <string name="mode_quick_online_desc">सहेजे गए क्रेडेंशियल मिले। तेज़ी से कनेक्ट करने के लिए उनका उपयोग करें?</string>
     <string name="action_use_saved">सहेजा उपयोग करें</string>
+
+    <!-- Menu -->
+    <string name="menu_file">फ़ाइल</string>
+    <string name="menu_view">दृश्य</string>
 
     <!-- Navigation -->
     <string name="nav_feed">फ़ीड</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">アクセストークン</string>
     <string name="label_activity">アクティビティ</string>
+    <string name="label_all_habits">すべて</string>
     <string name="label_app_mode">アプリモード</string>
     <string name="label_base_url">ベースURL</string>
     <string name="label_credentials">認証情報</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">認証情報が見つかりました</string>
     <string name="mode_quick_online_desc">保存された認証情報が検出されました。それらを使用して素早く接続しますか？</string>
     <string name="action_use_saved">保存済みを使用</string>
+
+    <!-- Menu -->
+    <string name="menu_file">ファイル</string>
+    <string name="menu_view">表示</string>
 
     <!-- Navigation -->
     <string name="nav_feed">フィード</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">წვდომის ტოკენი</string>
     <string name="label_activity">აქტივობა</string>
+    <string name="label_all_habits">ყველა</string>
     <string name="label_app_mode">აპის რეჟიმი</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">რწმუნებები</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">ნაპოვნია უფლებამოსილებები</string>
     <string name="mode_quick_online_desc">აღმოჩენილია შენახული უფლებამოსილებები. გამოვიყენოთ სწრაფი დაკავშირებისთვის?</string>
     <string name="action_use_saved">შენახულის გამოყენება</string>
+
+    <!-- Menu -->
+    <string name="menu_file">ფაილი</string>
+    <string name="menu_view">ხედი</string>
 
     <!-- Navigation -->
     <string name="nav_feed">ფიდი</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Қол жеткізу токені</string>
     <string name="label_activity">Белсенділік</string>
+    <string name="label_all_habits">Барлығы</string>
     <string name="label_app_mode">Қолданба режимі</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Тіркелгі деректері</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Тіркелгі деректері табылды</string>
     <string name="mode_quick_online_desc">Сақталған тіркелгі деректері табылды. Оларды жылдам қосылу үшін пайдалану керек пе?</string>
     <string name="action_use_saved">Сақталғанды пайдалану</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Көрініс</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Кирүү токени</string>
     <string name="label_activity">Активдүүлүк</string>
+    <string name="label_all_habits">Баары</string>
     <string name="label_app_mode">Колдонмо режими</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Эсеп маалыматы</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Эсеп маалыматтары табылды</string>
     <string name="mode_quick_online_desc">Сакталган эсеп маалыматтары табылды. Аларды тез туташуу үчүн колдонулсунбу?</string>
     <string name="action_use_saved">Сакталганды колдон</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Көрүнүш</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Token de acesso</string>
     <string name="label_activity">Atividade</string>
+    <string name="label_all_habits">Todos</string>
     <string name="label_app_mode">Modo do app</string>
     <string name="label_base_url">URL base</string>
     <string name="label_credentials">Credenciais</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Credenciais encontradas</string>
     <string name="mode_quick_online_desc">Credenciais salvas detectadas. Usá-las para conectar rapidamente?</string>
     <string name="action_use_saved">Usar salvas</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Ficheiro</string>
+    <string name="menu_view">Visualização</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Token de acces</string>
     <string name="label_activity">Activitate</string>
+    <string name="label_all_habits">Toate</string>
     <string name="label_app_mode">Mod aplicație</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Credențiale</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Credențiale găsite</string>
     <string name="mode_quick_online_desc">Credențiale salvate detectate. Le folosim pentru conectare rapidă?</string>
     <string name="action_use_saved">Folosește salvate</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Fișier</string>
+    <string name="menu_view">Vizualizare</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Flux</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -97,6 +97,7 @@
     <!-- Labels -->
     <string name="label_access_token">Токен доступа</string>
     <string name="label_activity">Активность</string>
+    <string name="label_all_habits">Все</string>
     <string name="label_app_mode">Режим приложения</string>
     <string name="label_base_url">URL сервера</string>
     <string name="label_credentials">Данные для входа</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Найдены данные для входа</string>
     <string name="mode_quick_online_desc">Найдены сохранённые данные для входа. Использовать их для быстрого подключения?</string>
     <string name="action_use_saved">Использовать</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Вид</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Токени дастрасӣ</string>
     <string name="label_activity">Фаъолият</string>
+    <string name="label_all_habits">Ҳама</string>
     <string name="label_app_mode">Режими барнома</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Маълумоти ҳисоб</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Маълумоти ҳисоб ёфт шуд</string>
     <string name="mode_quick_online_desc">Маълумоти ҳисоби захирашуда ошкор шуд. Барои пайваст шудани зуд истифода бурда шавад?</string>
     <string name="action_use_saved">Захирашударо истифода бур</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Намоиш</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Лента</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Giriş tokeni</string>
     <string name="label_activity">Işjeňlik</string>
+    <string name="label_all_habits">Hemmesi</string>
     <string name="label_app_mode">Programma režimi</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Hasap maglumatlary</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Hasap maglumatlary tapyldy</string>
     <string name="mode_quick_online_desc">Saklanýan hasap maglumatlary tapyldy. Olary çalt birikdirmek üçün ulanmalymy?</string>
     <string name="action_use_saved">Saklananyny ulan</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Faýl</string>
+    <string name="menu_view">Görnüş</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lenta</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Токен доступу</string>
     <string name="label_activity">Активність</string>
+    <string name="label_all_habits">Всі</string>
     <string name="label_app_mode">Режим додатку</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Облікові дані</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Знайдено облікові дані</string>
     <string name="mode_quick_online_desc">Виявлено збережені облікові дані. Використати їх для швидкого підключення?</string>
     <string name="action_use_saved">Використати</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Файл</string>
+    <string name="menu_view">Вигляд</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Стрічка</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">Kirish tokeni</string>
     <string name="label_activity">Faoliyat</string>
+    <string name="label_all_habits">Hammasi</string>
     <string name="label_app_mode">Ilova rejimi</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Hisob ma\'lumotlari</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Hisob ma\'lumotlari topildi</string>
     <string name="mode_quick_online_desc">Saqlangan hisob ma\'lumotlari aniqlandi. Ularni tez ulanish uchun ishlatilsinmi?</string>
     <string name="action_use_saved">Saqlanganni ishlat</string>
+
+    <!-- Menu -->
+    <string name="menu_file">Fayl</string>
+    <string name="menu_view">Ko'rinish</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Lenta</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -95,6 +95,7 @@
     <!-- Labels -->
     <string name="label_access_token">访问令牌</string>
     <string name="label_activity">活动</string>
+    <string name="label_all_habits">全部</string>
     <string name="label_app_mode">应用模式</string>
     <string name="label_base_url">服务器地址</string>
     <string name="label_credentials">凭证</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">找到凭证</string>
     <string name="mode_quick_online_desc">检测到已保存的凭证。使用它们快速连接？</string>
     <string name="action_use_saved">使用已保存</string>
+
+    <!-- Menu -->
+    <string name="menu_file">文件</string>
+    <string name="menu_view">显示</string>
 
     <!-- Navigation -->
     <string name="nav_feed">动态</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -97,6 +97,7 @@
     <!-- Labels -->
     <string name="label_access_token">Access token</string>
     <string name="label_activity">Activity</string>
+    <string name="label_all_habits">All</string>
     <string name="label_app_mode">App mode</string>
     <string name="label_base_url">Base URL</string>
     <string name="label_credentials">Credentials</string>
@@ -191,6 +192,10 @@
     <string name="mode_quick_online_title">Credentials Found</string>
     <string name="mode_quick_online_desc">Saved credentials detected. Use them to quickly connect online?</string>
     <string name="action_use_saved">Use saved</string>
+
+    <!-- Menu -->
+    <string name="menu_file">File</string>
+    <string name="menu_view">View</string>
 
     <!-- Navigation -->
     <string name="nav_feed">Feed</string>

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/AppColors.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/AppColors.kt
@@ -83,7 +83,7 @@ object AppColors {
   // Onboarding colors
   val background =
     ColorPair(
-      light = Color(0xFFFAFAFA),
+      light = Color(0xFFF0F2F5),
       dark = Color(0xFF121212),
     )
   val onBackground =
@@ -93,7 +93,7 @@ object AppColors {
     )
   val cardBackground =
     ColorPair(
-      light = Color(0xFFF8FAFC),
+      light = Color(0xFFFFFFFF),
       dark = Color(0xFF1E293B),
     )
   val onCardBackground =

--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/theme/VibitsTheme.kt
@@ -6,28 +6,26 @@ import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.compositionLocalOf
+import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.platform.theme.ConfigureSystemBars
 import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 
-/**
- * CompositionLocal for the current dark theme state.
- * This allows efficient access to theme state without multiple subscriptions.
- */
 val LocalDarkTheme = compositionLocalOf { false }
+val LocalWideLayout = compositionLocalOf { false }
 
-/**
- * Memos application theme with automatic dark/light mode support.
- * Uses platform-specific theme detection that updates dynamically.
- */
 @Composable
 fun VibitsTheme(
   darkTheme: Boolean = rememberSystemDarkTheme(),
+  wideLayout: Boolean = isDesktop,
   content: @Composable () -> Unit,
 ) {
   ConfigureSystemBars(darkTheme)
   val colorScheme = if (darkTheme) darkColorScheme() else lightColorScheme()
 
-  CompositionLocalProvider(LocalDarkTheme provides darkTheme) {
+  CompositionLocalProvider(
+    LocalDarkTheme provides darkTheme,
+    LocalWideLayout provides wideLayout,
+  ) {
     MaterialTheme(
       colorScheme = colorScheme,
       content = content,

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -14,20 +14,27 @@ import java.awt.image.BufferedImage
 import java.io.File
 import javax.imageio.ImageIO
 
-private const val APP_WIDTH = 540
-private const val APP_HEIGHT = 1080
+private const val WIDE_WIDTH = 900
+private const val WIDE_HEIGHT = 700
+private const val COMPACT_WIDTH = 540
+private const val COMPACT_HEIGHT = 1080
 
 @OptIn(ExperimentalTestApi::class)
-fun runAppUiTest(block: suspend DesktopComposeUiTest.() -> Unit) =
-  runDesktopComposeUiTest(width = APP_WIDTH, height = APP_HEIGHT, block = block)
+fun runWideUiTest(block: suspend DesktopComposeUiTest.() -> Unit) =
+  runDesktopComposeUiTest(width = WIDE_WIDTH, height = WIDE_HEIGHT, block = block)
+
+@OptIn(ExperimentalTestApi::class)
+fun runCompactUiTest(block: suspend DesktopComposeUiTest.() -> Unit) =
+  runDesktopComposeUiTest(width = COMPACT_WIDTH, height = COMPACT_HEIGHT, block = block)
 
 @OptIn(ExperimentalTestApi::class)
 fun ComposeUiTest.setThemedContent(
   darkTheme: Boolean = false,
+  wideLayout: Boolean = true,
   content: @Composable () -> Unit,
 ) {
   setContent {
-    VibitsTheme(darkTheme = darkTheme) {
+    VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
       content()
     }
   }
@@ -36,12 +43,29 @@ fun ComposeUiTest.setThemedContent(
 @OptIn(ExperimentalTestApi::class)
 fun ComposeUiTest.captureInBothThemes(
   name: String,
+  wideLayout: Boolean = true,
   content: @Composable () -> Unit,
 ) {
-  setThemedContent(darkTheme = false, content = content)
-  saveScreenshot(name)
-  setThemedContent(darkTheme = true, content = content)
+  setThemedContent(darkTheme = false, wideLayout = wideLayout, content = content)
+  saveScreenshot("${name}_light")
+  setThemedContent(darkTheme = true, wideLayout = wideLayout, content = content)
   saveScreenshot("${name}_dark")
+}
+
+@OptIn(ExperimentalTestApi::class)
+fun captureAllVariants(
+  name: String,
+  assertions: ComposeUiTest.() -> Unit = {},
+  content: @Composable () -> Unit,
+) {
+  runWideUiTest {
+    captureInBothThemes("wide_$name", wideLayout = true, content = content)
+    assertions()
+  }
+  runCompactUiTest {
+    captureInBothThemes("compact_$name", wideLayout = false, content = content)
+    assertions()
+  }
 }
 
 @OptIn(ExperimentalTestApi::class)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
@@ -28,6 +29,7 @@ import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
 import space.be1ski.vibits.feature.habits.presentation.state.isDataLoading
+import space.be1ski.vibits.feature.habits.presentation.view.components.HabitPicker
 
 /**
  * Stats tab with activity charts.
@@ -40,9 +42,10 @@ fun StatsScreen(
   habitsState: HabitsState = HabitsState(),
   onHabitsAction: (HabitsAction) -> Unit = {},
   onPostsListExpandedChange: (Boolean) -> Unit = {},
+  onSelectedHabitTagChange: (String?) -> Unit = {},
 ) {
   val derived = rememberStatsScreenDerived(state, appMode, habitsState, dateFormatter)
-  StatsScreenContent(derived, onHabitsAction, onPostsListExpandedChange)
+  StatsScreenContent(derived, onHabitsAction, onPostsListExpandedChange, onSelectedHabitTagChange)
   StatsScreenDialogs(derived, onHabitsAction)
 }
 
@@ -105,7 +108,7 @@ private fun rememberStatsScreenDerived(
     range is ActivityRange.Week ||
       range is ActivityRange.Month ||
       range is ActivityRange.Quarter
-  val useCompactHeight = range is ActivityRange.Year || range is ActivityRange.Month
+  val useCompactHeight = range !is ActivityRange.Week
   val collapseHabits = activityMode == ActivityMode.HABITS && range is ActivityRange.Year
   val showLast7DaysMatrix =
     activityMode == ActivityMode.HABITS &&
@@ -113,6 +116,10 @@ private fun rememberStatsScreenDerived(
       currentHabitsConfig.isNotEmpty()
   val showHabitSections =
     !showLast7DaysMatrix &&
+      activityMode == ActivityMode.HABITS &&
+      currentHabitsConfig.isNotEmpty()
+  val useHabitPicker =
+    state.wideLayout &&
       activityMode == ActivityMode.HABITS &&
       currentHabitsConfig.isNotEmpty()
   val selectedDay =
@@ -139,6 +146,7 @@ private fun rememberStatsScreenDerived(
     collapseHabits = collapseHabits,
     showLast7DaysMatrix = showLast7DaysMatrix,
     showHabitSections = showHabitSections,
+    useHabitPicker = useHabitPicker,
     selectedDay = selectedDay,
     todayConfig = todayConfig,
     todayDay = todayDay,
@@ -156,6 +164,7 @@ private fun StatsScreenContent(
   derived: StatsScreenDerivedState,
   dispatch: (HabitsAction) -> Unit,
   onPostsListExpandedChange: (Boolean) -> Unit,
+  onSelectedHabitTagChange: (String?) -> Unit,
 ) {
   val state = derived.state
   val columnModifier =
@@ -165,17 +174,41 @@ private fun StatsScreenContent(
       Modifier
     }
 
+  val selectedHabitTag = state.selectedHabitTag
+  LaunchedEffect(derived.currentHabitsConfig, selectedHabitTag) {
+    if (selectedHabitTag != null &&
+      derived.currentHabitsConfig.none { it.tag == selectedHabitTag }
+    ) {
+      onSelectedHabitTagChange(null)
+    }
+  }
+
+  val verticalSpacing = if (state.wideLayout) Indent.xs else Indent.s
   Column(
-    verticalArrangement = Arrangement.spacedBy(Indent.s),
+    verticalArrangement = Arrangement.spacedBy(verticalSpacing),
     modifier = Modifier.fillMaxSize().then(columnModifier).testTag(StatsTestTags.STATS_SCREEN),
   ) {
     StatsHabitsEmptyState(derived, dispatch)
     StatsInfoCard(derived, dispatch)
     StatsPostsInfoCard(derived)
-    StatsMainChart(derived, dispatch)
-    StatsWeeklyChart(derived, dispatch)
-    StatsCollapsiblePosts(derived, state.postsListExpanded, onPostsListExpandedChange)
-    StatsHabitSections(derived, dispatch)
+    if (derived.useHabitPicker && !derived.showLast7DaysMatrix) {
+      HabitPicker(
+        habits = derived.currentHabitsConfig,
+        selectedHabitTag = selectedHabitTag,
+        demoMode = state.demoMode,
+        onSelect = onSelectedHabitTagChange,
+      )
+      if (selectedHabitTag != null) {
+        StatsSelectedHabitChart(derived, dispatch, selectedHabitTag)
+      } else {
+        StatsMainChart(derived, dispatch)
+      }
+    } else {
+      StatsMainChart(derived, dispatch)
+      StatsWeeklyChart(derived, dispatch)
+      StatsCollapsiblePosts(derived, state.postsListExpanded, onPostsListExpandedChange)
+      StatsHabitSections(derived, dispatch)
+    }
   }
 }
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -25,7 +25,7 @@ import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material.icons.filled.Tune
 import androidx.compose.material3.Button
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
@@ -110,19 +110,21 @@ internal fun StatsInfoCard(
         modifier = Modifier.size(36.dp),
       ) {
         Icon(
-          imageVector = Icons.Filled.Settings,
+          imageVector = Icons.Filled.Tune,
           contentDescription = stringResource(Res.string.label_habits_config),
           modifier = Modifier.size(20.dp),
           tint = MaterialTheme.colorScheme.onSurfaceVariant,
         )
       }
-      Button(
-        onClick = {
-          val day = derived.todayDay ?: return@Button
-          dispatch(HabitsAction.Editor.OpenEditor(day = day, config = derived.todayConfig))
-        },
-      ) {
-        Text(stringResource(Res.string.action_track))
+      if (!state.wideLayout) {
+        Button(
+          onClick = {
+            val day = derived.todayDay ?: return@Button
+            dispatch(HabitsAction.Editor.OpenEditor(day = day, config = derived.todayConfig))
+          },
+        ) {
+          Text(stringResource(Res.string.action_track))
+        }
       }
     },
   )
@@ -464,6 +466,7 @@ private fun CompactPostRow(
 
 private const val COMPACT_POST_MAX_LENGTH = 50
 private const val MATRIX_CELL_FILL_MS = 220
+private const val MAX_MATRIX_CELL_HEIGHT_DP = 36
 
 @Suppress("LongMethod")
 @Composable
@@ -678,6 +681,198 @@ private fun HabitActivitySection(
   }
 }
 
+@Composable
+internal fun StatsSelectedHabitChart(
+  derived: StatsScreenDerivedState,
+  dispatch: (HabitsAction) -> Unit,
+  selectedHabitTag: String,
+) {
+  val habit = derived.currentHabitsConfig.firstOrNull { it.tag == selectedHabitTag } ?: return
+  val selectionId = "habit:${habit.tag}"
+
+  val onDaySelected =
+    remember(dispatch, selectionId) {
+      { day: ContributionDay -> dispatch(HabitsAction.Selection.SelectDay(day, selectionId)) }
+    }
+  val onClearSelection = remember(dispatch) { { dispatch(HabitsAction.Selection.ClearSelection) } }
+
+  if (derived.showLast7DaysMatrix) {
+    val onSingleHabitToggle =
+      remember(dispatch, derived.currentHabitsConfig) {
+        { day: ContributionDay, habitTag: String, habitLabel: String ->
+          dispatch(
+            HabitsAction.SingleToggle.RequestSingleHabitToggle(day, habitTag, habitLabel, derived.currentHabitsConfig),
+          )
+        }
+      }
+    SingleHabitWeekStrip(
+      days = derived.weekData.lastSevenDays(),
+      habit = habit,
+      compactHeight = derived.useCompactHeight,
+      demoMode = derived.state.demoMode,
+      formatter = derived.dateFormatter,
+      onHabitClick = onSingleHabitToggle,
+    )
+  } else {
+    SelectedHabitGrid(derived, habit, selectionId, onDaySelected, onClearSelection)
+  }
+}
+
+@Composable
+private fun SelectedHabitGrid(
+  derived: StatsScreenDerivedState,
+  habit: HabitConfig,
+  selectionId: String,
+  onDaySelected: (ContributionDay) -> Unit,
+  onClearSelection: () -> Unit,
+) {
+  val habitsState = derived.habitsState
+  val habitWeekData =
+    remember(derived.weekData, habit) {
+      derived.weekData.forHabit(habit)
+    }
+  val selectedDay =
+    remember(habitWeekData.weeks, habit, habitsState.selectedDate, habitsState.activeSelectionId) {
+      if (habitsState.activeSelectionId == selectionId) {
+        habitsState.selectedDate?.let { date -> habitWeekData.findDayByDate(date) }
+      } else {
+        null
+      }
+    }
+  val chartScrollState = rememberScrollState()
+  val showTimeline = derived.state.range is ActivityRange.Quarter || derived.state.range is ActivityRange.Year
+  val useCalendarLayout = derived.state.range is ActivityRange.Month
+
+  ContributionGrid(
+    state =
+      ContributionGridState(
+        weekData = habitWeekData,
+        range = derived.state.range,
+        selectedDay = selectedDay,
+        selectedWeekStart = null,
+        isActiveSelection = habitsState.activeSelectionId == selectionId,
+        scrollState = chartScrollState,
+        showWeekdayLegend = derived.showWeekdayLegend && !useCalendarLayout,
+        showAllWeekdayLabels = true,
+        compactHeight = derived.useCompactHeight,
+        showTimeline = showTimeline,
+        calendarLayout = useCalendarLayout,
+        today = derived.today,
+        habitColor = habit.color,
+        demoMode = derived.state.demoMode,
+      ),
+    dateFormatter = derived.dateFormatter,
+    onDaySelected = onDaySelected,
+    onClearSelection = onClearSelection,
+  )
+}
+
+@Composable
+private fun SingleHabitWeekStrip(
+  days: List<ContributionDay>,
+  habit: HabitConfig,
+  compactHeight: Boolean,
+  demoMode: Boolean,
+  formatter: DateFormatter,
+  onHabitClick: (day: ContributionDay, habitTag: String, habitLabel: String) -> Unit,
+) {
+  if (days.isEmpty()) return
+
+  BoxWithConstraints {
+    val labelWidth = HABIT_LABEL_WIDTH
+    val spacing = ChartDimens.spacing(compactHeight)
+    val availableWidth = (maxWidth - labelWidth - spacing).coerceAtLeast(0.dp)
+    val layout =
+      calculateLayout(
+        maxWidth = availableWidth,
+        columns = days.size.coerceAtLeast(1),
+        minColumnSize = ChartDimens.minCell(compactHeight),
+        spacing = spacing,
+      )
+    val cellWidth = layout.columnSize
+    val cellHeight = cellWidth.coerceAtMost(MAX_MATRIX_CELL_HEIGHT_DP.dp)
+
+    Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
+      Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+        Spacer(modifier = Modifier.width(labelWidth))
+        days.forEach { day ->
+          Box(
+            modifier = Modifier.size(width = cellWidth, height = cellHeight),
+            contentAlignment = Alignment.Center,
+          ) {
+            Text(formatter.dayOfWeekShort(day.date.dayOfWeek), style = MaterialTheme.typography.labelSmall)
+          }
+        }
+      }
+      SingleHabitRow(days, habit, demoMode, cellWidth, cellHeight, labelWidth, spacing, onHabitClick)
+      Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
+        Spacer(modifier = Modifier.width(labelWidth))
+        days.forEach { day ->
+          Box(
+            modifier = Modifier.size(width = cellWidth, height = cellHeight),
+            contentAlignment = Alignment.Center,
+          ) {
+            Text(day.date.day.toString(), style = MaterialTheme.typography.labelSmall)
+          }
+        }
+      }
+    }
+  }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun SingleHabitRow(
+  days: List<ContributionDay>,
+  habit: HabitConfig,
+  demoMode: Boolean,
+  cellWidth: androidx.compose.ui.unit.Dp,
+  cellHeight: androidx.compose.ui.unit.Dp,
+  labelWidth: androidx.compose.ui.unit.Dp,
+  spacing: androidx.compose.ui.unit.Dp,
+  onHabitClick: (day: ContributionDay, habitTag: String, habitLabel: String) -> Unit,
+) {
+  val pendingColor = AppColors.inactiveCell.resolve()
+  Row(
+    horizontalArrangement = Arrangement.spacedBy(spacing),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = habit.localizedLabel(demoMode),
+      style = MaterialTheme.typography.bodySmall,
+      modifier = Modifier.width(labelWidth),
+    )
+    days.forEach { day ->
+      val done = day.habitStatuses.firstOrNull { status -> status.tag == habit.tag }?.done == true
+      val alpha = if (!day.isClickable) DISABLED_CELL_ALPHA else 1f
+      val targetColor =
+        if (done) {
+          androidx.compose.ui.graphics
+            .Color(habit.color.argb)
+        } else {
+          pendingColor
+        }
+      val cellColor by animateColorAsState(
+        targetValue = targetColor.copy(alpha = alpha),
+        animationSpec = tween(durationMillis = MATRIX_CELL_FILL_MS),
+      )
+      Box(
+        modifier =
+          Modifier
+            .size(width = cellWidth, height = cellHeight)
+            .background(cellColor, shape = MaterialTheme.shapes.extraSmall)
+            .then(
+              if (day.isClickable) {
+                Modifier.clickable { onHabitClick(day, habit.tag, habit.label) }
+              } else {
+                Modifier
+              },
+            ),
+      )
+    }
+  }
+}
+
 @Suppress("LongMethod")
 @Composable
 private fun LastSevenDaysMatrix(
@@ -702,12 +897,16 @@ private fun LastSevenDaysMatrix(
         minColumnSize = ChartDimens.minCell(compactHeight),
         spacing = spacing,
       )
-    val cellSize = layout.columnSize
+    val cellWidth = layout.columnSize
+    val cellHeight = cellWidth.coerceAtMost(MAX_MATRIX_CELL_HEIGHT_DP.dp)
     Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
       Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
         Spacer(modifier = Modifier.width(labelWidth))
         days.forEach { day ->
-          Box(modifier = Modifier.size(cellSize), contentAlignment = Alignment.Center) {
+          Box(
+            modifier = Modifier.size(width = cellWidth, height = cellHeight),
+            contentAlignment = Alignment.Center,
+          ) {
             Text(
               formatter.dayOfWeekShort(day.date.dayOfWeek),
               style = MaterialTheme.typography.labelSmall,
@@ -724,6 +923,8 @@ private fun LastSevenDaysMatrix(
           Text(
             text = habit.localizedLabel(demoMode),
             style = MaterialTheme.typography.bodySmall,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis,
             modifier = Modifier.width(labelWidth),
           )
           days.forEach { day ->
@@ -743,7 +944,7 @@ private fun LastSevenDaysMatrix(
             Box(
               modifier =
                 Modifier
-                  .size(cellSize)
+                  .size(width = cellWidth, height = cellHeight)
                   .background(cellColor, shape = MaterialTheme.shapes.extraSmall)
                   .then(
                     if (day.isClickable) {
@@ -759,7 +960,10 @@ private fun LastSevenDaysMatrix(
       Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
         Spacer(modifier = Modifier.width(labelWidth))
         days.forEach { day ->
-          Box(modifier = Modifier.size(cellSize), contentAlignment = Alignment.Center) {
+          Box(
+            modifier = Modifier.size(width = cellWidth, height = cellHeight),
+            contentAlignment = Alignment.Center,
+          ) {
             Text(day.date.day.toString(), style = MaterialTheme.typography.labelSmall)
           }
         }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenModels.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenModels.kt
@@ -25,6 +25,8 @@ data class StatsScreenState(
   val enablePullRefresh: Boolean = true,
   val demoMode: Boolean = false,
   val postsListExpanded: Boolean = false,
+  val wideLayout: Boolean = false,
+  val selectedHabitTag: String? = null,
 )
 
 internal data class HabitActivitySectionState(
@@ -53,6 +55,7 @@ internal data class StatsScreenDerivedState(
   val collapseHabits: Boolean,
   val showLast7DaysMatrix: Boolean,
   val showHabitSections: Boolean,
+  val useHabitPicker: Boolean,
   val selectedDay: ContributionDay?,
   val todayConfig: List<HabitConfig>,
   val todayDay: ContributionDay?,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGrid.kt
@@ -26,14 +26,12 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.graphics.lerp
@@ -70,6 +68,7 @@ import space.be1ski.vibits.core.ui.platform.hoverAware
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
 import space.be1ski.vibits.core.utils.date.DAYS_IN_WEEK
+import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
 import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 
 internal object ChartDimens {
@@ -78,8 +77,6 @@ internal object ChartDimens {
   fun spacing(compact: Boolean): Dp = if (compact) COMPACT_SPACING_DP.dp else REGULAR_SPACING_DP.dp
 
   fun minCell(compact: Boolean): Dp = if (compact) COMPACT_CELL_DP.dp else REGULAR_CELL_DP.dp
-
-  fun maxCell(compact: Boolean): Dp? = if (compact) MAX_COMPACT_CELL_DP.dp else null
 }
 
 private const val LEGEND_WIDTH_DP = 26
@@ -87,12 +84,11 @@ private const val COMPACT_SPACING_DP = 1
 private const val REGULAR_SPACING_DP = 2
 private const val COMPACT_CELL_DP = 7
 private const val REGULAR_CELL_DP = 10
-private const val MAX_COMPACT_CELL_DP = 40
+private const val MAX_CALENDAR_CELL_HEIGHT_DP = 44
 
 private const val HABIT_COLOR_LIGHT_RATIO = 0.3f
 private const val CELL_BORDER_ANIMATION_MS = 140
 private const val CELL_FILL_ANIMATION_MS = 220
-private const val GRID_ENTER_ANIMATION_MS = 220
 
 /**
  * Renders GitHub-style daily activity grid for the provided [state].
@@ -111,16 +107,8 @@ fun ContributionGrid(
   if (!state.isActiveSelection && interaction.tooltip != null) {
     interaction.tooltip = null
   }
-  var animateIn by remember(state.range, state.weekData.weeks, state.calendarLayout) { mutableStateOf(false) }
-  LaunchedEffect(state.range, state.weekData.weeks, state.calendarLayout) { animateIn = true }
-  val contentAlpha by animateFloatAsState(
-    targetValue = if (animateIn) 1f else 0f,
-    animationSpec = tween(durationMillis = GRID_ENTER_ANIMATION_MS),
-  )
   Column(modifier = modifier) {
-    Box(modifier = Modifier.alpha(contentAlpha)) {
-      ContributionGridLayout(state, dateFormatter, onDaySelected, onClearSelection, interaction)
-    }
+    ContributionGridLayout(state, dateFormatter, onDaySelected, onClearSelection, interaction)
     ContributionGridTooltip(state, interaction, onEditRequested, onCreateRequested)
   }
 }
@@ -133,6 +121,7 @@ private class ContributionGridInteractionState {
 
 private data class ContributionGridLayoutState(
   val layout: ChartLayout,
+  val cellHeight: Dp,
   val spacing: Dp,
   val legendWidth: Dp,
   val legendSpacing: Dp,
@@ -187,7 +176,6 @@ private fun ContributionGridContent(
       .coerceAtLeast(1)
   val spacing = ChartDimens.spacing(state.compactHeight)
   val minCell = ChartDimens.minCell(state.compactHeight)
-  val maxCell = ChartDimens.maxCell(state.compactHeight)
   val legendWidth = if (state.showWeekdayLegend) ChartDimens.legendWidth else 0.dp
   val legendSpacing = if (state.showWeekdayLegend) spacing else 0.dp
   val availableWidth = (maxWidth - legendWidth - legendSpacing).coerceAtLeast(0.dp)
@@ -197,7 +185,6 @@ private fun ContributionGridContent(
       columns,
       minColumnSize = minCell,
       spacing = spacing,
-      maxColumnSize = maxCell,
     )
   val timelineLabels =
     remember(state.weekData.weeks, state.range) {
@@ -214,9 +201,11 @@ private fun ContributionGridContent(
         emptyList()
       }
     }
+  val cellHeight = layout.columnSize.coerceAtMost(MAX_CALENDAR_CELL_HEIGHT_DP.dp)
   val layoutState =
     ContributionGridLayoutState(
       layout = layout,
+      cellHeight = cellHeight,
       spacing = spacing,
       legendWidth = legendWidth,
       legendSpacing = legendSpacing,
@@ -240,16 +229,15 @@ private fun CalendarGridLayout(
 ) {
   val spacing = ChartDimens.spacing(state.compactHeight)
   val minCell = ChartDimens.minCell(state.compactHeight)
-  // Calendar layout should fill full width - no max cap
   val layout =
     calculateLayout(
       maxWidth,
       DAYS_IN_WEEK,
       minColumnSize = minCell,
       spacing = spacing,
-      maxColumnSize = null,
     )
   val cellSize = layout.columnSize
+  val cellHeight = cellSize.coerceAtMost(MAX_CALENDAR_CELL_HEIGHT_DP.dp)
 
   Column(
     modifier = Modifier.fillMaxWidth(),
@@ -257,7 +245,7 @@ private fun CalendarGridLayout(
     verticalArrangement = Arrangement.spacedBy(spacing),
   ) {
     // Weekday header row
-    CalendarWeekdayHeader(cellSize, spacing, state.weekendDays)
+    CalendarWeekdayHeader(cellSize, cellHeight, spacing, state.weekendDays)
 
     // Week rows
     state.weekData.weeks.forEach { week ->
@@ -271,6 +259,7 @@ private fun CalendarGridLayout(
                 maxCount = state.weekData.maxDaily,
                 enabled = day.inRange,
                 size = cellSize,
+                height = cellHeight,
                 isSelected = state.selectedDay?.date == day.date,
                 isHovered = interaction.hoveredDate == day.date,
                 isWeekSelected = false,
@@ -301,7 +290,8 @@ private fun CalendarGridLayout(
 
 @Composable
 private fun CalendarWeekdayHeader(
-  cellSize: Dp,
+  cellWidth: Dp,
+  cellHeight: Dp,
   spacing: Dp,
   weekendDays: Set<DayOfWeek>,
 ) {
@@ -330,7 +320,7 @@ private fun CalendarWeekdayHeader(
     weekdays.forEachIndexed { index, dayOfWeek ->
       val isWeekend = dayOfWeek in weekendDays
       Box(
-        modifier = Modifier.size(cellSize),
+        modifier = Modifier.size(width = cellWidth, height = cellHeight),
         contentAlignment = Alignment.Center,
       ) {
         Text(
@@ -366,7 +356,7 @@ private fun ContributionGridWeeks(
   ) {
     if (state.showWeekdayLegend) {
       DayOfWeekLegend(
-        cellSize = layout.columnSize,
+        cellSize = layoutState.cellHeight,
         spacing = spacing,
         showAllLabels = state.showAllWeekdayLabels,
       )
@@ -379,40 +369,52 @@ private fun ContributionGridWeeks(
       horizontalArrangement = Arrangement.spacedBy(spacing),
     ) {
       state.weekData.weeks.forEach { week ->
-        val isWeekSelected = state.selectedWeekStart == week.startDate
-        Column(verticalArrangement = Arrangement.spacedBy(spacing)) {
-          week.days.forEach { day ->
-            ContributionCell(
-              state =
-                ContributionCellState(
-                  day = day,
-                  maxCount = state.weekData.maxDaily,
-                  enabled = day.inRange,
-                  size = layout.columnSize,
-                  isSelected = state.selectedDay?.date == day.date,
-                  isHovered = interaction.hoveredDate == day.date,
-                  isWeekSelected = isWeekSelected,
-                  showDayNumber = state.showDayNumbers,
-                  isToday = state.today == day.date,
-                  habitColor = state.habitColor,
-                ),
-              onClick = { offset ->
-                onDaySelected(day)
-                interaction.tooltip = DayTooltip(day, offset)
-                interaction.suppressClear = true
-              },
-              onHoverChange = { hovering ->
-                interaction.hoveredDate =
-                  if (hovering) {
-                    day.date
-                  } else {
-                    interaction.hoveredDate?.takeIf { it != day.date }
-                  }
-              },
-            )
-          }
-        }
+        WeekColumn(state, week, onDaySelected, interaction, layoutState)
       }
+    }
+  }
+}
+
+@Composable
+private fun WeekColumn(
+  state: ContributionGridState,
+  week: ActivityWeek,
+  onDaySelected: (ContributionDay) -> Unit,
+  interaction: ContributionGridInteractionState,
+  layoutState: ContributionGridLayoutState,
+) {
+  val isWeekSelected = state.selectedWeekStart == week.startDate
+  Column(verticalArrangement = Arrangement.spacedBy(layoutState.spacing)) {
+    week.days.forEach { day ->
+      ContributionCell(
+        state =
+          ContributionCellState(
+            day = day,
+            maxCount = state.weekData.maxDaily,
+            enabled = day.inRange,
+            size = layoutState.layout.columnSize,
+            height = layoutState.cellHeight,
+            isSelected = state.selectedDay?.date == day.date,
+            isHovered = interaction.hoveredDate == day.date,
+            isWeekSelected = isWeekSelected,
+            showDayNumber = state.showDayNumbers,
+            isToday = state.today == day.date,
+            habitColor = state.habitColor,
+          ),
+        onClick = { offset ->
+          onDaySelected(day)
+          interaction.tooltip = DayTooltip(day, offset)
+          interaction.suppressClear = true
+        },
+        onHoverChange = { hovering ->
+          interaction.hoveredDate =
+            if (hovering) {
+              day.date
+            } else {
+              interaction.hoveredDate?.takeIf { it != day.date }
+            }
+        },
+      )
     }
   }
 }
@@ -431,6 +433,7 @@ private fun ContributionGridHeaderRow(
       TimelineRowState(
         labels = layoutState.headerLabels,
         cellSize = layout.columnSize,
+        cellHeight = layoutState.cellHeight,
         contentWidth = layout.contentWidth,
         spacing = layoutState.spacing,
         legendWidth = layoutState.legendWidth,
@@ -455,6 +458,7 @@ private fun ContributionGridTimelineRow(
       TimelineRowState(
         labels = layoutState.timelineLabels,
         cellSize = layout.columnSize,
+        cellHeight = layoutState.cellHeight,
         contentWidth = layout.contentWidth,
         spacing = layoutState.spacing,
         legendWidth = layoutState.legendWidth,
@@ -595,6 +599,7 @@ private fun DayOfWeekLegend(
 private data class TimelineRowState(
   val labels: List<String>,
   val cellSize: Dp,
+  val cellHeight: Dp,
   val contentWidth: Dp,
   val spacing: Dp,
   val legendWidth: Dp,
@@ -625,7 +630,7 @@ private fun TimelineRow(state: TimelineRowState) {
           modifier =
             Modifier
               .width(state.cellSize)
-              .height(state.cellSize + 4.dp),
+              .height(state.cellHeight + 4.dp),
           contentAlignment = Alignment.Center,
         ) {
           if (label.isNotBlank()) {
@@ -749,7 +754,7 @@ private fun ContributionCell(
   Box(
     modifier =
       Modifier
-        .size(state.size)
+        .size(width = state.size, height = state.height)
         .background(color = cellColor, shape = MaterialTheme.shapes.extraSmall)
         .border(width = animatedBorderWidth, color = animatedBorderColor, shape = MaterialTheme.shapes.extraSmall)
         .onGloballyPositioned { coordinates = it }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridState.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/ContributionGridState.kt
@@ -62,4 +62,5 @@ internal data class ContributionCellState(
   val isToday: Boolean = false,
   val isWeekend: Boolean = false,
   val habitColor: HabitColor? = null,
+  val height: Dp = size,
 )

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitPicker.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/HabitPicker.kt
@@ -1,0 +1,69 @@
+package space.be1ski.vibits.feature.habits.presentation.view.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.FilterChipDefaults
+import androidx.compose.material3.LocalMinimumInteractiveComponentSize
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.label_all_habits
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+
+private val COLOR_DOT_SIZE = 8.dp
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+internal fun HabitPicker(
+  habits: List<HabitConfig>,
+  selectedHabitTag: String?,
+  demoMode: Boolean,
+  onSelect: (String?) -> Unit,
+) {
+  CompositionLocalProvider(LocalMinimumInteractiveComponentSize provides Dp.Unspecified) {
+    FlowRow(
+      modifier = Modifier.padding(bottom = Indent.xs),
+      horizontalArrangement = Arrangement.spacedBy(Indent.xs),
+      verticalArrangement = Arrangement.spacedBy(Indent.x3s),
+    ) {
+      FilterChip(
+        selected = selectedHabitTag == null,
+        onClick = { onSelect(null) },
+        label = { Text(stringResource(Res.string.label_all_habits)) },
+        border = null,
+        elevation = null,
+      )
+      habits.forEach { habit ->
+        FilterChip(
+          selected = selectedHabitTag == habit.tag,
+          onClick = { onSelect(habit.tag) },
+          label = { Text(habit.localizedLabel(demoMode)) },
+          leadingIcon = {
+            Box(
+              modifier =
+                Modifier
+                  .size(COLOR_DOT_SIZE)
+                  .background(Color(habit.color.argb), CircleShape),
+            )
+          },
+          border = null,
+          elevation = null,
+        )
+      }
+    }
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppState.kt
@@ -12,6 +12,7 @@ data class AppState(
   val periodStartDate: LocalDate,
   val autoLoaded: Boolean = false,
   val postsListExpanded: Boolean = false,
+  val selectedHabitTag: String? = null,
 ) {
   val currentTimeRangeTab: TimeRangeTab
     get() =

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/action/AppAction.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/action/AppAction.kt
@@ -62,5 +62,9 @@ sealed interface AppAction : Action {
     data class SetPostsListExpanded(
       val expanded: Boolean,
     ) : UI
+
+    data class SetSelectedHabitTag(
+      val tag: String?,
+    ) : UI
   }
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/reducer/AppUIReducer.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/reducer/AppUIReducer.kt
@@ -16,5 +16,9 @@ internal val uiReducer: Reducer<AppAction.UI, AppState, AppEffect, Nothing> =
       is AppAction.UI.SetPostsListExpanded -> {
         state { state.copy(postsListExpanded = action.expanded) }
       }
+
+      is AppAction.UI.SetSelectedHabitTag -> {
+        state { state.copy(selectedHabitTag = action.tag) }
+      }
     }
   }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -1,22 +1,33 @@
 package space.be1ski.vibits.feature.homescreen.presentation.view
 
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.ui.platform.theme.rememberSystemDarkTheme
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.di.AppGraph
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
+private val DESKTOP_BREAKPOINT = 900.dp
+
 @Composable
-fun AppRoot(dependencies: AppDependencies) {
+fun AppRoot(
+  dependencies: AppDependencies,
+  onFeaturesReady: ((AppFeatures) -> Unit)? = null,
+) {
   val initialPrefs = remember { dependencies.loadPreferences() }
   remember { dependencies.localeProvider.configureLocale(initialPrefs.language) }
 
@@ -38,34 +49,41 @@ fun AppRoot(dependencies: AppDependencies) {
       onOnboardingCompleted = { showOnboarding = false },
     )
 
+  LaunchedEffect(featuresState.app) {
+    onFeaturesReady?.invoke(featuresState.app)
+  }
+
   SyncAppMode(featuresState, appMode) { appMode = it }
   ObserveOnboardingCheck(appMode, dependencies) { showOnboarding = it }
 
-  key(appLanguage) {
-    VibitsTheme(darkTheme = darkTheme) {
-      AppContent(
-        appMode = appMode,
-        showOnboarding = showOnboarding,
-        featuresState = featuresState,
-        appTheme = appTheme,
-        appLanguage = appLanguage,
-        exportService = dependencies.settingsDependencies.exportService,
-        onResetApp = {
-          resetApp(
-            dependencies = dependencies,
-            onThemeReset = { appTheme = AppTheme.SYSTEM },
-            onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
-            onVersionIncrement = { featuresVersion++ },
-            onModeReset = { appMode = AppMode.NOT_SELECTED },
-            onOnboardingReset = { showOnboarding = false },
-          )
-        },
-        onThemeChanged = { appTheme = it },
-        onLanguageChanged = {
-          dependencies.localeProvider.configureLocale(it)
-          appLanguage = it
-        },
-      )
+  BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
+    val wideLayout = maxWidth >= DESKTOP_BREAKPOINT
+    key(appLanguage) {
+      VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
+        AppContent(
+          appMode = appMode,
+          showOnboarding = showOnboarding,
+          featuresState = featuresState,
+          appTheme = appTheme,
+          appLanguage = appLanguage,
+          exportService = dependencies.settingsDependencies.exportService,
+          onResetApp = {
+            resetApp(
+              dependencies = dependencies,
+              onThemeReset = { appTheme = AppTheme.SYSTEM },
+              onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
+              onVersionIncrement = { featuresVersion++ },
+              onModeReset = { appMode = AppMode.NOT_SELECTED },
+              onOnboardingReset = { showOnboarding = false },
+            )
+          },
+          onThemeChanged = { appTheme = it },
+          onLanguageChanged = {
+            dependencies.localeProvider.configureLocale(it)
+            appLanguage = it
+          },
+        )
+      }
     }
   }
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellState.kt
@@ -1,0 +1,145 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.foundation.lazy.LazyListState
+import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.platform.date.currentLocalDate
+import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.ui.date.rememberDateFormatter
+import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
+import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
+import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
+import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
+import space.be1ski.vibits.feature.habits.presentation.view.components.rememberHabitsConfigTimeline
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+
+@Suppress("LongParameterList")
+internal class AppShellState(
+  val timeZone: TimeZone,
+  val today: LocalDate,
+  val dateFormatter: DateFormatter,
+  val habitsTimeline: List<HabitsConfigEntry>,
+  val todayHabits: TodayHabits,
+  val activityRange: ActivityRange,
+  val feedListState: LazyListState,
+  val callbacks: ScaffoldCallbacks,
+)
+
+@Composable
+internal fun rememberAppShellState(
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+): AppShellState {
+  val timeZone = remember { TimeZone.currentSystemDefault() }
+  val today = currentLocalDate()
+  val dateFormatter = rememberDateFormatter()
+  val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
+  val todayHabits = rememberTodayHabits(habitsTimeline, memosState.memos, timeZone, today)
+
+  val activityRange = activityRangeForAppState(appState)
+  val feedListState = rememberLazyListState()
+  val scope = rememberCoroutineScope()
+  val callbacks =
+    rememberScaffoldCallbacks(
+      appState = appState,
+      activityRange = activityRange,
+      onAppAction = features.app::send,
+      onHabitsAction = features.habits::send,
+      onMemosAction = features.memos::send,
+      feedListState = feedListState,
+      scope = scope,
+      todayHabits = todayHabits,
+    )
+
+  PrewarmCacheEffects(features, appState, memosState, habitsState)
+
+  return AppShellState(
+    timeZone = timeZone,
+    today = today,
+    dateFormatter = dateFormatter,
+    habitsTimeline = habitsTimeline,
+    todayHabits = todayHabits,
+    activityRange = activityRange,
+    feedListState = feedListState,
+    callbacks = callbacks,
+  )
+}
+
+@Composable
+private fun PrewarmCacheEffects(
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+) {
+  var prevAppMode by remember { mutableStateOf<AppMode?>(null) }
+  var prevMemosRevision by remember { mutableStateOf(0) }
+
+  LaunchedEffect(appState.appMode) {
+    if (prevAppMode != null && prevAppMode != appState.appMode) {
+      features.habits.send(HabitsAction.Cache.InvalidateAllCache)
+      prevMemosRevision = 0
+    }
+    prevAppMode = appState.appMode
+  }
+
+  LaunchedEffect(
+    appState.appMode,
+    memosState.memosRevision,
+    habitsState.needsCacheRefresh,
+    habitsState.isInitialLoading,
+  ) {
+    val revisionChanged = memosState.memosRevision != prevMemosRevision && prevMemosRevision != 0
+    val shouldPrewarm =
+      !habitsState.isInitialLoading &&
+        (habitsState.needsCacheRefresh || habitsState.activityDataCache.isEmpty() || revisionChanged)
+    if (memosState.memos.isNotEmpty() && shouldPrewarm) {
+      prevMemosRevision = memosState.memosRevision
+      features.habits.send(
+        HabitsAction.Cache.RequestPrewarmAllRanges(
+          memos = memosState.memos,
+          appMode = appState.appMode,
+        ),
+      )
+    }
+  }
+}
+
+@Composable
+internal fun rememberSuccessRateIfNeeded(
+  appState: AppState,
+  habitsTimeline: List<HabitsConfigEntry>,
+  activityRange: ActivityRange,
+  habitsState: HabitsState,
+): Float? {
+  val isHabitsScreen = appState.selectedScreen == Screen.HABITS
+  val hasHabits = remember(habitsTimeline) { habitsTimeline.lastOrNull()?.habits?.isNotEmpty() == true }
+  val shouldCalculate = isHabitsScreen && hasHabits
+  return if (shouldCalculate) {
+    val cachedData =
+      habitsState.getActivityData(
+        activityRange,
+        ActivityMode.HABITS,
+        appState.appMode,
+      )
+    cachedData?.successRate?.rate
+  } else {
+    null
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
@@ -7,4 +7,10 @@ object AppShellTestTags {
   const val BOTTOM_NAV_FEED = "app_nav_feed"
   const val FAB = "app_fab"
   const val HABIT_EDITOR_DIALOG = "app_habit_editor_dialog"
+  const val SIDEBAR_NAV_HABITS = "desktop_nav_habits"
+  const val SIDEBAR_NAV_STATS = "desktop_nav_stats"
+  const val SIDEBAR_NAV_FEED = "desktop_nav_feed"
+  const val SIDEBAR_TRACK_TODAY = "desktop_track_today"
+  const val SIDEBAR_NEW_MEMO = "desktop_new_memo"
+  const val SIDEBAR_SETTINGS = "desktop_settings"
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
@@ -1,0 +1,259 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.List
+import androidx.compose.material.icons.automirrored.filled.StickyNote2
+import androidx.compose.material.icons.filled.AddTask
+import androidx.compose.material.icons.filled.CheckCircle
+import androidx.compose.material.icons.filled.Edit
+import androidx.compose.material.icons.filled.Refresh
+import androidx.compose.material.icons.filled.Settings
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.date.currentLocalDate
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.action_refresh
+import space.be1ski.vibits.core.strings.generated.action_track_today
+import space.be1ski.vibits.core.strings.generated.app_name
+import space.be1ski.vibits.core.strings.generated.nav_feed
+import space.be1ski.vibits.core.strings.generated.nav_habits
+import space.be1ski.vibits.core.strings.generated.nav_memos
+import space.be1ski.vibits.core.strings.generated.nav_settings
+import space.be1ski.vibits.core.strings.generated.title_new_memo
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.ui.platform.hoverAware
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
+import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+import space.be1ski.vibits.feature.memos.presentation.view.SyncDot
+
+private val SIDEBAR_WIDTH = 240.dp
+
+@Suppress("LongParameterList")
+@Composable
+internal fun DesktopSidebar(
+  appState: AppState,
+  todayHabits: TodayHabits,
+  memosState: MemosState,
+  onAppAction: (AppAction) -> Unit,
+  onClearSelection: () -> Unit,
+  onFeedScrollToTop: () -> Unit,
+  onOpenTodayEditor: () -> Unit,
+  onShowCreateMemoDialog: () -> Unit,
+  onSettingsClick: () -> Unit,
+  dispatchMemos: (MemosAction) -> Unit,
+) {
+  Surface(
+    modifier = Modifier.width(SIDEBAR_WIDTH).fillMaxHeight(),
+    tonalElevation = 1.dp,
+  ) {
+    Column(modifier = Modifier.padding(Indent.s)) {
+      SidebarHeader(memosState, dispatchMemos)
+      SidebarNavigation(appState, onAppAction, onClearSelection, onFeedScrollToTop)
+      Spacer(modifier = Modifier.weight(1f))
+      SidebarActions(todayHabits, onOpenTodayEditor, onShowCreateMemoDialog, onSettingsClick)
+    }
+  }
+}
+
+@Composable
+private fun SidebarNavigation(
+  appState: AppState,
+  onAppAction: (AppAction) -> Unit,
+  onClearSelection: () -> Unit,
+  onFeedScrollToTop: () -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(Indent.x3s)) {
+    SidebarNavItem(
+      icon = Icons.Filled.CheckCircle,
+      label = stringResource(Res.string.nav_habits),
+      selected = appState.selectedScreen == Screen.HABITS,
+      testTag = AppShellTestTags.SIDEBAR_NAV_HABITS,
+      onClick = {
+        onClearSelection()
+        if (appState.selectedScreen == Screen.HABITS) {
+          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
+        } else {
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.HABITS))
+        }
+      },
+    )
+    SidebarNavItem(
+      icon = Icons.AutoMirrored.Filled.StickyNote2,
+      label = stringResource(Res.string.nav_memos),
+      selected = appState.selectedScreen == Screen.STATS,
+      testTag = AppShellTestTags.SIDEBAR_NAV_STATS,
+      onClick = {
+        onClearSelection()
+        if (appState.selectedScreen == Screen.STATS) {
+          onAppAction(AppAction.TimeRange.ResetToHome(currentLocalDate()))
+        } else {
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.STATS))
+        }
+      },
+    )
+    SidebarNavItem(
+      icon = Icons.AutoMirrored.Filled.List,
+      label = stringResource(Res.string.nav_feed),
+      selected = appState.selectedScreen == Screen.FEED,
+      testTag = AppShellTestTags.SIDEBAR_NAV_FEED,
+      onClick = {
+        onClearSelection()
+        if (appState.selectedScreen == Screen.FEED) {
+          onFeedScrollToTop()
+        } else {
+          onAppAction(AppAction.Navigation.SelectScreen(Screen.FEED))
+        }
+      },
+    )
+  }
+}
+
+@Composable
+private fun SidebarActions(
+  todayHabits: TodayHabits,
+  onOpenTodayEditor: () -> Unit,
+  onShowCreateMemoDialog: () -> Unit,
+  onSettingsClick: () -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(Indent.x3s)) {
+    if (todayHabits.config.isNotEmpty() && todayHabits.day != null) {
+      SidebarNavItem(
+        icon = Icons.Filled.AddTask,
+        label = stringResource(Res.string.action_track_today),
+        selected = false,
+        accent = true,
+        testTag = AppShellTestTags.SIDEBAR_TRACK_TODAY,
+        onClick = onOpenTodayEditor,
+      )
+    }
+    SidebarNavItem(
+      icon = Icons.Filled.Edit,
+      label = stringResource(Res.string.title_new_memo),
+      selected = false,
+      accent = true,
+      testTag = AppShellTestTags.SIDEBAR_NEW_MEMO,
+      onClick = onShowCreateMemoDialog,
+    )
+    SidebarNavItem(
+      icon = Icons.Filled.Settings,
+      label = stringResource(Res.string.nav_settings),
+      selected = false,
+      testTag = AppShellTestTags.SIDEBAR_SETTINGS,
+      onClick = onSettingsClick,
+    )
+  }
+}
+
+@Composable
+private fun SidebarHeader(
+  memosState: MemosState,
+  dispatchMemos: (MemosAction) -> Unit,
+) {
+  Row(
+    modifier = Modifier.fillMaxWidth().padding(start = Indent.xs, bottom = Indent.l),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Text(
+      text = stringResource(Res.string.app_name),
+      style = MaterialTheme.typography.titleLarge,
+    )
+    Spacer(modifier = Modifier.weight(1f))
+    if (!memosState.isOfflineMode) {
+      SyncDot(
+        syncStatus = memosState.syncStatus,
+        isSyncing = memosState.isSyncing,
+        onClick = { dispatchMemos(MemosAction.Sync.ShowSyncLogDialog) },
+      )
+    }
+    IconButton(onClick = { dispatchMemos(MemosAction.Loading.LoadMemos) }) {
+      Icon(
+        imageVector = Icons.Filled.Refresh,
+        contentDescription = stringResource(Res.string.action_refresh),
+        modifier = Modifier.size(20.dp),
+      )
+    }
+  }
+}
+
+@Composable
+private fun SidebarNavItem(
+  icon: ImageVector,
+  label: String,
+  selected: Boolean,
+  testTag: String,
+  onClick: () -> Unit,
+  accent: Boolean = false,
+) {
+  var hovered by remember { mutableStateOf(false) }
+  val shape = RoundedCornerShape(Indent.xs)
+  val primaryColor = MaterialTheme.colorScheme.primary
+  val backgroundColor =
+    when {
+      accent -> primaryColor.copy(alpha = 0.12f)
+      selected -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.08f)
+      hovered -> MaterialTheme.colorScheme.onSurface.copy(alpha = 0.04f)
+      else -> Color.Transparent
+    }
+  val contentColor =
+    when {
+      accent -> primaryColor
+      else -> MaterialTheme.colorScheme.onSurface
+    }
+
+  Row(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .clip(shape)
+        .background(backgroundColor, shape)
+        .hoverAware { hovered = it }
+        .clickable(onClick = onClick)
+        .testTag(testTag)
+        .padding(horizontal = Indent.s, vertical = Indent.xs),
+    horizontalArrangement = Arrangement.spacedBy(Indent.s),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    Icon(icon, contentDescription = null, modifier = Modifier.size(20.dp), tint = contentColor)
+    Text(
+      label,
+      style = MaterialTheme.typography.bodyMedium,
+      fontWeight = if (selected || accent) FontWeight.SemiBold else FontWeight.Normal,
+      color = contentColor,
+      maxLines = 1,
+      overflow = TextOverflow.Ellipsis,
+    )
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -14,9 +14,9 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.core.utils.date.quarterIndex
 import space.be1ski.vibits.core.utils.date.startOfWeek
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
@@ -55,6 +55,7 @@ internal fun SwipeableTabContent(
   dispatchMemos: (MemosAction) -> Unit = {},
   feedListState: LazyListState,
 ) {
+  val wideLayout = LocalWideLayout.current
   if (appState.selectedScreen == Screen.FEED) {
     FeedScreen(
       memos = memosState.memos,
@@ -63,7 +64,7 @@ internal fun SwipeableTabContent(
       onFilterChange = { filter -> dispatchMemos(MemosAction.Loading.ChangePostFilter(filter)) },
       isRefreshing = memosState.isLoading,
       onRefresh = {},
-      enablePullRefresh = !isDesktop,
+      enablePullRefresh = !wideLayout,
       demoMode = appState.isDemoMode,
       onMemoClick = { memo ->
         handleMemoClick(
@@ -97,7 +98,6 @@ internal fun SwipeableTabContent(
       habitsState = habitsState,
       onHabitsAction = onHabitsAction,
       onAppAction = onAppAction,
-      onMemosAction = dispatchMemos,
       dateFormatter = dateFormatter,
     )
   }
@@ -113,7 +113,6 @@ private fun SwipeablePagerContent(
   habitsState: HabitsState,
   onHabitsAction: (HabitsAction) -> Unit,
   onAppAction: (AppAction) -> Unit,
-  onMemosAction: (MemosAction) -> Unit,
   dateFormatter: DateFormatter,
 ) {
   val activityRange = activityRangeForAppState(appState)
@@ -170,7 +169,6 @@ private fun SwipeablePagerContent(
       habitsState = habitsState,
       onHabitsAction = onHabitsAction,
       onAppAction = onAppAction,
-      onMemosAction = onMemosAction,
       dateFormatter = dateFormatter,
     )
   }
@@ -184,9 +182,9 @@ private fun MemosTabContent(
   habitsState: HabitsState,
   onHabitsAction: (HabitsAction) -> Unit,
   onAppAction: (AppAction) -> Unit,
-  onMemosAction: (MemosAction) -> Unit,
   dateFormatter: DateFormatter,
 ) {
+  val wideLayout = LocalWideLayout.current
   val memos = memosState.memos
   when (appState.selectedScreen) {
     Screen.HABITS ->
@@ -196,14 +194,17 @@ private fun MemosTabContent(
             memos = memos,
             range = activityRange,
             activityMode = ActivityMode.HABITS,
-            useVerticalScroll = true,
+            useVerticalScroll = !wideLayout,
             enablePullRefresh = false,
             demoMode = appState.isDemoMode,
+            wideLayout = wideLayout,
+            selectedHabitTag = appState.selectedHabitTag,
           ),
         appMode = appState.appMode,
         dateFormatter = dateFormatter,
         habitsState = habitsState,
         onHabitsAction = onHabitsAction,
+        onSelectedHabitTagChange = { onAppAction(AppAction.UI.SetSelectedHabitTag(it)) },
       )
     Screen.STATS ->
       StatsScreen(
@@ -212,10 +213,11 @@ private fun MemosTabContent(
             memos = memos,
             range = activityRange,
             activityMode = ActivityMode.POSTS,
-            useVerticalScroll = true,
+            useVerticalScroll = !wideLayout,
             enablePullRefresh = false,
             demoMode = appState.isDemoMode,
             postsListExpanded = appState.postsListExpanded,
+            wideLayout = wideLayout,
           ),
         appMode = appState.appMode,
         dateFormatter = dateFormatter,
@@ -223,25 +225,7 @@ private fun MemosTabContent(
         onHabitsAction = onHabitsAction,
         onPostsListExpandedChange = { onAppAction(AppAction.UI.SetPostsListExpanded(it)) },
       )
-    Screen.FEED ->
-      FeedScreen(
-        memos = memos,
-        dateFormatter = dateFormatter,
-        activeFilter = memosState.activePostFilter,
-        onFilterChange = { filter -> onMemosAction(MemosAction.Loading.ChangePostFilter(filter)) },
-        isRefreshing = memosState.isLoading,
-        onRefresh = {},
-        enablePullRefresh = !isDesktop,
-        demoMode = appState.isDemoMode,
-        onMemoClick = { memo ->
-          handleMemoClick(
-            memo = memo,
-            memos = memosState.memos,
-            onMemosAction = onMemosAction,
-            onHabitsAction = onHabitsAction,
-          )
-        },
-      )
+    Screen.FEED -> Unit
   }
 }
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
@@ -36,15 +37,27 @@ internal fun VibitsApp(
     onLanguageChanged = onLanguageChanged,
   )
 
-  VibitsAppScaffold(
-    features = features,
-    appState = appState,
-    memosState = memosState,
-    habitsState = habitsState,
-    currentLanguage = currentLanguage,
-    currentTheme = currentTheme,
-    syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
-  )
+  if (LocalWideLayout.current) {
+    VibitsDesktopShell(
+      features = features,
+      appState = appState,
+      memosState = memosState,
+      habitsState = habitsState,
+      currentLanguage = currentLanguage,
+      currentTheme = currentTheme,
+      syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
+    )
+  } else {
+    VibitsAppScaffold(
+      features = features,
+      appState = appState,
+      memosState = memosState,
+      habitsState = habitsState,
+      currentLanguage = currentLanguage,
+      currentTheme = currentTheme,
+      syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
+    )
+  }
 
   SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService)
   MemoCreateDialog(state = memosState, dispatch = features.memos::send)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppComponents.kt
@@ -21,7 +21,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.platform.date.currentLocalDate
-import space.be1ski.vibits.core.platform.isDesktop
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_refresh
@@ -31,6 +30,7 @@ import space.be1ski.vibits.core.strings.generated.nav_habits
 import space.be1ski.vibits.core.strings.generated.nav_memos
 import space.be1ski.vibits.core.strings.generated.nav_settings
 import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
@@ -52,19 +52,20 @@ internal fun MemosHeader(
   theme: AppTheme,
   syncDebounceSeconds: Int,
 ) {
+  val wideLayout = LocalWideLayout.current
   Row(
     modifier = Modifier.fillMaxWidth(),
     horizontalArrangement = Arrangement.SpaceBetween,
     verticalAlignment = Alignment.CenterVertically,
   ) {
-    // Left side: App name + sync dot (on desktop)
+    // Left side: App name + sync dot (on wide layout)
     Row(
       horizontalArrangement = Arrangement.spacedBy(Indent.s),
       verticalAlignment = Alignment.CenterVertically,
     ) {
       Text(stringResource(Res.string.app_name), style = MaterialTheme.typography.headlineSmall)
-      // Show sync dot on desktop (left side) only in online mode
-      if (isDesktop && !memosState.isOfflineMode) {
+      // Show sync dot on wide layout (left side) only in online mode
+      if (wideLayout && !memosState.isOfflineMode) {
         SyncDot(
           syncStatus = memosState.syncStatus,
           isSyncing = memosState.isSyncing,
@@ -72,9 +73,9 @@ internal fun MemosHeader(
         )
       }
     }
-    // Right side: refresh button + sync dot (on mobile) + settings
+    // Right side: refresh button + sync dot (on compact layout) + settings
     Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs), verticalAlignment = Alignment.CenterVertically) {
-      if (isDesktop) {
+      if (wideLayout) {
         IconButton(onClick = { dispatchMemos(MemosAction.Loading.LoadMemos) }) {
           Icon(imageVector = Icons.Filled.Refresh, contentDescription = stringResource(Res.string.action_refresh))
         }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppScaffold.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsAppScaffold.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AddTask
 import androidx.compose.material.icons.filled.Edit
@@ -16,42 +15,29 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.platform.locale.AppLanguage
-import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_create_memo
 import space.be1ski.vibits.core.strings.generated.action_track_today
 import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.date.DateFormatter
-import space.be1ski.vibits.core.ui.date.rememberDateFormatter
-import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.habits.domain.usecase.EarliestMemoDateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.IsActivityRangeBeforeUseCase
-import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
-import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
-import space.be1ski.vibits.feature.habits.presentation.view.components.rememberHabitsConfigTimeline
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.memos.presentation.state.MemosState
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
-@Suppress("LongMethod")
 @Composable
 internal fun VibitsAppScaffold(
   features: AppFeatures,
@@ -62,64 +48,13 @@ internal fun VibitsAppScaffold(
   currentTheme: AppTheme,
   syncDebounceSeconds: Int,
 ) {
-  val timeZone = remember { TimeZone.currentSystemDefault() }
-  val today = currentLocalDate()
-  val dateFormatter = rememberDateFormatter()
-  val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
-  val todayHabits = rememberTodayHabits(habitsTimeline, memosState.memos, timeZone, today)
-
-  val activityRange = activityRangeForAppState(appState)
-  val feedListState = rememberLazyListState()
-  val scope = rememberCoroutineScope()
-  val callbacks =
-    rememberScaffoldCallbacks(
-      appState = appState,
-      activityRange = activityRange,
-      onAppAction = features.app::send,
-      onHabitsAction = features.habits::send,
-      onMemosAction = features.memos::send,
-      feedListState = feedListState,
-      scope = scope,
-      todayHabits = todayHabits,
-    )
-
-  // Prewarm trigger: single source of truth for cache warming
-  var prevAppMode by remember { mutableStateOf<AppMode?>(null) }
-  var prevMemosRevision by remember { mutableStateOf(0) }
-
-  LaunchedEffect(appState.appMode) {
-    if (prevAppMode != null && prevAppMode != appState.appMode) {
-      features.habits.send(HabitsAction.Cache.InvalidateAllCache)
-      // Reset memos revision to prevent prewarming with old mode's data
-      prevMemosRevision = 0
-    }
-    prevAppMode = appState.appMode
-  }
-
-  LaunchedEffect(
-    appState.appMode,
-    memosState.memosRevision,
-    habitsState.needsCacheRefresh,
-    habitsState.isInitialLoading,
-  ) {
-    val revisionChanged = memosState.memosRevision != prevMemosRevision && prevMemosRevision != 0
-    val shouldPrewarm =
-      !habitsState.isInitialLoading &&
-        (habitsState.needsCacheRefresh || habitsState.activityDataCache.isEmpty() || revisionChanged)
-    if (memosState.memos.isNotEmpty() && shouldPrewarm) {
-      prevMemosRevision = memosState.memosRevision
-      features.habits.send(
-        HabitsAction.Cache.RequestPrewarmAllRanges(
-          memos = memosState.memos,
-          appMode = appState.appMode,
-        ),
-      )
-    }
-  }
+  val shell = rememberAppShellState(features, appState, memosState, habitsState)
 
   Scaffold(
-    floatingActionButton = { AppFab(appState, todayHabits, callbacks) },
-    bottomBar = { MemosBottomNavigation(appState, features.app::send, callbacks.onClearSelection, callbacks.onFeedScrollToTop) },
+    floatingActionButton = { AppFab(appState, shell.todayHabits, shell.callbacks) },
+    bottomBar = {
+      MemosBottomNavigation(appState, features.app::send, shell.callbacks.onClearSelection, shell.callbacks.onFeedScrollToTop)
+    },
   ) { padding ->
     ScaffoldContent(
       padding = padding,
@@ -127,16 +62,16 @@ internal fun VibitsAppScaffold(
       appState = appState,
       memosState = memosState,
       habitsState = habitsState,
-      habitsTimeline = habitsTimeline,
-      activityRange = activityRange,
-      timeZone = timeZone,
-      today = today,
-      callbacks = callbacks,
+      habitsTimeline = shell.habitsTimeline,
+      activityRange = shell.activityRange,
+      timeZone = shell.timeZone,
+      today = shell.today,
+      callbacks = shell.callbacks,
       currentLanguage = currentLanguage,
       currentTheme = currentTheme,
       syncDebounceSeconds = syncDebounceSeconds,
-      feedListState = feedListState,
-      dateFormatter = dateFormatter,
+      feedListState = shell.feedListState,
+      dateFormatter = shell.dateFormatter,
     )
   }
 }
@@ -232,29 +167,5 @@ private fun ScaffoldContent(
       dispatchMemos = features.memos::send,
       feedListState = feedListState,
     )
-  }
-}
-
-@Composable
-private fun rememberSuccessRateIfNeeded(
-  appState: AppState,
-  habitsTimeline: List<HabitsConfigEntry>,
-  activityRange: ActivityRange,
-  habitsState: HabitsState,
-): Float? {
-  val isHabitsScreen = appState.selectedScreen == Screen.HABITS
-  val hasHabits = remember(habitsTimeline) { habitsTimeline.lastOrNull()?.habits?.isNotEmpty() == true }
-  val shouldCalculate = isHabitsScreen && hasHabits
-  return if (shouldCalculate) {
-    // Read from TEA cache
-    val cachedData =
-      habitsState.getActivityData(
-        activityRange,
-        ActivityMode.HABITS,
-        appState.appMode,
-      )
-    cachedData?.successRate?.rate
-  } else {
-    null
   }
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
@@ -1,0 +1,155 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.VerticalDivider
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.habits.domain.usecase.EarliestMemoDateUseCase
+import space.be1ski.vibits.feature.habits.domain.usecase.IsActivityRangeBeforeUseCase
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
+import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+import space.be1ski.vibits.feature.memos.presentation.view.SyncConflictDialog
+import space.be1ski.vibits.feature.memos.presentation.view.SyncLogDialog
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
+
+@Composable
+internal fun VibitsDesktopShell(
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  currentLanguage: AppLanguage,
+  currentTheme: AppTheme,
+  syncDebounceSeconds: Int,
+) {
+  val shell = rememberAppShellState(features, appState, memosState, habitsState)
+
+  Surface(modifier = Modifier.fillMaxSize()) {
+    Row(modifier = Modifier.fillMaxSize()) {
+      DesktopSidebar(
+        appState = appState,
+        todayHabits = shell.todayHabits,
+        memosState = memosState,
+        onAppAction = features.app::send,
+        onClearSelection = shell.callbacks.onClearSelection,
+        onFeedScrollToTop = shell.callbacks.onFeedScrollToTop,
+        onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
+        onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
+        onSettingsClick = {
+          features.settings.send(
+            SettingsAction.Dialog.Open(
+              baseUrl = memosState.baseUrl,
+              token = memosState.token,
+              appMode = appState.appMode,
+              language = currentLanguage,
+              theme = currentTheme,
+              syncDebounceSeconds = syncDebounceSeconds,
+            ),
+          )
+        },
+        dispatchMemos = features.memos::send,
+      )
+      VerticalDivider()
+      Column(modifier = Modifier.weight(1f).fillMaxSize()) {
+        DesktopContent(
+          features = features,
+          appState = appState,
+          memosState = memosState,
+          habitsState = habitsState,
+          shell = shell,
+        )
+      }
+    }
+  }
+
+  SyncDialogs(memosState = memosState, dispatchMemos = features.memos::send)
+}
+
+@Composable
+private fun SyncDialogs(
+  memosState: MemosState,
+  dispatchMemos: (MemosAction) -> Unit,
+) {
+  if (memosState.showSyncLogDialog) {
+    SyncLogDialog(onDismiss = { dispatchMemos(MemosAction.Sync.DismissSyncLogDialog) })
+  }
+  if (memosState.showConflictDialog) {
+    SyncConflictDialog(
+      conflictCount = memosState.syncConflicts.size,
+      onKeepLocal = { dispatchMemos(MemosAction.Sync.ResolveKeepLocal) },
+      onKeepServer = { dispatchMemos(MemosAction.Sync.ResolveKeepServer) },
+      onDismiss = { dispatchMemos(MemosAction.Sync.DismissConflictDialog) },
+    )
+  }
+}
+
+@Composable
+private fun DesktopContent(
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  shell: AppShellState,
+) {
+  val selectedTab = appState.currentTimeRangeTab
+  val currentRange = currentRangeForTab(selectedTab, shell.today)
+  val earliestDate = remember(memosState.memos) { EarliestMemoDateUseCase(memosState.memos, shell.timeZone) }
+  val minRange = minRangeForTab(selectedTab, earliestDate)
+  val canGoBack = minRange?.let { IsActivityRangeBeforeUseCase(it, shell.activityRange) } ?: true
+  val canGoForward = IsActivityRangeBeforeUseCase(shell.activityRange, currentRange)
+
+  Column(
+    modifier = Modifier.padding(horizontal = Indent.m, vertical = Indent.xs).fillMaxSize(),
+    verticalArrangement = Arrangement.spacedBy(Indent.xs),
+  ) {
+    val errorText =
+      memosState.errorMessage
+        ?: if (memosState.credentialsMode && memosState.needsCredentials) stringResource(Res.string.msg_fill_all_fields) else null
+    errorText?.let { Text(it, color = MaterialTheme.colorScheme.error) }
+
+    if (appState.selectedScreen != Screen.FEED) {
+      val successRate = rememberSuccessRateIfNeeded(appState, shell.habitsTimeline, shell.activityRange, habitsState)
+      TimeRangeControls(
+        selectedTab = selectedTab,
+        rangeLabel = formatRangeLabel(shell.activityRange, shell.dateFormatter),
+        successRate = successRate,
+        canGoBack = canGoBack,
+        canGoForward = canGoForward,
+        onTabChange = shell.callbacks.onTabChange,
+        onNavigateBack = shell.callbacks.onNavigateBack,
+        onNavigateForward = shell.callbacks.onNavigateForward,
+      )
+    }
+
+    SwipeableTabContent(
+      memosState = memosState,
+      appState = appState,
+      currentRange = currentRange,
+      minRange = minRange,
+      habitsState = habitsState,
+      onHabitsAction = features.habits::send,
+      onAppAction = features.app::send,
+      dateFormatter = shell.dateFormatter,
+      dispatchMemos = features.memos::send,
+      feedListState = shell.feedListState,
+    )
+  }
+}

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -2,7 +2,6 @@
 
 package space.be1ski.vibits.feature.homescreen.presentation.view
 
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
@@ -13,9 +12,10 @@ import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.elm.test.RecordingFeature
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
-import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.captureAllVariants
+import space.be1ski.vibits.core.ui.test.runCompactUiTest
+import space.be1ski.vibits.core.ui.test.runWideUiTest
 import space.be1ski.vibits.core.ui.test.saveScreenshot
-import space.be1ski.vibits.core.ui.test.setThemedContent
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
@@ -32,7 +32,6 @@ import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseC
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
-import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
@@ -40,13 +39,11 @@ import space.be1ski.vibits.feature.memos.domain.model.ExportResult
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.memos.presentation.state.MemosState
-import space.be1ski.vibits.feature.memos.presentation.view.FeedTestTags
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
 import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
-import space.be1ski.vibits.feature.settings.presentation.view.SettingsTestTags
 import space.be1ski.vibits.feature.sync.domain.model.ConflictType
 import space.be1ski.vibits.feature.sync.domain.model.SyncConflict
 import space.be1ski.vibits.feature.sync.domain.model.SyncOperation
@@ -179,6 +176,7 @@ class AppScreenshotTest {
     habitsState: HabitsState = HabitsState(),
     settingsState: SettingsState = SettingsState(),
     darkTheme: Boolean = false,
+    wideLayout: Boolean = true,
   ) {
     val features =
       AppFeatures(
@@ -188,7 +186,7 @@ class AppScreenshotTest {
         settings = RecordingFeature(settingsState),
       )
     setContent {
-      VibitsTheme(darkTheme = darkTheme) {
+      VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
         VibitsApp(
           features = features,
           currentTheme = AppTheme.SYSTEM,
@@ -205,11 +203,24 @@ class AppScreenshotTest {
     memosState: MemosState = MemosState(memos = demoMemos, initialDataLoaded = true),
     habitsState: HabitsState = HabitsState(),
     settingsState: SettingsState = SettingsState(),
+    wideLayout: Boolean = true,
   ) {
-    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = false)
-    saveScreenshot(name)
-    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = true)
-    saveScreenshot("${name}_dark")
+    val platform = if (wideLayout) "wide" else "compact"
+    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = false, wideLayout = wideLayout)
+    saveScreenshot("${platform}_light_$name")
+    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = true, wideLayout = wideLayout)
+    saveScreenshot("${platform}_dark_$name")
+  }
+
+  private fun captureAppAllVariants(
+    name: String,
+    appState: AppState,
+    memosState: MemosState = MemosState(memos = demoMemos, initialDataLoaded = true),
+    habitsState: HabitsState = HabitsState(),
+    settingsState: SettingsState = SettingsState(),
+  ) {
+    runWideUiTest { captureApp(name, appState, memosState, habitsState, settingsState) }
+    runCompactUiTest { captureApp(name, appState, memosState, habitsState, settingsState, wideLayout = false) }
   }
 
   private fun habitsAppState(
@@ -256,161 +267,113 @@ class AppScreenshotTest {
   // region Loading
 
   @Test
-  fun `when app is loading then captures loading screen`() =
-    runAppUiTest {
-      val features =
-        AppFeatures(
-          app = RecordingFeature(AppState(appMode = AppMode.DEMO, periodStartDate = today)),
-          memos = RecordingFeature(MemosState(initialDataLoaded = false)),
-          habits = RecordingFeature(HabitsState()),
-          settings = RecordingFeature(SettingsState()),
-        )
-      val content: @Composable () -> Unit = {
-        AppContent(
-          appMode = AppMode.DEMO,
-          showOnboarding = false,
-          featuresState =
-            FeaturesState(
-              modeSelection = RecordingFeature(ModeSelectionState()),
-              onboarding = RecordingFeature(OnboardingState()),
-              app = features,
-            ),
-          appTheme = AppTheme.SYSTEM,
-          appLanguage = AppLanguage.ENGLISH,
-          exportService = fakeExportService,
-          onResetApp = {},
-          onThemeChanged = {},
-          onLanguageChanged = {},
-        )
-      }
-
-      setThemedContent(darkTheme = false, content = content)
-      onNodeWithTag(AppShellTestTags.LOADING_SCREEN).assertIsDisplayed()
-      saveScreenshot("app_loading")
-
-      setThemedContent(darkTheme = true, content = content)
-      onNodeWithTag(AppShellTestTags.LOADING_SCREEN).assertIsDisplayed()
-      saveScreenshot("app_loading_dark")
+  fun `when app is loading then captures loading screen`() {
+    val features =
+      AppFeatures(
+        app = RecordingFeature(AppState(appMode = AppMode.DEMO, periodStartDate = today)),
+        memos = RecordingFeature(MemosState(initialDataLoaded = false)),
+        habits = RecordingFeature(HabitsState()),
+        settings = RecordingFeature(SettingsState()),
+      )
+    captureAllVariants(
+      "app_loading",
+      assertions = { onNodeWithTag(AppShellTestTags.LOADING_SCREEN).assertIsDisplayed() },
+    ) {
+      AppContent(
+        appMode = AppMode.DEMO,
+        showOnboarding = false,
+        featuresState =
+          FeaturesState(
+            modeSelection = RecordingFeature(ModeSelectionState()),
+            onboarding = RecordingFeature(OnboardingState()),
+            app = features,
+          ),
+        appTheme = AppTheme.SYSTEM,
+        appLanguage = AppLanguage.ENGLISH,
+        exportService = fakeExportService,
+        onResetApp = {},
+        onThemeChanged = {},
+        onLanguageChanged = {},
+      )
     }
+  }
 
   // endregion
 
   // region Habits stats
 
   @Test
-  fun `when habits week view then captures week habits`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 12, 9)
-      val range = ActivityRange.Week(periodStart)
-      captureApp(
-        name = "app_habits_week",
-        appState = habitsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
-    }
+  fun `when habits week view then captures week habits`() {
+    val periodStart = LocalDate(2024, 12, 9)
+    val range = ActivityRange.Week(periodStart)
+    val appState = habitsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(name = "app_habits_week", appState = appState, habitsState = habitsState)
+  }
 
   @Test
-  fun `when habits month view then captures month habits`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 11, 1)
-      val range = ActivityRange.Month(2024, Month.NOVEMBER)
-      captureApp(
-        name = "app_habits_month",
-        appState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
-    }
+  fun `when habits month view then captures month habits`() {
+    val periodStart = LocalDate(2024, 11, 1)
+    val range = ActivityRange.Month(2024, Month.NOVEMBER)
+    val appState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(name = "app_habits_month", appState = appState, habitsState = habitsState)
+  }
 
   @Test
-  fun `when habits quarter view then captures quarter habits`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 10, 1)
-      val range = ActivityRange.Quarter(2024, 4)
-      captureApp(
-        name = "app_habits_quarter",
-        appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
-    }
+  fun `when habits quarter view then captures quarter habits`() {
+    val periodStart = LocalDate(2024, 10, 1)
+    val range = ActivityRange.Quarter(2024, 4)
+    val appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(name = "app_habits_quarter", appState = appState, habitsState = habitsState)
+  }
 
   @Test
-  fun `when habits year view then captures year habits`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 6, 15)
-      val range = ActivityRange.Year(2024)
-      captureApp(
-        name = "app_habits_year",
-        appState = habitsAppState(tab = TimeRangeTab.YEARS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_HABITS).assertIsDisplayed()
-    }
+  fun `when habits year view then captures year habits`() {
+    val periodStart = LocalDate(2024, 6, 15)
+    val range = ActivityRange.Year(2024)
+    val appState = habitsAppState(tab = TimeRangeTab.YEARS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(name = "app_habits_year", appState = appState, habitsState = habitsState)
+  }
 
   // endregion
 
   // region Posts stats
 
   @Test
-  fun `when posts week view then captures week posts`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 12, 9)
-      val range = ActivityRange.Week(periodStart)
-      captureApp(
-        name = "app_stats_week",
-        appState = postsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range, mode = ActivityMode.POSTS),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_STATS).assertIsDisplayed()
-    }
+  fun `when posts week view then captures week posts`() {
+    val periodStart = LocalDate(2024, 12, 9)
+    val range = ActivityRange.Week(periodStart)
+    val appState = postsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range, mode = ActivityMode.POSTS)
+    captureAppAllVariants(name = "app_stats_week", appState = appState, habitsState = habitsState)
+  }
 
   @Test
-  fun `when posts month view then captures month posts`() =
-    runAppUiTest {
-      val periodStart = LocalDate(2024, 11, 1)
-      val range = ActivityRange.Month(2024, Month.NOVEMBER)
-      captureApp(
-        name = "app_stats_month",
-        appState = postsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = periodStart),
-        habitsState = habitsStateWithCache(range, mode = ActivityMode.POSTS),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_STATS).assertIsDisplayed()
-    }
+  fun `when posts month view then captures month posts`() {
+    val periodStart = LocalDate(2024, 11, 1)
+    val range = ActivityRange.Month(2024, Month.NOVEMBER)
+    val appState = postsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = periodStart)
+    val habitsState = habitsStateWithCache(range, mode = ActivityMode.POSTS)
+    captureAppAllVariants(name = "app_stats_month", appState = appState, habitsState = habitsState)
+  }
 
   // endregion
 
   // region Feed
 
   @Test
-  fun `when feed has data then captures feed screen`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_feed",
-        appState = feedAppState(),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_FEED).assertIsDisplayed()
-    }
+  fun `when feed has data then captures feed screen`() = captureAppAllVariants(name = "app_feed", appState = feedAppState())
 
   @Test
   fun `when feed is empty then captures empty feed`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_feed_empty",
-        appState = feedAppState(),
-        memosState = MemosState(memos = emptyList(), initialDataLoaded = true),
-      )
-
-      onNodeWithTag(AppShellTestTags.BOTTOM_NAV_FEED).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_feed_empty",
+      appState = feedAppState(),
+      memosState = MemosState(memos = emptyList(), initialDataLoaded = true),
+    )
 
   // endregion
 
@@ -418,189 +381,161 @@ class AppScreenshotTest {
 
   @Test
   fun `when settings open in online mode then captures online settings`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_settings_online",
-        appState = habitsAppState(),
-        settingsState =
-          SettingsState(
-            isOpen = true,
-            appMode = AppMode.ONLINE,
-            editBaseUrl = "https://memos.example.com",
-            editToken = "test-token-123",
-          ),
-      )
-
-      onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_settings_online",
+      appState = habitsAppState(),
+      settingsState =
+        SettingsState(
+          isOpen = true,
+          appMode = AppMode.ONLINE,
+          editBaseUrl = "https://memos.example.com",
+          editToken = "test-token-123",
+        ),
+    )
 
   @Test
   fun `when settings open in demo mode then captures demo settings`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_settings_demo",
-        appState = habitsAppState(),
-        settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO),
-      )
-
-      onNodeWithTag(SettingsTestTags.SETTINGS_DIALOG).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_settings_demo",
+      appState = habitsAppState(),
+      settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO),
+    )
 
   @Test
   fun `when logs dialog open then captures logs`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_settings_logs",
-        appState = habitsAppState(),
-        settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showLogsDialog = true),
-      )
-
-      onNodeWithTag(SettingsTestTags.LOGS_DIALOG).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_settings_logs",
+      appState = habitsAppState(),
+      settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showLogsDialog = true),
+    )
 
   @Test
   fun `when reset confirmation open then captures reset dialog`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_settings_reset",
-        appState = habitsAppState(),
-        settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showResetConfirmation = true),
-      )
-
-      onNodeWithTag(SettingsTestTags.RESET_OPTIONS_DIALOG).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_settings_reset",
+      appState = habitsAppState(),
+      settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showResetConfirmation = true),
+    )
 
   // endregion
 
   // region Habit dialogs
 
   @Test
-  fun `when habit editor open then captures editor dialog`() =
-    runAppUiTest {
-      val editorDay =
-        ContributionDay(
-          date = today,
-          count = 1,
-          totalHabits = 4,
-          completionRatio = 0.25f,
-          habitStatuses =
-            listOf(
-              HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
-              HabitStatus(tag = "#habits/water", label = "Water", done = false),
-              HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
-              HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
-            ),
-          dailyMemo = null,
-          inRange = true,
-        )
-      val range = ActivityRange.Week(LocalDate(2024, 12, 9))
-      captureApp(
-        name = "app_habit_editor",
-        appState = habitsAppState(),
-        habitsState =
-          habitsStateWithCache(range).copy(
-            editorDay = editorDay,
-            editorConfig = allHabits,
-            editorSelections =
-              mapOf(
-                "#habits/exercise" to true,
-                "#habits/water" to false,
-                "#habits/reading" to false,
-                "#habits/meditation" to false,
-              ),
+  fun `when habit editor open then captures editor dialog`() {
+    val editorDay =
+      ContributionDay(
+        date = today,
+        count = 1,
+        totalHabits = 4,
+        completionRatio = 0.25f,
+        habitStatuses =
+          listOf(
+            HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
+            HabitStatus(tag = "#habits/water", label = "Water", done = false),
+            HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
+            HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
           ),
+        dailyMemo = null,
+        inRange = true,
       )
-
-      onNodeWithTag(AppShellTestTags.HABIT_EDITOR_DIALOG).assertIsDisplayed()
-    }
+    val range = ActivityRange.Week(LocalDate(2024, 12, 9))
+    captureAppAllVariants(
+      name = "app_habit_editor",
+      appState = habitsAppState(),
+      habitsState =
+        habitsStateWithCache(range).copy(
+          editorDay = editorDay,
+          editorConfig = allHabits,
+          editorSelections =
+            mapOf(
+              "#habits/exercise" to true,
+              "#habits/water" to false,
+              "#habits/reading" to false,
+              "#habits/meditation" to false,
+            ),
+        ),
+    )
+  }
 
   @Test
-  fun `when config dialog open then captures habits config`() =
-    runAppUiTest {
-      val range = ActivityRange.Week(LocalDate(2024, 12, 9))
-      captureApp(
-        name = "app_habits_config",
-        appState = habitsAppState(),
-        habitsState =
-          habitsStateWithCache(range).copy(
-            showConfigDialog = true,
-            editingHabits =
-              allHabits.mapIndexed { i, h ->
-                EditableHabit(id = "$i", tag = h.tag, label = h.label, color = h.color)
-              },
-          ),
-      )
-
-      onNodeWithTag(StatsTestTags.HABITS_CONFIG_DIALOG).assertIsDisplayed()
-    }
+  fun `when config dialog open then captures habits config`() {
+    val range = ActivityRange.Week(LocalDate(2024, 12, 9))
+    captureAppAllVariants(
+      name = "app_habits_config",
+      appState = habitsAppState(),
+      habitsState =
+        habitsStateWithCache(range).copy(
+          showConfigDialog = true,
+          editingHabits =
+            allHabits.mapIndexed { i, h ->
+              EditableHabit(id = "$i", tag = h.tag, label = h.label, color = h.color)
+            },
+        ),
+    )
+  }
 
   @Test
-  fun `when delete confirm shown then captures delete dialog`() =
-    runAppUiTest {
-      val testDay =
-        ContributionDay(
-          date = today,
-          count = 2,
-          totalHabits = 4,
-          completionRatio = 0.5f,
-          habitStatuses =
-            listOf(
-              HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
-              HabitStatus(tag = "#habits/water", label = "Water", done = true),
-              HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
-              HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
-            ),
-          dailyMemo = null,
-          inRange = true,
-        )
-      val range = ActivityRange.Week(LocalDate(2024, 12, 9))
-      captureApp(
-        name = "app_habits_delete",
-        appState = habitsAppState(),
-        habitsState =
-          habitsStateWithCache(range).copy(
-            showDeleteConfirm = true,
-            editorDay = testDay,
+  fun `when delete confirm shown then captures delete dialog`() {
+    val testDay =
+      ContributionDay(
+        date = today,
+        count = 2,
+        totalHabits = 4,
+        completionRatio = 0.5f,
+        habitStatuses =
+          listOf(
+            HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
+            HabitStatus(tag = "#habits/water", label = "Water", done = true),
+            HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
+            HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
           ),
+        dailyMemo = null,
+        inRange = true,
       )
-
-      onNodeWithTag(StatsTestTags.EMPTY_DELETE_DIALOG).assertIsDisplayed()
-    }
+    val range = ActivityRange.Week(LocalDate(2024, 12, 9))
+    captureAppAllVariants(
+      name = "app_habits_delete",
+      appState = habitsAppState(),
+      habitsState =
+        habitsStateWithCache(range).copy(
+          showDeleteConfirm = true,
+          editorDay = testDay,
+        ),
+    )
+  }
 
   @Test
-  fun `when single toggle shown then captures toggle dialog`() =
-    runAppUiTest {
-      val testDay =
-        ContributionDay(
-          date = today,
-          count = 1,
-          totalHabits = 4,
-          completionRatio = 0.25f,
-          habitStatuses =
-            listOf(
-              HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
-              HabitStatus(tag = "#habits/water", label = "Water", done = false),
-              HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
-              HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
-            ),
-          dailyMemo = null,
-          inRange = true,
-        )
-      val range = ActivityRange.Week(LocalDate(2024, 12, 9))
-      captureApp(
-        name = "app_habits_toggle",
-        appState = habitsAppState(),
-        habitsState =
-          habitsStateWithCache(range).copy(
-            singleToggleDay = testDay,
-            singleToggleHabitTag = "#habits/water",
-            singleToggleHabitLabel = "Water",
-            singleToggleConfig = allHabits,
+  fun `when single toggle shown then captures toggle dialog`() {
+    val testDay =
+      ContributionDay(
+        date = today,
+        count = 1,
+        totalHabits = 4,
+        completionRatio = 0.25f,
+        habitStatuses =
+          listOf(
+            HabitStatus(tag = "#habits/exercise", label = "Exercise", done = true),
+            HabitStatus(tag = "#habits/water", label = "Water", done = false),
+            HabitStatus(tag = "#habits/reading", label = "Reading", done = false),
+            HabitStatus(tag = "#habits/meditation", label = "Meditation", done = false),
           ),
+        dailyMemo = null,
+        inRange = true,
       )
-
-      onNodeWithTag(StatsTestTags.SINGLE_TOGGLE_DIALOG).assertIsDisplayed()
-    }
+    val range = ActivityRange.Week(LocalDate(2024, 12, 9))
+    captureAppAllVariants(
+      name = "app_habits_toggle",
+      appState = habitsAppState(),
+      habitsState =
+        habitsStateWithCache(range).copy(
+          singleToggleDay = testDay,
+          singleToggleHabitTag = "#habits/water",
+          singleToggleHabitLabel = "Water",
+          singleToggleConfig = allHabits,
+        ),
+    )
+  }
 
   // endregion
 
@@ -608,46 +543,38 @@ class AppScreenshotTest {
 
   @Test
   fun `when edit config warning shown then captures warning dialog`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_feed_edit_warning",
-        appState = feedAppState(),
-        habitsState = HabitsState(showEditConfigWarning = true),
-      )
-
-      onNodeWithTag(StatsTestTags.EDIT_CONFIG_WARNING_DIALOG).assertIsDisplayed()
-    }
+    captureAppAllVariants(
+      name = "app_feed_edit_warning",
+      appState = feedAppState(),
+      habitsState = HabitsState(showEditConfigWarning = true),
+    )
 
   @Test
   fun `when sync conflict dialog shown then captures conflict dialog`() =
-    runAppUiTest {
-      captureApp(
-        name = "app_sync_conflict",
-        appState = feedAppState(),
-        memosState =
-          MemosState(
-            memos = demoMemos,
-            initialDataLoaded = true,
-            showConflictDialog = true,
-            syncConflicts =
-              listOf(
-                SyncConflict(
-                  operation =
-                    SyncOperation(
-                      id = "op1",
-                      type = SyncOperationType.UPDATE,
-                      memoName = demoMemos.first().name,
-                    ),
-                  localMemo = demoMemos.first(),
-                  serverMemo = demoMemos.first(),
-                  conflictType = ConflictType.BOTH_MODIFIED,
-                ),
+    captureAppAllVariants(
+      name = "app_sync_conflict",
+      appState = feedAppState(),
+      memosState =
+        MemosState(
+          memos = demoMemos,
+          initialDataLoaded = true,
+          showConflictDialog = true,
+          syncConflicts =
+            listOf(
+              SyncConflict(
+                operation =
+                  SyncOperation(
+                    id = "op1",
+                    type = SyncOperationType.UPDATE,
+                    memoName = demoMemos.first().name,
+                  ),
+                localMemo = demoMemos.first(),
+                serverMemo = demoMemos.first(),
+                conflictType = ConflictType.BOTH_MODIFIED,
               ),
-          ),
-      )
-
-      onNodeWithTag(FeedTestTags.SYNC_CONFLICT_DIALOG).assertIsDisplayed()
-    }
+            ),
+        ),
+    )
 
   // endregion
 }

--- a/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
+++ b/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
@@ -5,8 +5,7 @@ import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
 import space.be1ski.vibits.core.elm.test.RecordingFeature
 import space.be1ski.vibits.core.ui.form.CredentialValidationError
-import space.be1ski.vibits.core.ui.test.captureInBothThemes
-import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.captureAllVariants
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
 import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect
 import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
@@ -24,44 +23,42 @@ class ModeSelectionScreenshotTest {
 
   @Test
   fun `when default state then captures mode selection screen`() =
-    runAppUiTest {
-      captureInBothThemes("mode_selection_default") { ModeSelectionScreen(createFeature()) }
-
-      onNodeWithTag(ModeSelectionTestTags.ONLINE_CARD).assertIsDisplayed()
-    }
+    captureAllVariants(
+      "mode_selection_default",
+      assertions = { onNodeWithTag(ModeSelectionTestTags.ONLINE_CARD).assertIsDisplayed() },
+    ) { ModeSelectionScreen(createFeature()) }
 
   @Test
   fun `when quick online dialog shown then captures dialog`() =
-    runAppUiTest {
-      captureInBothThemes("mode_selection_quick_online_dialog") {
-        ModeSelectionScreen(createFeature(ModeSelectionState(showQuickOnlineDialog = true)))
-      }
-
-      onNodeWithTag(ModeSelectionTestTags.QUICK_ONLINE_DIALOG).assertIsDisplayed()
+    captureAllVariants(
+      "mode_selection_quick_online_dialog",
+      assertions = { onNodeWithTag(ModeSelectionTestTags.QUICK_ONLINE_DIALOG).assertIsDisplayed() },
+    ) {
+      ModeSelectionScreen(createFeature(ModeSelectionState(showQuickOnlineDialog = true)))
     }
 
   @Test
   fun `when credentials dialog shown then captures dialog`() =
-    runAppUiTest {
-      captureInBothThemes("mode_selection_credentials_dialog") {
-        ModeSelectionScreen(createFeature(ModeSelectionState(showCredentialsDialog = true)))
-      }
-
-      onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
+    captureAllVariants(
+      "mode_selection_credentials_dialog",
+      assertions = { onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed() },
+    ) {
+      ModeSelectionScreen(createFeature(ModeSelectionState(showCredentialsDialog = true)))
     }
 
   @Test
   fun `when credentials dialog has error then captures error state`() =
-    runAppUiTest {
-      val feature =
+    captureAllVariants(
+      "mode_selection_credentials_error",
+      assertions = { onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed() },
+    ) {
+      ModeSelectionScreen(
         createFeature(
           ModeSelectionState(
             showCredentialsDialog = true,
             error = CredentialValidationError.CONNECTION_FAILED,
           ),
-        )
-      captureInBothThemes("mode_selection_credentials_error") { ModeSelectionScreen(feature) }
-
-      onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed()
+        ),
+      )
     }
 }

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/ChoosePresetScreen.kt
@@ -91,7 +91,8 @@ fun ChoosePresetScreen(
     Spacer(modifier = Modifier.height(Indent.m))
 
     LazyColumn(
-      verticalArrangement = Arrangement.spacedBy(Indent.s),
+      verticalArrangement = Arrangement.spacedBy(Indent.xs),
+      modifier = Modifier.weight(1f),
     ) {
       items(presets, key = { it.id }) { preset ->
         val localizedName = preset.localizedName()
@@ -104,9 +105,7 @@ fun ChoosePresetScreen(
       }
     }
 
-    Spacer(modifier = Modifier.weight(1f))
-
-    Spacer(modifier = Modifier.height(Indent.m))
+    Spacer(modifier = Modifier.height(Indent.s))
 
     Button(
       onClick = onContinue,

--- a/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreen.kt
+++ b/feature/onboarding/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreen.kt
@@ -1,13 +1,17 @@
 package space.be1ski.vibits.feature.onboarding.presentation.view
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.safeDrawing
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import space.be1ski.vibits.core.ui.theme.AppColors
 import space.be1ski.vibits.core.ui.theme.resolve
 import space.be1ski.vibits.feature.onboarding.presentation.action.OnboardingAction
@@ -31,51 +35,67 @@ fun OnboardingScreen(
         .windowInsetsPadding(WindowInsets.safeDrawing),
     color = AppColors.background.resolve(),
   ) {
-    when (state.currentStep) {
-      OnboardingStep.Welcome -> {
-        WelcomeScreen(
-          onContinue = { onAction(OnboardingAction.Navigation.Continue) },
-          onSkip = { onAction(OnboardingAction.Navigation.Skip) },
-          modifier = modifier.fillMaxSize(),
-        )
-      }
+    Box(
+      modifier = Modifier.fillMaxSize(),
+      contentAlignment = Alignment.TopCenter,
+    ) {
+      OnboardingStepContent(state, onAction)
+    }
+  }
+}
 
-      OnboardingStep.ChoosePreset -> {
-        ChoosePresetScreen(
-          presets = state.presets,
-          selectedPresetId = state.selectedPresetId,
-          onSelectPreset = { presetId, localizedName ->
-            onAction(OnboardingAction.Preset.SelectPreset(presetId, localizedName))
-          },
-          onContinue = { onAction(OnboardingAction.Navigation.Continue) },
-          onBack = { onAction(OnboardingAction.Navigation.Back) },
-          modifier = modifier.fillMaxSize(),
-        )
-      }
+private val ONBOARDING_MAX_WIDTH = 480.dp
 
-      OnboardingStep.HabitSetup -> {
-        HabitSetupScreen(
-          selectedPresetId = state.selectedPresetId,
-          presets = state.presets,
-          habitName = state.habitName,
-          selectedColor = state.selectedColor,
-          isCreating = state.isCreatingHabit,
-          error = state.creationError,
-          onUpdateName = { onAction(OnboardingAction.Habit.UpdateHabitName(it)) },
-          onColorChange = { onAction(OnboardingAction.Habit.UpdateHabitColor(it)) },
-          onCreate = { onAction(OnboardingAction.Habit.CreateHabit) },
-          onBack = { onAction(OnboardingAction.Navigation.Back) },
-          modifier = modifier.fillMaxSize(),
-        )
-      }
+@Composable
+private fun OnboardingStepContent(
+  state: OnboardingState,
+  onAction: (OnboardingAction) -> Unit,
+) {
+  val screenModifier = Modifier.widthIn(max = ONBOARDING_MAX_WIDTH).fillMaxSize()
+  when (state.currentStep) {
+    OnboardingStep.Welcome -> {
+      WelcomeScreen(
+        onContinue = { onAction(OnboardingAction.Navigation.Continue) },
+        onSkip = { onAction(OnboardingAction.Navigation.Skip) },
+        modifier = screenModifier,
+      )
+    }
 
-      OnboardingStep.Success -> {
-        SuccessScreen(
-          onMarkFirstCheckIn = { onAction(OnboardingAction.Completion.MarkFirstCheckIn) },
-          onGoToDashboard = { onAction(OnboardingAction.Completion.GoToDashboard) },
-          modifier = modifier.fillMaxSize(),
-        )
-      }
+    OnboardingStep.ChoosePreset -> {
+      ChoosePresetScreen(
+        presets = state.presets,
+        selectedPresetId = state.selectedPresetId,
+        onSelectPreset = { presetId, localizedName ->
+          onAction(OnboardingAction.Preset.SelectPreset(presetId, localizedName))
+        },
+        onContinue = { onAction(OnboardingAction.Navigation.Continue) },
+        onBack = { onAction(OnboardingAction.Navigation.Back) },
+        modifier = screenModifier,
+      )
+    }
+
+    OnboardingStep.HabitSetup -> {
+      HabitSetupScreen(
+        selectedPresetId = state.selectedPresetId,
+        presets = state.presets,
+        habitName = state.habitName,
+        selectedColor = state.selectedColor,
+        isCreating = state.isCreatingHabit,
+        error = state.creationError,
+        onUpdateName = { onAction(OnboardingAction.Habit.UpdateHabitName(it)) },
+        onColorChange = { onAction(OnboardingAction.Habit.UpdateHabitColor(it)) },
+        onCreate = { onAction(OnboardingAction.Habit.CreateHabit) },
+        onBack = { onAction(OnboardingAction.Navigation.Back) },
+        modifier = screenModifier,
+      )
+    }
+
+    OnboardingStep.Success -> {
+      SuccessScreen(
+        onMarkFirstCheckIn = { onAction(OnboardingAction.Completion.MarkFirstCheckIn) },
+        onGoToDashboard = { onAction(OnboardingAction.Completion.GoToDashboard) },
+        modifier = screenModifier,
+      )
     }
   }
 }

--- a/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
+++ b/feature/onboarding/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/onboarding/presentation/view/OnboardingScreenshotTest.kt
@@ -3,8 +3,7 @@ package space.be1ski.vibits.feature.onboarding.presentation.view
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onNodeWithTag
-import space.be1ski.vibits.core.ui.test.captureInBothThemes
-import space.be1ski.vibits.core.ui.test.runAppUiTest
+import space.be1ski.vibits.core.ui.test.captureAllVariants
 import space.be1ski.vibits.core.utils.habits.DemoHabit
 import space.be1ski.vibits.feature.onboarding.domain.model.HabitPreset
 import space.be1ski.vibits.feature.onboarding.presentation.state.OnboardingState
@@ -17,84 +16,73 @@ class OnboardingScreenshotTest {
 
   @Test
   fun `when welcome step then captures welcome screen`() =
-    runAppUiTest {
-      captureInBothThemes("onboarding_welcome") {
-        OnboardingScreen(
-          state = OnboardingState(currentStep = OnboardingStep.Welcome),
-          onAction = {},
-        )
-      }
-
-      onNodeWithTag(OnboardingTestTags.WELCOME_SCREEN).assertIsDisplayed()
+    captureAllVariants(
+      "onboarding_welcome",
+      assertions = { onNodeWithTag(OnboardingTestTags.WELCOME_SCREEN).assertIsDisplayed() },
+    ) {
+      OnboardingScreen(state = OnboardingState(currentStep = OnboardingStep.Welcome), onAction = {})
     }
 
   @Test
   fun `when choose preset step then captures preset selection screen`() =
-    runAppUiTest {
-      captureInBothThemes("onboarding_choose_preset") {
-        OnboardingScreen(
-          state =
-            OnboardingState(
-              currentStep = OnboardingStep.ChoosePreset,
-              presets = testPresets,
-              selectedPresetId = "exercise",
-            ),
-          onAction = {},
-        )
-      }
-
-      onNodeWithTag(OnboardingTestTags.CHOOSE_PRESET_SCREEN).assertIsDisplayed()
+    captureAllVariants(
+      "onboarding_choose_preset",
+      assertions = { onNodeWithTag(OnboardingTestTags.CHOOSE_PRESET_SCREEN).assertIsDisplayed() },
+    ) {
+      OnboardingScreen(
+        state =
+          OnboardingState(
+            currentStep = OnboardingStep.ChoosePreset,
+            presets = testPresets,
+            selectedPresetId = "exercise",
+          ),
+        onAction = {},
+      )
     }
 
   @Test
   fun `when habit setup step then captures habit setup screen`() =
-    runAppUiTest {
-      captureInBothThemes("onboarding_habit_setup") {
-        OnboardingScreen(
-          state =
-            OnboardingState(
-              currentStep = OnboardingStep.HabitSetup,
-              presets = testPresets,
-              selectedPresetId = "exercise",
-              habitName = "Exercise",
-            ),
-          onAction = {},
-        )
-      }
-
-      onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
+    captureAllVariants(
+      "onboarding_habit_setup",
+      assertions = { onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed() },
+    ) {
+      OnboardingScreen(
+        state =
+          OnboardingState(
+            currentStep = OnboardingStep.HabitSetup,
+            presets = testPresets,
+            selectedPresetId = "exercise",
+            habitName = "Exercise",
+          ),
+        onAction = {},
+      )
     }
 
   @Test
   fun `when habit setup has error then captures error state`() =
-    runAppUiTest {
-      captureInBothThemes("onboarding_habit_setup_error") {
-        OnboardingScreen(
-          state =
-            OnboardingState(
-              currentStep = OnboardingStep.HabitSetup,
-              presets = testPresets,
-              selectedPresetId = "exercise",
-              habitName = "",
-              creationError = "habit_name_required",
-            ),
-          onAction = {},
-        )
-      }
-
-      onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed()
+    captureAllVariants(
+      "onboarding_habit_setup_error",
+      assertions = { onNodeWithTag(OnboardingTestTags.HABIT_SETUP_SCREEN).assertIsDisplayed() },
+    ) {
+      OnboardingScreen(
+        state =
+          OnboardingState(
+            currentStep = OnboardingStep.HabitSetup,
+            presets = testPresets,
+            selectedPresetId = "exercise",
+            habitName = "",
+            creationError = "habit_name_required",
+          ),
+        onAction = {},
+      )
     }
 
   @Test
   fun `when success step then captures success screen`() =
-    runAppUiTest {
-      captureInBothThemes("onboarding_success") {
-        OnboardingScreen(
-          state = OnboardingState(currentStep = OnboardingStep.Success),
-          onAction = {},
-        )
-      }
-
-      onNodeWithTag(OnboardingTestTags.SUCCESS_SCREEN).assertIsDisplayed()
+    captureAllVariants(
+      "onboarding_success",
+      assertions = { onNodeWithTag(OnboardingTestTags.SUCCESS_SCREEN).assertIsDisplayed() },
+    ) {
+      OnboardingScreen(state = OnboardingState(currentStep = OnboardingStep.Success), onAction = {})
     }
 }


### PR DESCRIPTION
## Summary
- Desktop sidebar with navigation (Habits, Memos, Feed), sync controls, and action buttons
- Responsive layout: `isDesktop` migrated from compile-time constant to runtime `CompositionLocal` with auto-detection via `BoxWithConstraints` (>=900dp)
- All platforms (desktop, web, Android foldables) adapt between mobile and desktop layouts
- HabitPicker chip filter for per-habit chart display on desktop
- Dynamic window height adjustment when toggling memos list visibility
- Persist selected habit tag across pager swipes (lifted to AppState)
- Visual fixes: Tune icon for habits config, no border/elevation on FilterChip hover, equal styling for Track today / New memo buttons
- Localized desktop menu bar with keyboard shortcuts (all 20 locales)
- Screenshot tests capture both desktop (900x700) and mobile (540x1080) layouts in light/dark themes

## Test plan
- [x] `checkJvm` passes (ktlint, detekt, compile, tests)
- [x] Screenshot tests cover desktop + mobile layouts in both themes
- [ ] Verify sidebar navigation switches between Habits, Memos, Feed
- [ ] Verify "Show memos" / "Hide memos" adjusts window height
- [ ] Verify selected habit persists when swiping between periods
- [ ] Verify menu bar labels are localized
- [ ] Verify web demo switches between mobile/desktop at 900dp breakpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)