### PR TITLE
Constrain web app width to 1200px

### DIFF
--- a/app/web/src/wasmJsMain/resources/index.html
+++ b/app/web/src/wasmJsMain/resources/index.html
@@ -20,6 +20,8 @@
       #root {
         width: 100%;
         height: 100%;
+        max-width: 1200px;
+        margin: 0 auto;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
         box-sizing: border-box;


### PR DESCRIPTION
## Summary

On large monitors (4K) the web app stretches to full viewport width, making pre-app screens (mode selection, onboarding) and the main app look poor.

Adds `max-width: 1200px` with `margin: 0 auto` to the root container.

🤖 Generated with [Claude Code](https://claude.com/claude-code)