### PR TITLE
Add missing test for ResetToHome on SETTINGS screen

### DIFF
--- a/feature/homescreen/src/commonTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/AppReducerTest.kt
+++ b/feature/homescreen/src/commonTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/AppReducerTest.kt
@@ -132,6 +132,17 @@ class AppReducerTest {
     }
 
   @Test
+  fun `when TimeRange ResetToHome on SETTINGS screen then resets only date`() =
+    appReducer.test(AppState(periodStartDate = testDate, selectedScreen = Screen.SETTINGS)) {
+      val today = LocalDate(2024, Month.JANUARY, 1)
+
+      send(AppAction.TimeRange.ResetToHome(today))
+
+      assertState { periodStartDate == today }
+      assertNoEffects()
+    }
+
+  @Test
   fun `when Mode SetAppMode then updates app mode`() =
     appReducer.test(AppState(periodStartDate = testDate)) {
       send(AppAction.Mode.SetAppMode(AppMode.ONLINE))


### PR DESCRIPTION
## Summary
- Add test coverage for `Screen.SETTINGS` branch in `AppTimeRangeReducer.ResetToHome`
- Fixes codecov patch coverage failure from #326 (50% → target 93%)

## Changes
- Add `when TimeRange ResetToHome on SETTINGS screen then resets only date` test in `AppReducerTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)