### PR TITLE
Add changelog dialog on app upgrade

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,9 @@ on:
   release:
     types: [created]
 
+env:
+  CHANGELOG_RELEASES_URL: https://api.github.com/repos/be1ski/vibits/releases
+
 permissions:
   contents: write
   pages: write

--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -32,6 +32,7 @@ compose.desktop {
       )
       packageName = "Vibits"
       packageVersion = appVersion
+      jvmArgs += "-Dmemos.version=$appVersion"
 
       macOS {
         iconFile.set(project.file("src/desktopMain/resources/icon.icns"))

--- a/build-logic/convention/src/main/kotlin/vibits.buildconfig.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.buildconfig.gradle.kts
@@ -1,0 +1,45 @@
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+
+abstract class BuildConfigExtension {
+  internal val fields = mutableMapOf<String, String>()
+
+  fun field(name: String, value: String) {
+    fields[name] = value
+  }
+}
+
+val ext = extensions.create<BuildConfigExtension>("generatedConfig")
+
+val packagePrefix = providers.gradleProperty("vibits.packagePrefix")
+
+val generateBuildConfig = tasks.register("generateBuildConfig") {
+  val outputDir = layout.buildDirectory.dir("generated/buildconfig")
+  val fields = ext.fields.toMap()
+  val pathSegments = project.path.split(":").filter { it.isNotEmpty() }
+  val packageName = "${packagePrefix.get()}.${pathSegments.joinToString(".")}"
+
+  inputs.property("fields", fields.toString())
+  outputs.dir(outputDir)
+
+  doLast {
+    val dir = outputDir.get().asFile.resolve(packageName.replace('.', '/'))
+    dir.mkdirs()
+    dir.resolve("BuildConfig.kt").writeText(
+      buildString {
+        appendLine("package $packageName")
+        appendLine()
+        appendLine("object BuildConfig {")
+        fields.forEach { (name, value) ->
+          appendLine("  const val $name: String = \"$value\"")
+        }
+        appendLine("}")
+      },
+    )
+  }
+}
+
+plugins.withId("org.jetbrains.kotlin.multiplatform") {
+  extensions.getByType<KotlinMultiplatformExtension>().sourceSets.getByName("commonMain") {
+    kotlin.srcDir(generateBuildConfig)
+  }
+}

--- a/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.structure.gradle.kts
@@ -207,7 +207,8 @@ fun checkEmptyModules(violations: MutableList<String>) {
     .forEach { sub ->
       val srcDir = sub.file("src")
       val hasFiles = srcDir.exists() && srcDir.walkTopDown().any { it.isFile }
-      if (!hasFiles) {
+      val hasGeneratedSources = sub.plugins.hasPlugin("vibits.buildconfig")
+      if (!hasFiles && !hasGeneratedSources) {
         violations += "${sub.path} — module has no source files. Remove it from settings.gradle.kts or add source files."
       }
     }

--- a/core/env/build.gradle.kts
+++ b/core/env/build.gradle.kts
@@ -1,0 +1,8 @@
+plugins {
+  id("vibits.kmp.library")
+  id("vibits.buildconfig")
+}
+
+generatedConfig {
+  field("RELEASES_URL", providers.environmentVariable("CHANGELOG_RELEASES_URL").getOrElse(""))
+}

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">رجوع</string>
     <string name="action_cancel">إلغاء</string>
+    <string name="action_changelog_dismiss">حسنًا</string>
     <string name="action_create_new_config">إنشاء تكوين جديد (موصى به)</string>
     <string name="action_edit_anyway">تحرير على أي حال</string>
     <string name="action_clear">مسح</string>
@@ -218,6 +219,7 @@
     <string name="time_years">سنوات</string>
 
     <!-- Titles -->
+    <string name="title_changelog">ما الجديد</string>
     <string name="title_choose_starter_habit">اختر عادة البداية</string>
     <string name="title_create_day">إنشاء يوم</string>
     <string name="title_delete_config">حذف الإعدادات؟</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Geri</string>
     <string name="action_cancel">Ləğv et</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Yeni konfiqurasiya yarat (tövsiyə olunur)</string>
     <string name="action_edit_anyway">Yenə də redaktə et</string>
     <string name="action_clear">Təmizlə</string>
@@ -218,6 +219,7 @@
     <string name="time_years">İllər</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Yeniliklər</string>
     <string name="title_choose_starter_habit">Başlanğıc vərdişi seç</string>
     <string name="title_create_day">Gün yarat</string>
     <string name="title_delete_config">Konfiqurasiyanı silinsin?</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Назад</string>
     <string name="action_cancel">Скасаваць</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Стварыць новую канфігурацыю (рэкамендавана)</string>
     <string name="action_edit_anyway">Рэдагаваць усё адно</string>
     <string name="action_clear">Ачысціць</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Гады</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Што новага</string>
     <string name="title_choose_starter_habit">Абярыце пачатковую звычку</string>
     <string name="title_create_day">Стварыць дзень</string>
     <string name="title_delete_config">Выдаліць канфіг?</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Zurück</string>
     <string name="action_cancel">Abbrechen</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Neue Konfiguration erstellen (empfohlen)</string>
     <string name="action_edit_anyway">Trotzdem bearbeiten</string>
     <string name="action_clear">Löschen</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Jahre</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Was ist neu</string>
     <string name="title_choose_starter_habit">Wählen Sie eine Startgewohnheit</string>
     <string name="title_create_day">Tag erstellen</string>
     <string name="title_delete_config">Konfiguration löschen?</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Atrás</string>
     <string name="action_cancel">Cancelar</string>
+    <string name="action_changelog_dismiss">Aceptar</string>
     <string name="action_create_new_config">Crear Nueva Configuración (Recomendado)</string>
     <string name="action_edit_anyway">Editar De Todos Modos</string>
     <string name="action_clear">Borrar</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Años</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Novedades</string>
     <string name="title_choose_starter_habit">Elige un hábito inicial</string>
     <string name="title_create_day">Crear día</string>
     <string name="title_delete_config">¿Eliminar configuración?</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Retour</string>
     <string name="action_cancel">Annuler</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Créer une nouvelle configuration (recommandé)</string>
     <string name="action_edit_anyway">Modifier quand même</string>
     <string name="action_clear">Effacer</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Années</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Nouveautés</string>
     <string name="title_choose_starter_habit">Choisissez une habitude de départ</string>
     <string name="title_create_day">Créer un jour</string>
     <string name="title_delete_config">Supprimer la configuration ?</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">पीछे</string>
     <string name="action_cancel">रद्द करें</string>
+    <string name="action_changelog_dismiss">ठीक है</string>
     <string name="action_create_new_config">नई कॉन्फ़िगरेशन बनाएँ (अनुशंसित)</string>
     <string name="action_edit_anyway">फिर भी संपादित करें</string>
     <string name="action_clear">साफ़ करें</string>
@@ -218,6 +219,7 @@
     <string name="time_years">वर्ष</string>
 
     <!-- Titles -->
+    <string name="title_changelog">नया क्या है</string>
     <string name="title_choose_starter_habit">शुरुआती आदत चुनें</string>
     <string name="title_create_day">दिन बनाएं</string>
     <string name="title_delete_config">कॉन्फ़िग हटाएं?</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">戻る</string>
     <string name="action_cancel">キャンセル</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">新しい設定を作成（推奨）</string>
     <string name="action_edit_anyway">それでも編集</string>
     <string name="action_clear">クリア</string>
@@ -218,6 +219,7 @@
     <string name="time_years">年</string>
 
     <!-- Titles -->
+    <string name="title_changelog">新機能</string>
     <string name="title_choose_starter_habit">最初の習慣を選択</string>
     <string name="title_create_day">日を作成</string>
     <string name="title_delete_config">設定を削除しますか？</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">უკან</string>
     <string name="action_cancel">გაუქმება</string>
+    <string name="action_changelog_dismiss">კარგი</string>
     <string name="action_create_new_config">ახალი კონფიგურაციის შექმნა (რეკომენდებულია)</string>
     <string name="action_edit_anyway">მაინც რედაქტირება</string>
     <string name="action_clear">გასუფთავება</string>
@@ -218,6 +219,7 @@
     <string name="time_years">წლები</string>
 
     <!-- Titles -->
+    <string name="title_changelog">სიახლეები</string>
     <string name="title_choose_starter_habit">საწყისი ჩვევის არჩევა</string>
     <string name="title_create_day">დღის შექმნა</string>
     <string name="title_delete_config">წაიშალოს კონფიგურაცია?</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Артқа</string>
     <string name="action_cancel">Болдырмау</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Жаңа конфигурация жасау (ұсынылады)</string>
     <string name="action_edit_anyway">Бәрібір өңдеу</string>
     <string name="action_clear">Тазалау</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Жылдар</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Жаңалықтар</string>
     <string name="title_choose_starter_habit">Бастапқы әдетті таңдау</string>
     <string name="title_create_day">Күн жасау</string>
     <string name="title_delete_config">Конфигті жою керек пе?</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -3,6 +3,7 @@
     <string name="action_add_first_habit">Биринчи адатты кошуу</string>
     <string name="action_back">Артка</string>
     <string name="action_cancel">Жокко чыгаруу</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Тазалоо</string>
     <string name="action_continue">Улантуу</string>
     <string name="action_create_new_config">Жаңы конфигурация түзүү (сунушталат)</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Жылдар</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Жаңылыктар</string>
     <string name="title_choose_starter_habit">Башталгыч адатты тандаңыз</string>
     <string name="title_create_day">Күн түзүү</string>
     <string name="title_delete_config">Конфигди өчүрүү керекпи?</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Voltar</string>
     <string name="action_cancel">Cancelar</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Criar nova configuração (recomendado)</string>
     <string name="action_edit_anyway">Editar mesmo assim</string>
     <string name="action_clear">Limpar</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Anos</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Novidades</string>
     <string name="title_choose_starter_habit">Escolha um hábito inicial</string>
     <string name="title_create_day">Criar dia</string>
     <string name="title_delete_config">Excluir configuração?</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -3,6 +3,7 @@
     <string name="action_add_first_habit">Adaugă primul tău obicei</string>
     <string name="action_back">Înapoi</string>
     <string name="action_cancel">Anulare</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Curăță</string>
     <string name="action_continue">Continuă</string>
     <string name="action_create_new_config">Creează o configurație nouă (recomandat)</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Ani</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Noutăți</string>
     <string name="title_choose_starter_habit">Alege un obicei de început</string>
     <string name="title_create_day">Creează zi</string>
     <string name="title_delete_config">Ștergeți configurația?</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Назад</string>
     <string name="action_cancel">Отмена</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Очистить</string>
     <string name="action_close">Закрыть</string>
     <string name="action_copied">Скопировано</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Годы</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Что нового</string>
     <string name="title_choose_starter_habit">Выбери начальную привычку</string>
     <string name="title_create_day">Создать день</string>
     <string name="title_delete_config">Удалить конфигурацию?</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -3,6 +3,7 @@
     <string name="action_add_first_habit">Одати аввалро илова кунед</string>
     <string name="action_back">Бозгашт</string>
     <string name="action_cancel">Бекор кардан</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Тоза кардан</string>
     <string name="action_continue">Идома додан</string>
     <string name="action_create_new_config">Эҷоди конфигуратсияи нав (тавсия мешавад)</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Солҳо</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Навигариҳо</string>
     <string name="title_choose_starter_habit">Одати оғозиниро интихоб кунед</string>
     <string name="title_create_day">Эҷоди рӯз</string>
     <string name="title_delete_config">Конфигро нест кунем?</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -3,6 +3,7 @@
     <string name="action_add_first_habit">Ilkinji endigi goş</string>
     <string name="action_back">Yza</string>
     <string name="action_cancel">Ýatyr</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Arassala</string>
     <string name="action_continue">Dowam et</string>
     <string name="action_create_new_config">Täze konfigurasiýa döretmek (maslahat berilýär)</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Ýyllar</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Täzelikler</string>
     <string name="title_choose_starter_habit">Başlangyç endigi saýla</string>
     <string name="title_create_day">Gün döret</string>
     <string name="title_delete_config">Konfigurasiýany öçürmeli?</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Назад</string>
     <string name="action_cancel">Скасувати</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Створити нову конфігурацію (рекомендовано)</string>
     <string name="action_edit_anyway">Редагувати все одно</string>
     <string name="action_clear">Очистити</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Роки</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Що нового</string>
     <string name="title_choose_starter_habit">Оберіть початкову звичку</string>
     <string name="title_create_day">Створити день</string>
     <string name="title_delete_config">Видалити конфіг?</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Orqaga</string>
     <string name="action_cancel">Bekor qilish</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_create_new_config">Yangi konfiguratsiya yaratish (tavsiya etiladi)</string>
     <string name="action_edit_anyway">Baribir tahrirlash</string>
     <string name="action_clear">Tozalash</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Yillar</string>
 
     <!-- Titles -->
+    <string name="title_changelog">Yangiliklar</string>
     <string name="title_choose_starter_habit">Boshlang'ich odatni tanlash</string>
     <string name="title_create_day">Kun yaratish</string>
     <string name="title_delete_config">Konfigni o'chirish kerakmi?</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">返回</string>
     <string name="action_cancel">取消</string>
+    <string name="action_changelog_dismiss">确定</string>
     <string name="action_create_new_config">创建新配置（推荐）</string>
     <string name="action_edit_anyway">仍然编辑</string>
     <string name="action_clear">清除</string>
@@ -218,6 +219,7 @@
     <string name="time_years">年</string>
 
     <!-- Titles -->
+    <string name="title_changelog">新功能</string>
     <string name="title_choose_starter_habit">选择初始习惯</string>
     <string name="title_create_day">创建日记录</string>
     <string name="title_delete_config">删除配置？</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -2,6 +2,7 @@
     <!-- Actions -->
     <string name="action_back">Back</string>
     <string name="action_cancel">Cancel</string>
+    <string name="action_changelog_dismiss">OK</string>
     <string name="action_clear">Clear</string>
     <string name="action_close">Close</string>
     <string name="action_copied">Copied</string>
@@ -218,6 +219,7 @@
     <string name="time_years">Years</string>
 
     <!-- Titles -->
+    <string name="title_changelog">What's New</string>
     <string name="title_choose_starter_habit">Choose a starter habit</string>
     <string name="title_create_day">Create day</string>
     <string name="title_delete_config">Delete config?</string>

--- a/feature/changelog/data/build.gradle.kts
+++ b/feature/changelog/data/build.gradle.kts
@@ -1,0 +1,27 @@
+plugins {
+  id("vibits.kmp.library")
+  id("vibits.kmp.metro")
+  alias(libs.plugins.kotlin.serialization)
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(projects.core.platform)
+        implementation(projects.core.utils)
+        implementation(projects.feature.changelog.domain)
+        implementation(libs.kotlinx.serialization.json)
+        implementation(libs.ktor.client.content.negotiation)
+        implementation(libs.ktor.client.core)
+        implementation(libs.ktor.serialization.kotlinx.json)
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation(projects.feature.changelog.domain.testing)
+        implementation(libs.ktor.client.mock)
+      }
+    }
+  }
+}

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImpl.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImpl.kt
@@ -1,0 +1,20 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+
+@Inject
+class ChangelogRepositoryImpl(
+  private val api: GitHubReleasesApi,
+) : ChangelogRepository {
+  override suspend fun getReleases(): List<ChangelogEntry> =
+    api.getReleases().map { dto ->
+      ChangelogEntry(
+        version = dto.tagName.removePrefix("v"),
+        title = dto.name.ifBlank { dto.tagName },
+        body = dto.body,
+        date = dto.publishedAt.substringBefore("T"),
+      )
+    }
+}

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleaseDto.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleaseDto.kt
@@ -1,0 +1,12 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class GitHubReleaseDto(
+  @SerialName("tag_name") val tagName: String = "",
+  val name: String = "",
+  val body: String = "",
+  @SerialName("published_at") val publishedAt: String = "",
+)

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApi.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApi.kt
@@ -1,0 +1,32 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.request.header
+import io.ktor.http.HttpHeaders
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
+import space.be1ski.vibits.core.utils.logging.Log
+
+private const val TAG = "GitHubReleasesApi"
+
+class GitHubReleasesApi(
+  private val httpClient: HttpClient,
+  private val releasesUrl: String,
+) {
+  suspend fun getReleases(): List<GitHubReleaseDto> {
+    if (releasesUrl.isBlank()) return emptyList()
+    Log.i(TAG, "GET $releasesUrl")
+    return runSuspendCatching {
+      val response: List<GitHubReleaseDto> =
+        httpClient
+          .get(releasesUrl) {
+            header(HttpHeaders.Accept, "application/vnd.github+json")
+          }.body()
+      Log.i(TAG, "GET $releasesUrl -> OK, ${response.size} releases")
+      response
+    }.onFailure { e ->
+      Log.e(TAG, "GET $releasesUrl -> FAILED", e)
+    }.getOrThrow()
+  }
+}

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/LastSeenVersionStoreImpl.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/LastSeenVersionStoreImpl.kt
@@ -1,0 +1,18 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import space.be1ski.vibits.core.platform.storage.KeyValueStore
+import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
+
+class LastSeenVersionStoreImpl(
+  private val store: KeyValueStore,
+) : LastSeenVersionStore {
+  override fun getLastSeenVersion(): String? = store.getString(KEY_LAST_SEEN_VERSION)
+
+  override fun setLastSeenVersion(version: String) {
+    store.putString(KEY_LAST_SEEN_VERSION, version)
+  }
+
+  private companion object {
+    const val KEY_LAST_SEEN_VERSION = "last_seen_app_version"
+  }
+}

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImplTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImplTest.kt
@@ -1,0 +1,98 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ChangelogRepositoryImplTest {
+  @Test
+  fun `when getReleases then maps DTOs to domain entries`() =
+    runTest {
+      val json =
+        """
+        [
+          {
+            "tag_name": "v1.2.0",
+            "name": "Release 1.2.0",
+            "body": "## Changes\n* Feature X",
+            "published_at": "2026-02-15T12:00:00Z"
+          }
+        ]
+        """.trimIndent()
+
+      val client =
+        HttpClient(MockEngine { respond(json, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())) }) {
+          install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+      val repository = ChangelogRepositoryImpl(GitHubReleasesApi(client, "https://api.github.com/repos/test/repo/releases"))
+      val result = repository.getReleases()
+
+      assertEquals(1, result.size)
+      assertEquals("1.2.0", result[0].version)
+      assertEquals("Release 1.2.0", result[0].title)
+      assertEquals("## Changes\n* Feature X", result[0].body)
+      assertEquals("2026-02-15", result[0].date)
+    }
+
+  @Test
+  fun `when release has blank name then uses tag name as title`() =
+    runTest {
+      val json =
+        """
+        [
+          {
+            "tag_name": "v1.0.0",
+            "name": "",
+            "body": "Initial release",
+            "published_at": "2026-01-01T00:00:00Z"
+          }
+        ]
+        """.trimIndent()
+
+      val client =
+        HttpClient(MockEngine { respond(json, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())) }) {
+          install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+      val repository = ChangelogRepositoryImpl(GitHubReleasesApi(client, "https://api.github.com/repos/test/repo/releases"))
+      val result = repository.getReleases()
+
+      assertEquals("v1.0.0", result[0].title)
+    }
+
+  @Test
+  fun `when release has no T in date then uses full date`() =
+    runTest {
+      val json =
+        """
+        [
+          {
+            "tag_name": "v1.0.0",
+            "name": "Release",
+            "body": "body",
+            "published_at": "2026-01-01"
+          }
+        ]
+        """.trimIndent()
+
+      val client =
+        HttpClient(MockEngine { respond(json, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())) }) {
+          install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+
+      val repository = ChangelogRepositoryImpl(GitHubReleasesApi(client, "https://api.github.com/repos/test/repo/releases"))
+      val result = repository.getReleases()
+
+      assertEquals("2026-01-01", result[0].date)
+    }
+}

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApiTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApiTest.kt
@@ -1,0 +1,117 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockRequestHandleScope
+import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.request.HttpRequestData
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.headersOf
+import io.ktor.serialization.kotlinx.json.json
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+private const val TEST_RELEASES_URL = "https://api.github.com/repos/test/repo/releases"
+
+class GitHubReleasesApiTest {
+  @Test
+  fun `when getReleases then sends GET with accept header`() =
+    runTest {
+      val client =
+        clientWithHandler { request ->
+          assertEquals(HttpMethod.Get, request.method)
+          assertEquals(
+            "application/vnd.github+json",
+            request.headers[HttpHeaders.Accept],
+          )
+          assertTrue(request.url.toString().startsWith(TEST_RELEASES_URL))
+          respond(
+            content = "[]",
+            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+          )
+        }
+
+      val api = GitHubReleasesApi(client, TEST_RELEASES_URL)
+      val result = api.getReleases()
+
+      assertTrue(result.isEmpty())
+    }
+
+  @Test
+  fun `when getReleases with data then parses DTOs`() =
+    runTest {
+      val json =
+        """
+        [
+          {
+            "tag_name": "v1.2.0",
+            "name": "Release 1.2.0",
+            "body": "## Changes\n* Added feature X",
+            "published_at": "2026-02-15T12:00:00Z"
+          },
+          {
+            "tag_name": "v1.1.0",
+            "name": "Release 1.1.0",
+            "body": "Bug fixes",
+            "published_at": "2026-02-01T12:00:00Z"
+          }
+        ]
+        """.trimIndent()
+
+      val client =
+        clientWithHandler {
+          respond(
+            content = json,
+            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+          )
+        }
+
+      val api = GitHubReleasesApi(client, TEST_RELEASES_URL)
+      val result = api.getReleases()
+
+      assertEquals(2, result.size)
+      assertEquals("v1.2.0", result[0].tagName)
+      assertEquals("Release 1.2.0", result[0].name)
+      assertEquals("## Changes\n* Added feature X", result[0].body)
+      assertEquals("2026-02-15T12:00:00Z", result[0].publishedAt)
+      assertEquals("v1.1.0", result[1].tagName)
+    }
+
+  @Test
+  fun `when getReleases fails then throws exception`() =
+    runTest {
+      val client =
+        HttpClient(MockEngine { throw RuntimeException("Network error") }) {
+          install(ContentNegotiation) { json() }
+        }
+
+      val api = GitHubReleasesApi(client, TEST_RELEASES_URL)
+
+      val error =
+        kotlin.test.assertFailsWith<RuntimeException> {
+          api.getReleases()
+        }
+
+      assertEquals("Network error", error.message)
+    }
+
+  private fun clientWithHandler(
+    handler: suspend MockRequestHandleScope.(HttpRequestData) -> io.ktor.client.request.HttpResponseData,
+  ): HttpClient =
+    HttpClient(MockEngine { request -> handler(request) }) {
+      install(ContentNegotiation) {
+        json(
+          Json {
+            ignoreUnknownKeys = true
+            isLenient = true
+          },
+        )
+      }
+    }
+}

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/LastSeenVersionStoreImplTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/LastSeenVersionStoreImplTest.kt
@@ -1,0 +1,54 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class LastSeenVersionStoreImplTest {
+  @Test
+  fun `when no version stored then returns null`() {
+    val store: LastSeenVersionStore = LastSeenVersionStoreImpl(FakeKeyValueStore())
+
+    assertNull(store.getLastSeenVersion())
+  }
+
+  @Test
+  fun `when version set then returns it`() {
+    val store: LastSeenVersionStore = LastSeenVersionStoreImpl(FakeKeyValueStore())
+
+    store.setLastSeenVersion("1.2.0")
+
+    assertEquals("1.2.0", store.getLastSeenVersion())
+  }
+
+  @Test
+  fun `when version updated then returns latest`() {
+    val store: LastSeenVersionStore = LastSeenVersionStoreImpl(FakeKeyValueStore())
+
+    store.setLastSeenVersion("1.0.0")
+    store.setLastSeenVersion("1.1.0")
+
+    assertEquals("1.1.0", store.getLastSeenVersion())
+  }
+}
+
+private class FakeKeyValueStore : space.be1ski.vibits.core.platform.storage.KeyValueStore {
+  private val map = mutableMapOf<String, String>()
+
+  override fun getString(
+    key: String,
+    defaultValue: String?,
+  ): String? = map[key] ?: defaultValue
+
+  override fun putString(
+    key: String,
+    value: String,
+  ) {
+    map[key] = value
+  }
+
+  override fun remove(key: String) {
+    map.remove(key)
+  }
+}

--- a/feature/changelog/domain/build.gradle.kts
+++ b/feature/changelog/domain/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+  id("vibits.kmp.library")
+  id("vibits.kmp.metro")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        implementation(projects.core.platform)
+        implementation(projects.core.utils)
+      }
+    }
+    commonTest {
+      dependencies {
+        implementation(projects.feature.changelog.data)
+        implementation(projects.feature.changelog.domain.testing)
+      }
+    }
+  }
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/ChangelogEntry.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/ChangelogEntry.kt
@@ -1,0 +1,8 @@
+package space.be1ski.vibits.feature.changelog.domain.model
+
+data class ChangelogEntry(
+  val version: String,
+  val title: String,
+  val body: String,
+  val date: String,
+)

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/ChangelogRepository.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/ChangelogRepository.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.changelog.domain.repository
+
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+
+fun interface ChangelogRepository {
+  suspend fun getReleases(): List<ChangelogEntry>
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/LastSeenVersionStore.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/LastSeenVersionStore.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.changelog.domain.repository
+
+interface LastSeenVersionStore {
+  fun getLastSeenVersion(): String?
+
+  fun setLastSeenVersion(version: String)
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCase.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCase.kt
@@ -1,0 +1,94 @@
+package space.be1ski.vibits.feature.changelog.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
+
+private const val TAG = "Changelog"
+
+@Inject
+class GetChangelogUseCase(
+  private val changelogRepository: ChangelogRepository,
+  private val lastSeenVersionStore: LastSeenVersionStore,
+) {
+  suspend operator fun invoke(currentVersion: String): List<ChangelogEntry> {
+    val lastSeen = resolveLastSeenVersion(currentVersion) ?: return emptyList()
+    return fetchAndFilter(lastSeen, currentVersion)
+  }
+
+  private fun resolveLastSeenVersion(currentVersion: String): String? =
+    when {
+      currentVersion == "web" || currentVersion == "dev" -> {
+        Log.d(TAG, "Skipping changelog for version: $currentVersion")
+        null
+      }
+      lastSeenVersionStore.getLastSeenVersion() == null -> {
+        Log.d(TAG, "First install, saving current version: $currentVersion")
+        lastSeenVersionStore.setLastSeenVersion(currentVersion)
+        null
+      }
+      lastSeenVersionStore.getLastSeenVersion() == currentVersion -> null
+      else -> lastSeenVersionStore.getLastSeenVersion()
+    }
+
+  private suspend fun fetchAndFilter(
+    lastSeen: String,
+    currentVersion: String,
+  ): List<ChangelogEntry> {
+    val releases =
+      runSuspendCatching { changelogRepository.getReleases() }
+        .onFailure { Log.e(TAG, "Failed to fetch releases", it) }
+        .getOrNull()
+
+    val lastSeenParsed = releases?.let { parseVersion(lastSeen) }
+    val currentParsed = releases?.let { parseVersion(currentVersion) }
+
+    val filtered =
+      when {
+        releases == null -> emptyList()
+        lastSeenParsed == null || currentParsed == null -> {
+          Log.w(TAG, "Cannot parse versions: lastSeen=$lastSeen, current=$currentVersion")
+          emptyList()
+        }
+        else ->
+          releases
+            .filter { entry ->
+              val v = parseVersion(entry.version)
+              v != null && compareVersions(v, lastSeenParsed) > 0 && compareVersions(v, currentParsed) <= 0
+            }.sortedWith(
+              Comparator { a, b ->
+                compareVersions(parseVersion(b.version) ?: emptyList(), parseVersion(a.version) ?: emptyList())
+              },
+            )
+      }
+
+    if (releases != null) {
+      lastSeenVersionStore.setLastSeenVersion(currentVersion)
+      Log.i(TAG, "Showing changelog: ${filtered.size} entries from $lastSeen to $currentVersion")
+    }
+    return filtered
+  }
+}
+
+internal fun parseVersion(version: String): List<Int>? {
+  val cleaned = version.removePrefix("v")
+  val parts = cleaned.split(".")
+  val numbers = parts.mapNotNull { it.toIntOrNull() }
+  return if (numbers.size == parts.size && numbers.isNotEmpty()) numbers else null
+}
+
+internal fun compareVersions(
+  a: List<Int>,
+  b: List<Int>,
+): Int {
+  val maxLen = maxOf(a.size, b.size)
+  for (i in 0 until maxLen) {
+    val partA = a.getOrElse(i) { 0 }
+    val partB = b.getOrElse(i) { 0 }
+    if (partA != partB) return partA.compareTo(partB)
+  }
+  return 0
+}

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCaseTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCaseTest.kt
@@ -1,0 +1,174 @@
+package space.be1ski.vibits.feature.changelog.domain.usecase
+
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.test.FakeChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.test.FakeLastSeenVersionStore
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class GetChangelogUseCaseTest {
+  private val repository = FakeChangelogRepository()
+  private val store = FakeLastSeenVersionStore()
+  private val useCase = GetChangelogUseCase(repository, store)
+
+  @Test
+  fun `when first install then saves version and returns empty`() =
+    runTest {
+      val result = useCase("1.2.0")
+
+      assertTrue(result.isEmpty())
+      assertEquals("1.2.0", store.lastSetVersion)
+      assertEquals(0, repository.getReleaseCalls)
+    }
+
+  @Test
+  fun `when same version then returns empty without fetching`() =
+    runTest {
+      store.setLastSeenVersion("1.2.0")
+
+      val result = useCase("1.2.0")
+
+      assertTrue(result.isEmpty())
+      assertEquals(0, repository.getReleaseCalls)
+    }
+
+  @Test
+  fun `when web version then returns empty`() =
+    runTest {
+      val result = useCase("web")
+
+      assertTrue(result.isEmpty())
+      assertEquals(0, repository.getReleaseCalls)
+      assertNull(store.lastSetVersion)
+    }
+
+  @Test
+  fun `when dev version then returns empty`() =
+    runTest {
+      val result = useCase("dev")
+
+      assertTrue(result.isEmpty())
+      assertEquals(0, repository.getReleaseCalls)
+      assertNull(store.lastSetVersion)
+    }
+
+  @Test
+  fun `when upgrade then returns filtered entries newest first`() =
+    runTest {
+      store.setLastSeenVersion("1.0.0")
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("0.9.0", "Old release", "old stuff", "2026-01-01"),
+            ChangelogEntry("1.0.0", "Current release", "current", "2026-01-15"),
+            ChangelogEntry("1.1.0", "Minor update", "minor changes", "2026-02-01"),
+            ChangelogEntry("1.2.0", "Latest release", "new features", "2026-02-15"),
+            ChangelogEntry("2.0.0", "Future release", "future", "2026-03-01"),
+          ),
+        )
+
+      val result = useCase("1.2.0")
+
+      assertEquals(2, result.size)
+      assertEquals("1.2.0", result[0].version)
+      assertEquals("1.1.0", result[1].version)
+      assertEquals("1.2.0", store.lastSetVersion)
+    }
+
+  @Test
+  fun `when network failure then returns empty and does not update version`() =
+    runTest {
+      store.setLastSeenVersion("1.0.0")
+      repository.releasesResult = Result.failure(RuntimeException("Network error"))
+
+      val result = useCase("1.1.0")
+
+      assertTrue(result.isEmpty())
+      assertEquals("1.0.0", store.getLastSeenVersion())
+    }
+
+  @Test
+  fun `when unparseable last seen version then saves current and returns empty`() =
+    runTest {
+      store.setLastSeenVersion("invalid")
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("1.0.0", "Release", "body", "2026-01-01")),
+        )
+
+      val result = useCase("1.1.0")
+
+      assertTrue(result.isEmpty())
+      assertEquals("1.1.0", store.lastSetVersion)
+    }
+
+  @Test
+  fun `when version with v prefix in releases then strips prefix for comparison`() =
+    runTest {
+      store.setLastSeenVersion("1.0.0")
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("v1.1.0", "Release v1.1.0", "changes", "2026-02-01"),
+          ),
+        )
+
+      val result = useCase("1.1.0")
+
+      assertEquals(1, result.size)
+      assertEquals("v1.1.0", result[0].version)
+    }
+
+  @Test
+  fun `when cancellation during fetch then propagates`() =
+    runTest {
+      store.setLastSeenVersion("1.0.0")
+      repository.releasesResult = Result.failure(CancellationException("cancelled"))
+
+      assertFailsWith<CancellationException> {
+        useCase("1.1.0")
+      }
+    }
+
+  @Test
+  fun `when no releases match range then returns empty and updates version`() =
+    runTest {
+      store.setLastSeenVersion("1.0.0")
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("0.9.0", "Old", "old", "2026-01-01"),
+            ChangelogEntry("1.0.0", "Current", "current", "2026-01-15"),
+          ),
+        )
+
+      val result = useCase("1.1.0")
+
+      assertTrue(result.isEmpty())
+      assertEquals("1.1.0", store.lastSetVersion)
+    }
+
+  @Test
+  fun `when parseVersion then parses semver correctly`() {
+    assertEquals(listOf(1, 2, 3), parseVersion("1.2.3"))
+    assertEquals(listOf(1, 2, 3), parseVersion("v1.2.3"))
+    assertEquals(listOf(1, 0), parseVersion("1.0"))
+    assertNull(parseVersion("invalid"))
+    assertNull(parseVersion(""))
+    assertNull(parseVersion("1.2.beta"))
+  }
+
+  @Test
+  fun `when compareVersions then compares correctly`() {
+    assertTrue(compareVersions(listOf(1, 1, 0), listOf(1, 0, 0)) > 0)
+    assertTrue(compareVersions(listOf(1, 0, 0), listOf(1, 1, 0)) < 0)
+    assertEquals(0, compareVersions(listOf(1, 0, 0), listOf(1, 0, 0)))
+    assertTrue(compareVersions(listOf(2, 0), listOf(1, 9, 9)) > 0)
+    assertEquals(0, compareVersions(listOf(1, 0), listOf(1, 0, 0)))
+  }
+}

--- a/feature/changelog/domain/testing/build.gradle.kts
+++ b/feature/changelog/domain/testing/build.gradle.kts
@@ -1,0 +1,13 @@
+plugins {
+  id("vibits.kmp.library")
+}
+
+kotlin {
+  sourceSets {
+    commonMain {
+      dependencies {
+        api(projects.feature.changelog.domain)
+      }
+    }
+  }
+}

--- a/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeChangelogRepository.kt
+++ b/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeChangelogRepository.kt
@@ -1,0 +1,15 @@
+package space.be1ski.vibits.feature.changelog.domain.test
+
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+
+class FakeChangelogRepository : ChangelogRepository {
+  var releasesResult: Result<List<ChangelogEntry>> = Result.success(emptyList())
+  var getReleaseCalls: Int = 0
+    private set
+
+  override suspend fun getReleases(): List<ChangelogEntry> {
+    getReleaseCalls++
+    return releasesResult.getOrThrow()
+  }
+}

--- a/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeLastSeenVersionStore.kt
+++ b/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeLastSeenVersionStore.kt
@@ -1,0 +1,20 @@
+package space.be1ski.vibits.feature.changelog.domain.test
+
+import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
+
+class FakeLastSeenVersionStore(
+  private var version: String? = null,
+) : LastSeenVersionStore {
+  var setCalls: Int = 0
+    private set
+  var lastSetVersion: String? = null
+    private set
+
+  override fun getLastSeenVersion(): String? = version
+
+  override fun setLastSeenVersion(version: String) {
+    setCalls++
+    lastSetVersion = version
+    this.version = version
+  }
+}

--- a/feature/homescreen/build.gradle.kts
+++ b/feature/homescreen/build.gradle.kts
@@ -15,12 +15,15 @@ kotlin {
     commonMain {
       dependencies {
         api(projects.core.elm)
+        api(projects.core.env)
         api(projects.core.platform)
         api(projects.core.strings)
         api(projects.core.ui)
         api(projects.core.utils)
         api(projects.feature.auth.data)
         api(projects.feature.auth.domain)
+        api(projects.feature.changelog.data)
+        api(projects.feature.changelog.domain)
         api(projects.feature.habits.domain)
         api(projects.feature.habits.presentation)
         api(projects.feature.memos.data)
@@ -57,6 +60,7 @@ kotlin {
     commonTest {
       dependencies {
         implementation(projects.core.elm.test)
+        implementation(projects.feature.changelog.domain.testing)
         implementation(projects.feature.settings.domain.testing)
         implementation(libs.ktor.client.mock)
       }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppDependencies.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppDependencies.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.feature.homescreen.di
 
 import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.core.platform.locale.LocaleProvider
+import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.di.HabitsDependencies
 import space.be1ski.vibits.feature.homescreen.domain.usecase.LoadAppDetailsUseCase
 import space.be1ski.vibits.feature.memos.di.MemosDependencies
@@ -24,6 +25,7 @@ class AppDependencies(
   val loadPreferences: LoadPreferencesUseCase,
   val fixInvalidOnlineMode: FixInvalidOnlineModeUseCase,
   val saveTimeRangeTab: SaveTimeRangeTabUseCase,
+  val getChangelog: GetChangelogUseCase,
   val loadAppDetails: LoadAppDetailsUseCase,
   val loadAppMode: LoadAppModeUseCase,
   val shouldShowOnboarding: ShouldShowOnboardingUseCase,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
+import space.be1ski.vibits.core.env.BuildConfig
 import space.be1ski.vibits.core.platform.app.AppDetailsProvider
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.env.LocalConfigProvider
@@ -23,6 +24,11 @@ import space.be1ski.vibits.feature.auth.data.CredentialsRepositoryImpl
 import space.be1ski.vibits.feature.auth.data.platform.CredentialsStore
 import space.be1ski.vibits.feature.auth.data.platform.createCredentialsStore
 import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
+import space.be1ski.vibits.feature.changelog.data.ChangelogRepositoryImpl
+import space.be1ski.vibits.feature.changelog.data.GitHubReleasesApi
+import space.be1ski.vibits.feature.changelog.data.LastSeenVersionStoreImpl
+import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
 import space.be1ski.vibits.feature.memos.data.ConnectionTesterImpl
 import space.be1ski.vibits.feature.memos.data.MemoStorageManagerImpl
 import space.be1ski.vibits.feature.memos.data.ModeAwareMemosRepository
@@ -137,7 +143,18 @@ abstract class AppGraph {
   @SingleIn(AppScope::class)
   fun syncOperationStore(): SyncOperationStore = createSyncOperationStore()
 
+  @Provides
+  @SingleIn(AppScope::class)
+  fun lastSeenVersionStore(): LastSeenVersionStore = LastSeenVersionStoreImpl(createKeyValueStore())
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun gitHubReleasesApi(httpClient: HttpClient): GitHubReleasesApi = GitHubReleasesApi(httpClient, BuildConfig.RELEASES_URL)
+
   // Repository bindings (explicit @Binds needed for native targets due to KT-75865)
+  @Binds
+  abstract fun bindChangelogRepository(impl: ChangelogRepositoryImpl): ChangelogRepository
+
   @Binds
   abstract fun bindAppModeRepository(impl: AppModeRepositoryImpl): AppModeRepository
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -21,6 +21,7 @@ import space.be1ski.vibits.core.strings.generated.msg_state_loading
 import space.be1ski.vibits.core.strings.generated.title_state_loading
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.StatePanel
+import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
@@ -67,6 +68,8 @@ internal fun AppContent(
   appTheme: AppTheme,
   appLanguage: AppLanguage,
   exportService: ExportService,
+  currentVersion: String,
+  getChangelog: GetChangelogUseCase,
   onResetApp: () -> Unit,
   onThemeChanged: (AppTheme) -> Unit,
   onLanguageChanged: (AppLanguage) -> Unit,
@@ -86,6 +89,8 @@ internal fun AppContent(
           appTheme = appTheme,
           appLanguage = appLanguage,
           exportService = exportService,
+          currentVersion = currentVersion,
+          getChangelog = getChangelog,
           onResetApp = onResetApp,
           onThemeChanged = onThemeChanged,
           onLanguageChanged = onLanguageChanged,
@@ -97,6 +102,8 @@ internal fun AppContent(
         appTheme = appTheme,
         appLanguage = appLanguage,
         exportService = exportService,
+        currentVersion = currentVersion,
+        getChangelog = getChangelog,
         onResetApp = onResetApp,
         onThemeChanged = onThemeChanged,
         onLanguageChanged = onLanguageChanged,
@@ -105,12 +112,15 @@ internal fun AppContent(
   }
 }
 
+@Suppress("LongParameterList")
 @Composable
 private fun AppWithLoadingScreen(
   features: AppFeatures,
   appTheme: AppTheme,
   appLanguage: AppLanguage,
   exportService: ExportService,
+  currentVersion: String,
+  getChangelog: GetChangelogUseCase,
   onResetApp: () -> Unit,
   onThemeChanged: (AppTheme) -> Unit,
   onLanguageChanged: (AppLanguage) -> Unit,
@@ -125,6 +135,8 @@ private fun AppWithLoadingScreen(
       currentTheme = appTheme,
       currentLanguage = appLanguage,
       exportService = exportService,
+      currentVersion = currentVersion,
+      getChangelog = getChangelog,
       onResetApp = onResetApp,
       onThemeChanged = onThemeChanged,
       onLanguageChanged = onLanguageChanged,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -29,6 +29,7 @@ fun AppRoot(
   onFeaturesReady: ((AppFeatures) -> Unit)? = null,
 ) {
   val initialPrefs = remember { dependencies.loadPreferences() }
+  val currentVersion = remember { dependencies.loadAppDetails().version }
   remember { dependencies.localeProvider.configureLocale(initialPrefs.language) }
 
   var appMode by remember { mutableStateOf(dependencies.fixInvalidOnlineMode()) }
@@ -67,6 +68,8 @@ fun AppRoot(
           appTheme = appTheme,
           appLanguage = appLanguage,
           exportService = dependencies.settingsDependencies.exportService,
+          currentVersion = currentVersion,
+          getChangelog = dependencies.getChangelog,
           onResetApp = {
             resetApp(
               dependencies = dependencies,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/ChangelogDialog.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/ChangelogDialog.kt
@@ -1,0 +1,150 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.LinkAnnotation
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.action_changelog_dismiss
+import space.be1ski.vibits.core.strings.generated.title_changelog
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+
+private const val GROUP_LINK_TEXT = 1
+private const val GROUP_LINK_URL = 2
+private const val GROUP_BOLD = 3
+private const val GROUP_BARE_URL = 4
+
+private val formattedPattern =
+  Regex("""!\[.*?]\(.*?\)|\[(.+?)]\((https?://\S+?)\)|\*\*(.+?)\*\*|(https?://\S+)""")
+
+@Composable
+internal fun ChangelogDialog(
+  entries: List<ChangelogEntry>,
+  onDismiss: () -> Unit,
+) {
+  AlertDialog(
+    onDismissRequest = onDismiss,
+    title = { Text(stringResource(Res.string.title_changelog)) },
+    text = {
+      Column(
+        modifier =
+          Modifier
+            .fillMaxWidth()
+            .heightIn(max = 400.dp)
+            .verticalScroll(rememberScrollState()),
+        verticalArrangement = Arrangement.spacedBy(Indent.m),
+      ) {
+        entries.forEach { entry ->
+          ChangelogEntryContent(entry)
+        }
+      }
+    },
+    confirmButton = {
+      TextButton(onClick = onDismiss) {
+        Text(stringResource(Res.string.action_changelog_dismiss))
+      }
+    },
+  )
+}
+
+@Composable
+private fun ChangelogEntryContent(entry: ChangelogEntry) {
+  val linkColor = MaterialTheme.colorScheme.primary
+  Column(
+    modifier = Modifier.fillMaxWidth(),
+    verticalArrangement = Arrangement.spacedBy(Indent.xs),
+  ) {
+    Text(
+      text = "${entry.title} (${entry.date})",
+      style = MaterialTheme.typography.titleSmall,
+    )
+    if (entry.body.isNotBlank()) {
+      Text(
+        text = renderBody(entry.body, linkColor),
+        style = MaterialTheme.typography.bodySmall,
+      )
+    }
+  }
+}
+
+@Composable
+private fun renderBody(
+  body: String,
+  linkColor: Color,
+) = buildAnnotatedString {
+  body.lines().forEach { line ->
+    when {
+      line.startsWith("## ") -> {
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) {
+          append(line.removePrefix("## "))
+        }
+        append("\n")
+      }
+      line.startsWith("* ") || line.startsWith("- ") -> {
+        append("  ")
+        appendFormattedLine(line.drop(2).trimStart(), linkColor)
+        append("\n")
+      }
+      line.isBlank() -> append("\n")
+      else -> {
+        appendFormattedLine(line, linkColor)
+        append("\n")
+      }
+    }
+  }
+}
+
+private fun AnnotatedString.Builder.appendFormattedLine(
+  text: String,
+  linkColor: Color,
+) {
+  var lastIndex = 0
+  formattedPattern.findAll(text).forEach { match ->
+    append(text.substring(lastIndex, match.range.first))
+    when {
+      match.value.startsWith("![") -> Unit
+      match.groupValues[GROUP_LINK_TEXT].isNotEmpty() ->
+        appendLink(match.groupValues[GROUP_LINK_TEXT], match.groupValues[GROUP_LINK_URL], linkColor)
+      match.groupValues[GROUP_BOLD].isNotEmpty() ->
+        withStyle(SpanStyle(fontWeight = FontWeight.Bold)) { append(match.groupValues[GROUP_BOLD]) }
+      match.groupValues[GROUP_BARE_URL].isNotEmpty() ->
+        appendLink(match.groupValues[GROUP_BARE_URL], match.groupValues[GROUP_BARE_URL], linkColor)
+    }
+    lastIndex = match.range.last + 1
+  }
+  if (lastIndex < text.length) {
+    append(text.substring(lastIndex))
+  }
+}
+
+private fun AnnotatedString.Builder.appendLink(
+  text: String,
+  url: String,
+  linkColor: Color,
+) {
+  val start = length
+  withStyle(SpanStyle(color = linkColor, textDecoration = TextDecoration.Underline)) {
+    append(text)
+  }
+  addLink(LinkAnnotation.Url(url), start, length)
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -1,21 +1,30 @@
 package space.be1ski.vibits.feature.homescreen.presentation.view
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.ui.theme.LocalWideLayout
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.view.SettingsDialog
 
+@Suppress("LongParameterList")
 @Composable
 internal fun VibitsApp(
   features: AppFeatures,
   currentTheme: AppTheme,
   currentLanguage: AppLanguage,
   exportService: ExportService,
+  currentVersion: String,
+  getChangelog: GetChangelogUseCase,
   onResetApp: () -> Unit = {},
   onThemeChanged: (AppTheme) -> Unit = {},
   onLanguageChanged: (AppLanguage) -> Unit = {},
@@ -24,6 +33,15 @@ internal fun VibitsApp(
   val memosState by features.memos.state.collectAsState()
   val habitsState by features.habits.state.collectAsState()
   val settingsState by features.settings.state.collectAsState()
+
+  var changelogEntries by remember { mutableStateOf<List<ChangelogEntry>?>(null) }
+
+  LaunchedEffect(Unit) {
+    val entries = getChangelog(currentVersion)
+    if (entries.isNotEmpty()) {
+      changelogEntries = entries
+    }
+  }
 
   FeatureCoordinator(
     features = features,
@@ -63,4 +81,11 @@ internal fun VibitsApp(
   MemoCreateDialog(state = memosState, dispatch = features.memos::send)
   MemoEditDialog(state = memosState, dispatch = features.memos::send)
   HabitsDialogs(appState = appState, habitsState = habitsState, dispatch = features.habits::send)
+
+  changelogEntries?.let { entries ->
+    ChangelogDialog(
+      entries = entries,
+      onDismiss = { changelogEntries = null },
+    )
+  }
 }

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -17,6 +17,10 @@ import space.be1ski.vibits.core.ui.test.runCompactUiTest
 import space.be1ski.vibits.core.ui.test.runWideUiTest
 import space.be1ski.vibits.core.ui.test.saveScreenshot
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.test.FakeChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.test.FakeLastSeenVersionStore
+import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.CachedActivity
@@ -71,6 +75,8 @@ class AppScreenshotTest {
 
       override fun exportMemos() = ExportResult.Success("/fake")
     }
+
+  private val fakeGetChangelog = GetChangelogUseCase(FakeChangelogRepository(), FakeLastSeenVersionStore())
 
   private val demoMemos: List<Memo> by lazy { generateDemoMemos() }
   private val buildActivityData = BuildActivityDataUseCase(BuildDayDataUseCase())
@@ -177,6 +183,8 @@ class AppScreenshotTest {
     settingsState: SettingsState = SettingsState(),
     darkTheme: Boolean = false,
     wideLayout: Boolean = true,
+    currentVersion: String = "dev",
+    getChangelog: GetChangelogUseCase = fakeGetChangelog,
   ) {
     val features =
       AppFeatures(
@@ -192,6 +200,8 @@ class AppScreenshotTest {
           currentTheme = AppTheme.SYSTEM,
           currentLanguage = AppLanguage.ENGLISH,
           exportService = fakeExportService,
+          currentVersion = currentVersion,
+          getChangelog = getChangelog,
         )
       }
     }
@@ -204,11 +214,31 @@ class AppScreenshotTest {
     habitsState: HabitsState = HabitsState(),
     settingsState: SettingsState = SettingsState(),
     wideLayout: Boolean = true,
+    currentVersion: String = "dev",
+    getChangelog: GetChangelogUseCase = fakeGetChangelog,
   ) {
     val platform = if (wideLayout) "wide" else "compact"
-    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = false, wideLayout = wideLayout)
+    setVibitsApp(
+      appState,
+      memosState,
+      habitsState,
+      settingsState,
+      darkTheme = false,
+      wideLayout = wideLayout,
+      currentVersion = currentVersion,
+      getChangelog = getChangelog,
+    )
     saveScreenshot("${platform}_light_$name")
-    setVibitsApp(appState, memosState, habitsState, settingsState, darkTheme = true, wideLayout = wideLayout)
+    setVibitsApp(
+      appState,
+      memosState,
+      habitsState,
+      settingsState,
+      darkTheme = true,
+      wideLayout = wideLayout,
+      currentVersion = currentVersion,
+      getChangelog = getChangelog,
+    )
     saveScreenshot("${platform}_dark_$name")
   }
 
@@ -218,9 +248,24 @@ class AppScreenshotTest {
     memosState: MemosState = MemosState(memos = demoMemos, initialDataLoaded = true),
     habitsState: HabitsState = HabitsState(),
     settingsState: SettingsState = SettingsState(),
+    currentVersion: String = "dev",
+    getChangelog: GetChangelogUseCase = fakeGetChangelog,
   ) {
-    runWideUiTest { captureApp(name, appState, memosState, habitsState, settingsState) }
-    runCompactUiTest { captureApp(name, appState, memosState, habitsState, settingsState, wideLayout = false) }
+    runWideUiTest {
+      captureApp(name, appState, memosState, habitsState, settingsState, currentVersion = currentVersion, getChangelog = getChangelog)
+    }
+    runCompactUiTest {
+      captureApp(
+        name,
+        appState,
+        memosState,
+        habitsState,
+        settingsState,
+        wideLayout = false,
+        currentVersion = currentVersion,
+        getChangelog = getChangelog,
+      )
+    }
   }
 
   private fun habitsAppState(
@@ -291,6 +336,8 @@ class AppScreenshotTest {
         appTheme = AppTheme.SYSTEM,
         appLanguage = AppLanguage.ENGLISH,
         exportService = fakeExportService,
+        currentVersion = "dev",
+        getChangelog = fakeGetChangelog,
         onResetApp = {},
         onThemeChanged = {},
         onLanguageChanged = {},
@@ -548,6 +595,44 @@ class AppScreenshotTest {
       appState = feedAppState(),
       habitsState = HabitsState(showEditConfigWarning = true),
     )
+
+  @Test
+  fun `when changelog dialog shown then captures changelog`() {
+    val entries =
+      listOf(
+        ChangelogEntry(
+          version = "1.2.0",
+          title = "Release 1.2.0",
+          body = "## Highlights\n* **Changelog dialog** on app upgrade\n* Improved sync reliability\n* Fixed habit streak calculation",
+          date = "2026-03-01",
+        ),
+        ChangelogEntry(
+          version = "1.1.0",
+          title = "Release 1.1.0",
+          body = "## Changes\n* Desktop sidebar layout\n* Dark mode improvements\n* Bug fixes",
+          date = "2026-02-15",
+        ),
+      )
+
+    fun freshChangelog() =
+      GetChangelogUseCase(
+        FakeChangelogRepository().apply { releasesResult = Result.success(entries) },
+        FakeLastSeenVersionStore("1.0.0"),
+      )
+    val appState = habitsAppState()
+    runWideUiTest {
+      setVibitsApp(appState, currentVersion = "1.2.0", getChangelog = freshChangelog())
+      saveScreenshot("wide_light_app_changelog")
+      setVibitsApp(appState, darkTheme = true, currentVersion = "1.2.0", getChangelog = freshChangelog())
+      saveScreenshot("wide_dark_app_changelog")
+    }
+    runCompactUiTest {
+      setVibitsApp(appState, wideLayout = false, currentVersion = "1.2.0", getChangelog = freshChangelog())
+      saveScreenshot("compact_light_app_changelog")
+      setVibitsApp(appState, darkTheme = true, wideLayout = false, currentVersion = "1.2.0", getChangelog = freshChangelog())
+      saveScreenshot("compact_dark_app_changelog")
+    }
+  }
 
   @Test
   fun `when sync conflict dialog shown then captures conflict dialog`() =

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -39,6 +39,7 @@ include(
 
   ":core:elm",
   ":core:elm:test",
+  ":core:env",
   ":core:platform",
   ":core:platform:testing",
   ":core:strings",
@@ -49,6 +50,10 @@ include(
   ":feature:auth:domain",
   ":feature:auth:domain:testing",
   ":feature:auth:data",
+
+  ":feature:changelog:domain",
+  ":feature:changelog:domain:testing",
+  ":feature:changelog:data",
 
   ":feature:memos:domain",
   ":feature:memos:domain:testing",


### PR DESCRIPTION
## Summary
- Show a "What's New" dialog when the app detects a version upgrade, with release notes fetched from GitHub Releases API
- Lightweight markdown rendering with clickable links, bold text, and bullet points
- New `feature/changelog/` module (domain, data, testing) with 21 tests
- New `core/env` module for compile-time ENV-based config generation (`vibits.buildconfig` convention plugin)
- Fix desktop version always showing "dev" in Homebrew by passing `appVersion` as JVM arg in native distributions

## Architecture
- `vibits.buildconfig` — reusable convention plugin in `build-logic/` that generates `BuildConfig.kt` from declared fields
- `core/env` — centralized module for all ENV-sourced compile-time config (currently `RELEASES_URL` from `CHANGELOG_RELEASES_URL` env var)
- `feature/changelog/domain` — `ChangelogEntry` model, `ChangelogRepository` + `LastSeenVersionStore` interfaces, `GetChangelogUseCase` with version comparison
- `feature/changelog/data` — `GitHubReleasesApi`, `ChangelogRepositoryImpl`, `LastSeenVersionStoreImpl` (KeyValueStore-backed)
- `feature/homescreen` — DI bindings in `AppGraph`, `ChangelogDialog` composable, integration via `LaunchedEffect`

## Behavior
- Skips on first install (saves current version, no dialog)
- Skips for `web` and `dev` builds
- Network failure = silent skip (no dialog, no last-seen update)
- Version filtering: shows entries where `lastSeen < version <= current`

## Test plan
- [x] `./gradlew checkJvm` — all checks pass (ktlint, detekt, compile, 21 new tests)
- [x] Screenshot tests — changelog dialog captured in all 4 variants (wide/compact × light/dark)
- [ ] Manual desktop test with simulated upgrade scenario

🤖 Generated with [Claude Code](https://claude.com/claude-code)