### PR TITLE
Add responsive portrait/landscape modes for web app

### DIFF
--- a/app/web/src/wasmJsMain/resources/index.html
+++ b/app/web/src/wasmJsMain/resources/index.html
@@ -16,15 +16,28 @@
         overflow: hidden;
         background-color: #1C1B1F;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
       #root {
-        width: 100%;
-        height: 100%;
-        max-width: 1200px;
-        margin: 0 auto;
+        box-sizing: border-box;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
-        box-sizing: border-box;
+      }
+      @media (max-aspect-ratio: 1/1) {
+        #root {
+          aspect-ratio: 9 / 19.5;
+          height: 100vh;
+          max-width: 100vw;
+        }
+      }
+      @media (min-aspect-ratio: 1/1) {
+        #root {
+          aspect-ratio: 9 / 7;
+          height: 100vh;
+          max-width: 100vw;
+        }
       }
     </style>
   </head>


### PR DESCRIPTION
## Summary

- Replace fixed `max-width: 1200px` with aspect-ratio-based media queries
- Portrait windows (taller than wide) get phone proportions (9:19.5) — triggers mobile scaffold with tabs
- Landscape windows (wider than tall) get desktop proportions (9:7) — triggers desktop shell with sidebar
- Content is centered via flexbox, capped by `max-width: 100vw` to prevent overflow

## Test plan

- [ ] Run `./gradlew :app:web:wasmJsBrowserDevelopmentRun`
- [ ] Stretch browser horizontally → desktop layout with sidebar (9:7 proportions)
- [ ] Squeeze into narrow vertical window → phone layout with tabs (9:19.5 proportions)
- [ ] 4K fullscreen → desktop layout, centered, not stretched edge-to-edge

🤖 Generated with [Claude Code](https://claude.com/claude-code)