### PR TITLE
Improve desktop wide layout and web responsive modes

### DIFF
--- a/app/web/src/wasmJsMain/resources/index.html
+++ b/app/web/src/wasmJsMain/resources/index.html
@@ -16,15 +16,28 @@
         overflow: hidden;
         background-color: #1C1B1F;
         font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Noto Sans", "Apple Color Emoji", "Segoe UI Emoji", "Noto Color Emoji", sans-serif;
+        display: flex;
+        justify-content: center;
+        align-items: center;
       }
       #root {
-        width: 100%;
-        height: 100%;
-        max-width: 1200px;
-        margin: 0 auto;
+        box-sizing: border-box;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
-        box-sizing: border-box;
+      }
+      @media (max-aspect-ratio: 1/1) {
+        #root {
+          aspect-ratio: 9 / 19.5;
+          height: 100vh;
+          max-width: 100vw;
+        }
+      }
+      @media (min-aspect-ratio: 1/1) {
+        #root {
+          aspect-ratio: 9 / 7;
+          height: 100vh;
+          max-width: 100vw;
+        }
       }
     </style>
   </head>

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenConstants.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenConstants.kt
@@ -2,4 +2,4 @@ package space.be1ski.vibits.feature.habits.presentation.view
 
 import androidx.compose.ui.unit.dp
 
-internal val HABIT_LABEL_WIDTH = 160.dp
+internal val HABIT_LABEL_WIDTH = 200.dp

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppState.kt
@@ -20,6 +20,7 @@ data class AppState(
         Screen.HABITS -> habitsTimeRangeTab
         Screen.STATS -> postsTimeRangeTab
         Screen.FEED -> habitsTimeRangeTab
+        Screen.SETTINGS -> habitsTimeRangeTab
       }
 
   val isDemoMode: Boolean

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/Screen.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/Screen.kt
@@ -4,4 +4,5 @@ enum class Screen {
   HABITS,
   STATS,
   FEED,
+  SETTINGS,
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/reducer/AppTimeRangeReducer.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/reducer/AppTimeRangeReducer.kt
@@ -53,6 +53,7 @@ internal val timeRangeReducer: Reducer<AppAction.TimeRange, AppState, AppEffect,
             Screen.STATS ->
               state.copy(periodStartDate = action.today, postsTimeRangeTab = TimeRangeTab.WEEKS)
             Screen.FEED -> state.copy(periodStartDate = action.today)
+            Screen.SETTINGS -> state.copy(periodStartDate = action.today)
           }
         }
       }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
@@ -83,7 +83,7 @@ internal fun DesktopSidebar(
       SidebarHeader(memosState, dispatchMemos)
       SidebarNavigation(appState, onAppAction, onClearSelection, onFeedScrollToTop)
       Spacer(modifier = Modifier.weight(1f))
-      SidebarActions(todayHabits, onOpenTodayEditor, onShowCreateMemoDialog, onSettingsClick)
+      SidebarActions(appState.selectedScreen, todayHabits, onOpenTodayEditor, onShowCreateMemoDialog, onSettingsClick)
     }
   }
 }
@@ -143,6 +143,7 @@ private fun SidebarNavigation(
 
 @Composable
 private fun SidebarActions(
+  selectedScreen: Screen,
   todayHabits: TodayHabits,
   onOpenTodayEditor: () -> Unit,
   onShowCreateMemoDialog: () -> Unit,
@@ -170,7 +171,7 @@ private fun SidebarActions(
     SidebarNavItem(
       icon = Icons.Filled.Settings,
       label = stringResource(Res.string.nav_settings),
-      selected = false,
+      selected = selectedScreen == Screen.SETTINGS,
       testTag = AppShellTestTags.SIDEBAR_SETTINGS,
       onClick = onSettingsClick,
     )

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
@@ -3,8 +3,10 @@ package space.be1ski.vibits.feature.homescreen.presentation.view
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
+import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
 import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
@@ -49,9 +51,13 @@ internal fun FeatureCoordinator(
   }
 
   // Auto-open settings when credentials required (skip for DEMO/OFFLINE modes)
+  val wideLayout = LocalWideLayout.current
   LaunchedEffect(memosState.credentialsMode, settingsState.isOpen, appState.appMode) {
     val skipCredentialsCheck = appState.skipCredentialsCheck
     if (!skipCredentialsCheck && memosState.credentialsMode && !settingsState.isOpen) {
+      if (wideLayout) {
+        features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
+      }
       features.settings.send(
         SettingsAction.Dialog.Open(
           baseUrl = memosState.baseUrl,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/ScaffoldCallbacks.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/ScaffoldCallbacks.kt
@@ -67,6 +67,7 @@ internal fun rememberScaffoldCallbacks(
           Screen.HABITS -> onAppAction(AppAction.TimeRange.ChangeHabitsTab(appState.habitsTimeRangeTab, newTab))
           Screen.STATS -> onAppAction(AppAction.TimeRange.ChangePostsTab(appState.postsTimeRangeTab, newTab))
           Screen.FEED -> {}
+          Screen.SETTINGS -> {}
         }
       }
     }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -85,6 +85,7 @@ internal fun SwipeableTabContent(
       Screen.HABITS -> appState.habitsTimeRangeTab
       Screen.STATS -> appState.postsTimeRangeTab
       Screen.FEED -> appState.habitsTimeRangeTab
+      Screen.SETTINGS -> appState.habitsTimeRangeTab
     }
 
   // Key the entire pager on selectedTab to force re-initialization when tab changes
@@ -226,6 +227,7 @@ private fun MemosTabContent(
         onPostsListExpandedChange = { onAppAction(AppAction.UI.SetPostsListExpanded(it)) },
       )
     Screen.FEED -> Unit
+    Screen.SETTINGS -> Unit
   }
 }
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -17,7 +17,7 @@ import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.view.SettingsDialog
 
-@Suppress("LongParameterList")
+@Suppress("LongParameterList", "LongMethod")
 @Composable
 internal fun VibitsApp(
   features: AppFeatures,
@@ -57,15 +57,19 @@ internal fun VibitsApp(
     onLanguageChanged = onLanguageChanged,
   )
 
-  if (LocalWideLayout.current) {
+  val wideLayout = LocalWideLayout.current
+  if (wideLayout) {
     VibitsDesktopShell(
       features = features,
       appState = appState,
       memosState = memosState,
       habitsState = habitsState,
+      settingsState = settingsState,
       currentLanguage = currentLanguage,
       currentTheme = currentTheme,
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
+      exportService = exportService,
+      testLogs = testLogs,
     )
   } else {
     VibitsAppScaffold(
@@ -79,7 +83,9 @@ internal fun VibitsApp(
     )
   }
 
-  SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService, testLogs = testLogs)
+  if (!wideLayout) {
+    SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService, testLogs = testLogs)
+  }
   MemoCreateDialog(state = memosState, dispatch = features.memos::send)
   MemoEditDialog(state = memosState, dispatch = features.memos::send)
   HabitsDialogs(appState = appState, habitsState = habitsState, dispatch = features.habits::send)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
@@ -1,46 +1,72 @@
 package space.be1ski.vibits.feature.homescreen.presentation.view
 
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.habits.domain.usecase.EarliestMemoDateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.IsActivityRangeBeforeUseCase
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
+import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import space.be1ski.vibits.feature.memos.presentation.state.MemosState
 import space.be1ski.vibits.feature.memos.presentation.view.SyncConflictDialog
 import space.be1ski.vibits.feature.memos.presentation.view.SyncLogDialog
 import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
+import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
+import space.be1ski.vibits.feature.settings.presentation.view.SettingsPage
 
+private val DESKTOP_CONTENT_MAX_WIDTH = 900.dp
+
+@Suppress("LongMethod")
 @Composable
 internal fun VibitsDesktopShell(
   features: AppFeatures,
   appState: AppState,
   memosState: MemosState,
   habitsState: HabitsState,
+  settingsState: SettingsState,
   currentLanguage: AppLanguage,
   currentTheme: AppTheme,
   syncDebounceSeconds: Int,
+  exportService: ExportService,
+  testLogs: List<LogEntry>? = null,
 ) {
   val shell = rememberAppShellState(features, appState, memosState, habitsState)
+
+  // Sync settings screen ↔ dialog state
+  LaunchedEffect(settingsState.isOpen, appState.selectedScreen) {
+    if (!settingsState.isOpen && appState.selectedScreen == Screen.SETTINGS) {
+      features.app.send(AppAction.Navigation.SelectScreen(Screen.HABITS))
+    }
+    if (settingsState.isOpen && appState.selectedScreen != Screen.SETTINGS) {
+      features.settings.send(SettingsAction.Dialog.Dismiss)
+    }
+  }
 
   Surface(modifier = Modifier.fillMaxSize()) {
     Row(modifier = Modifier.fillMaxSize()) {
@@ -54,6 +80,7 @@ internal fun VibitsDesktopShell(
         onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
         onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
         onSettingsClick = {
+          features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
           features.settings.send(
             SettingsAction.Dialog.Open(
               baseUrl = memosState.baseUrl,
@@ -68,12 +95,19 @@ internal fun VibitsDesktopShell(
         dispatchMemos = features.memos::send,
       )
       VerticalDivider()
-      Column(modifier = Modifier.weight(1f).fillMaxSize()) {
+      Box(
+        modifier = Modifier.weight(1f).fillMaxSize(),
+        contentAlignment = Alignment.TopCenter,
+      ) {
         DesktopContent(
+          modifier = Modifier.widthIn(max = DESKTOP_CONTENT_MAX_WIDTH),
           features = features,
           appState = appState,
           memosState = memosState,
           habitsState = habitsState,
+          settingsState = settingsState,
+          exportService = exportService,
+          testLogs = testLogs,
           shell = shell,
         )
       }
@@ -101,14 +135,30 @@ private fun SyncDialogs(
   }
 }
 
+@Suppress("LongMethod", "LongParameterList")
 @Composable
 private fun DesktopContent(
+  modifier: Modifier = Modifier,
   features: AppFeatures,
   appState: AppState,
   memosState: MemosState,
   habitsState: HabitsState,
+  settingsState: SettingsState,
+  exportService: ExportService,
+  testLogs: List<LogEntry>?,
   shell: AppShellState,
 ) {
+  if (appState.selectedScreen == Screen.SETTINGS) {
+    SettingsPage(
+      modifier = modifier.fillMaxSize(),
+      state = settingsState,
+      dispatch = features.settings::send,
+      exportService = exportService,
+      testLogs = testLogs,
+    )
+    return
+  }
+
   val selectedTab = appState.currentTimeRangeTab
   val currentRange = currentRangeForTab(selectedTab, shell.today)
   val earliestDate = remember(memosState.memos) { EarliestMemoDateUseCase(memosState.memos, shell.timeZone) }
@@ -117,7 +167,7 @@ private fun DesktopContent(
   val canGoForward = IsActivityRangeBeforeUseCase(shell.activityRange, currentRange)
 
   Column(
-    modifier = Modifier.padding(horizontal = Indent.m, vertical = Indent.xs).fillMaxSize(),
+    modifier = modifier.fillMaxSize().padding(horizontal = Indent.m, vertical = Indent.xs),
     verticalArrangement = Arrangement.spacedBy(Indent.xs),
   ) {
     val errorText =

--- a/feature/homescreen/src/commonTest/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppStateTest.kt
+++ b/feature/homescreen/src/commonTest/kotlin/space/be1ski/vibits/feature/homescreen/domain/model/AppStateTest.kt
@@ -51,6 +51,19 @@ class AppStateTest {
   }
 
   @Test
+  fun `when selectedScreen is SETTINGS then currentTimeRangeTab returns habitsTimeRangeTab`() {
+    val state =
+      AppState(
+        selectedScreen = Screen.SETTINGS,
+        habitsTimeRangeTab = TimeRangeTab.MONTHS,
+        postsTimeRangeTab = TimeRangeTab.WEEKS,
+        periodStartDate = testDate,
+      )
+
+    assertEquals(TimeRangeTab.MONTHS, state.currentTimeRangeTab)
+  }
+
+  @Test
   fun `when appMode is DEMO then isDemoMode is true`() {
     val state = AppState(appMode = AppMode.DEMO, periodStartDate = testDate)
 

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -317,6 +317,14 @@ class AppScreenshotTest {
       autoLoaded = true,
     )
 
+  private fun settingsAppState() =
+    AppState(
+      appMode = AppMode.DEMO,
+      selectedScreen = Screen.SETTINGS,
+      periodStartDate = LocalDate(2024, 12, 9),
+      autoLoaded = true,
+    )
+
   private fun habitsStateWithCache(
     range: ActivityRange,
     mode: ActivityMode = ActivityMode.HABITS,
@@ -445,11 +453,34 @@ class AppScreenshotTest {
 
   // region Settings dialogs
 
+  private fun captureSettingsVariants(
+    name: String,
+    settingsState: SettingsState,
+    testLogs: List<LogEntry>? = null,
+  ) {
+    runWideUiTest {
+      captureApp(
+        name,
+        appState = settingsAppState(),
+        settingsState = settingsState,
+        testLogs = testLogs,
+      )
+    }
+    runCompactUiTest {
+      captureApp(
+        name,
+        appState = habitsAppState(),
+        settingsState = settingsState,
+        wideLayout = false,
+        testLogs = testLogs,
+      )
+    }
+  }
+
   @Test
   fun `when settings open in online mode then captures online settings`() =
-    captureAppAllVariants(
+    captureSettingsVariants(
       name = "app_settings_online",
-      appState = habitsAppState(),
       settingsState =
         SettingsState(
           isOpen = true,
@@ -461,17 +492,15 @@ class AppScreenshotTest {
 
   @Test
   fun `when settings open in demo mode then captures demo settings`() =
-    captureAppAllVariants(
+    captureSettingsVariants(
       name = "app_settings_demo",
-      appState = habitsAppState(),
       settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO),
     )
 
   @Test
   fun `when logs dialog open then captures logs`() =
-    captureAppAllVariants(
+    captureSettingsVariants(
       name = "app_settings_logs",
-      appState = habitsAppState(),
       settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showLogsDialog = true),
       testLogs =
         listOf(
@@ -485,9 +514,8 @@ class AppScreenshotTest {
 
   @Test
   fun `when reset confirmation open then captures reset dialog`() =
-    captureAppAllVariants(
+    captureSettingsVariants(
       name = "app_settings_reset",
-      appState = habitsAppState(),
       settingsState = SettingsState(isOpen = true, appMode = AppMode.DEMO, showResetConfirmation = true),
     )
 

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsDialogContent.kt
@@ -142,7 +142,7 @@ fun SettingsDialog(
     modifier = Modifier.testTag(SettingsTestTags.SETTINGS_DIALOG),
     title = { Text(stringResource(Res.string.nav_settings)) },
     text = {
-      SettingsDialogBody(state = state, dispatch = dispatch, exportService = exportService)
+      SettingsFormContent(state = state, dispatch = dispatch, exportService = exportService)
     },
     confirmButton = { SettingsDialogConfirmButton(dispatch) },
     dismissButton = { SettingsDialogDismissButton(dispatch) },
@@ -166,7 +166,7 @@ fun SettingsDialog(
 
 @Suppress("LongMethod", "CyclomaticComplexMethod")
 @Composable
-private fun SettingsDialogBody(
+internal fun SettingsFormContent(
   state: SettingsState,
   dispatch: (SettingsAction) -> Unit,
   exportService: ExportService,
@@ -500,7 +500,7 @@ private fun SettingsDialogDismissButton(dispatch: (SettingsAction) -> Unit) {
 }
 
 @Composable
-private fun ResetConfirmationDialog(
+internal fun ResetConfirmationDialog(
   onConfirm: () -> Unit,
   onConfirmWithMemos: () -> Unit,
   onDismiss: () -> Unit,
@@ -661,7 +661,7 @@ private fun ResetOptionsDialog(
 }
 
 @Composable
-private fun LogsDialog(
+internal fun LogsDialog(
   onDismiss: () -> Unit,
   initialLogs: List<LogEntry> = Log.logs,
 ) {

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsPage.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsPage.kt
@@ -1,0 +1,83 @@
+package space.be1ski.vibits.feature.settings.presentation.view
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.action_cancel
+import space.be1ski.vibits.core.strings.generated.action_save
+import space.be1ski.vibits.core.strings.generated.nav_settings
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.core.utils.logging.LogEntry
+import space.be1ski.vibits.feature.memos.domain.repository.ExportService
+import space.be1ski.vibits.feature.settings.presentation.action.SettingsAction
+import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
+
+@Composable
+fun SettingsPage(
+  modifier: Modifier = Modifier,
+  state: SettingsState,
+  dispatch: (SettingsAction) -> Unit,
+  exportService: ExportService,
+  testLogs: List<LogEntry>? = null,
+) {
+  Box(
+    modifier = modifier.testTag(SettingsTestTags.SETTINGS_PAGE),
+    contentAlignment = Alignment.Center,
+  ) {
+    Column(
+      modifier =
+        Modifier
+          .verticalScroll(rememberScrollState())
+          .padding(horizontal = Indent.l, vertical = Indent.m),
+      verticalArrangement = Arrangement.spacedBy(Indent.m),
+    ) {
+      Text(
+        text = stringResource(Res.string.nav_settings),
+        style = MaterialTheme.typography.headlineMedium,
+      )
+      SettingsFormContent(state = state, dispatch = dispatch, exportService = exportService)
+      Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.spacedBy(Indent.s, Alignment.End),
+      ) {
+        TextButton(onClick = { dispatch(SettingsAction.Dialog.Dismiss) }) {
+          Text(stringResource(Res.string.action_cancel))
+        }
+        Button(onClick = { dispatch(SettingsAction.SaveAndLogs.Save) }) {
+          Text(stringResource(Res.string.action_save))
+        }
+      }
+    }
+  }
+
+  if (state.showLogsDialog) {
+    LogsDialog(
+      onDismiss = { dispatch(SettingsAction.SaveAndLogs.CloseLogs) },
+      initialLogs = testLogs ?: Log.logs,
+    )
+  }
+
+  if (state.showResetConfirmation) {
+    ResetConfirmationDialog(
+      onConfirm = { dispatch(SettingsAction.Reset.ConfirmReset) },
+      onConfirmWithMemos = { dispatch(SettingsAction.Reset.ConfirmResetWithMemos) },
+      onDismiss = { dispatch(SettingsAction.Reset.CancelReset) },
+    )
+  }
+}

--- a/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsTestTags.kt
+++ b/feature/settings/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/settings/presentation/view/SettingsTestTags.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.feature.settings.presentation.view
 
 object SettingsTestTags {
   const val SETTINGS_DIALOG = "settings_dialog"
+  const val SETTINGS_PAGE = "settings_page"
   const val LOGS_DIALOG = "settings_logs_dialog"
   const val RESET_OPTIONS_DIALOG = "settings_reset_options_dialog"
 }


### PR DESCRIPTION
## Summary
- Show settings as a full page (not dialog) in desktop wide layout with sidebar highlight
- Constrain all desktop content to 900dp max width, centered — defined in one place
- Increase habit label width to 200dp so longer names like "Два приёма пищи за день" fit
- Add responsive portrait/landscape modes for web app
- Fix stale settings dialog bug when resizing window between wide and compact modes

## Changes
- Add `Screen.SETTINGS` enum value; render settings as page inside `DesktopContent`
- Single `DESKTOP_CONTENT_MAX_WIDTH = 900dp` in `VibitsDesktopShell` constrains all screens
- `SettingsDialog` only rendered in compact layout; `SettingsPage` used in wide layout
- `LaunchedEffect` syncs settings open state ↔ selected screen in both directions
- `HABIT_LABEL_WIDTH` increased from 160dp to 200dp
- Web `index.html` adds responsive portrait/landscape aspect ratio handling

## Test plan
- [x] `checkJvm` passes
- [x] Screenshot tests pass
- [ ] Manual: resize desktop window between wide and compact with settings open — no stale dialog
- [ ] Manual: all screens centered and capped at same width in wide layout

🤖 Generated with [Claude Code](https://claude.com/claude-code)