### PR TITLE
Redesign habit editor as full-screen sheet

### DIFF
--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HabitsDialogs.kt
@@ -3,17 +3,31 @@ package space.be1ski.vibits.feature.homescreen.presentation.view
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Dialog
+import androidx.compose.ui.window.DialogProperties
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
@@ -26,6 +40,8 @@ import space.be1ski.vibits.core.strings.generated.title_create_day
 import space.be1ski.vibits.core.strings.generated.title_delete_day
 import space.be1ski.vibits.core.strings.generated.title_update_day
 import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.core.ui.date.DateFormatter
+import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.EditorError
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
@@ -34,16 +50,21 @@ import space.be1ski.vibits.feature.habits.presentation.view.components.HabitsCon
 import space.be1ski.vibits.feature.habits.presentation.view.components.localizedLabel
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 
+private val DIALOG_TONAL_ELEVATION = 6.dp
+private const val WIDE_DIALOG_WIDTH_FRACTION = 0.6f
+private const val WIDE_DIALOG_HEIGHT_FRACTION = 0.8f
+
 @Composable
 internal fun HabitsDialogs(
   appState: AppState,
   habitsState: HabitsState,
+  dateFormatter: DateFormatter,
   dispatch: (HabitsAction) -> Unit,
 ) {
   val demoMode = appState.isDemoMode
   EditConfigWarningDialog(habitsState, dispatch)
   HabitsConfigDialog(habitsState, demoMode, dispatch)
-  HabitEditorDialog(appState, habitsState, dispatch)
+  HabitEditorDialog(appState, habitsState, dateFormatter, dispatch)
   DeleteDayConfirmDialog(habitsState, dispatch)
 }
 
@@ -51,76 +72,134 @@ internal fun HabitsDialogs(
 private fun HabitEditorDialog(
   appState: AppState,
   habitsState: HabitsState,
+  dateFormatter: DateFormatter,
   dispatch: (HabitsAction) -> Unit,
 ) {
   if (!habitsState.isEditorOpen) {
     return
   }
   val demoMode = appState.isDemoMode
-  AlertDialog(
+  val wideLayout = LocalWideLayout.current
+
+  Dialog(
     onDismissRequest = { dispatch(HabitsAction.Editor.CloseEditor) },
-    modifier = Modifier.testTag(AppShellTestTags.HABIT_EDITOR_DIALOG),
-    title = {
-      val titleRes = if (habitsState.isEditing) Res.string.title_update_day else Res.string.title_create_day
-      Text(stringResource(titleRes))
-    },
-    text = { HabitEditorContent(habitsState, demoMode, dispatch) },
-    confirmButton = { HabitEditorConfirmButton(habitsState, dispatch) },
-    dismissButton = { HabitEditorDismissButton(dispatch) },
-  )
+    properties = DialogProperties(usePlatformDefaultWidth = false),
+  ) {
+    Surface(
+      modifier =
+        Modifier
+          .testTag(AppShellTestTags.HABIT_EDITOR_DIALOG)
+          .then(
+            if (wideLayout) {
+              Modifier.fillMaxWidth(WIDE_DIALOG_WIDTH_FRACTION).fillMaxHeight(WIDE_DIALOG_HEIGHT_FRACTION)
+            } else {
+              Modifier.fillMaxSize()
+            },
+          ),
+      shape = if (wideLayout) MaterialTheme.shapes.extraLarge else RectangleShape,
+      tonalElevation = DIALOG_TONAL_ELEVATION,
+    ) {
+      HabitEditorPage(habitsState, demoMode, dateFormatter, dispatch)
+    }
+  }
 }
 
 @Composable
-private fun HabitEditorContent(
+private fun HabitEditorPage(
   habitsState: HabitsState,
   demoMode: Boolean,
+  dateFormatter: DateFormatter,
   dispatch: (HabitsAction) -> Unit,
 ) {
-  Column(verticalArrangement = Arrangement.spacedBy(Indent.xs)) {
-    if (habitsState.editorConfig.isNotEmpty()) {
-      habitsState.editorConfig.forEach { habit ->
-        val tag = habit.tag
-        val done = habitsState.editorSelections[tag] == true
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Checkbox(
+  Column(modifier = Modifier.fillMaxSize().padding(Indent.xl)) {
+    val titleRes = if (habitsState.isEditing) Res.string.title_update_day else Res.string.title_create_day
+    Text(stringResource(titleRes), style = MaterialTheme.typography.headlineSmall)
+    habitsState.editorDay?.let { day ->
+      Text(
+        dateFormatter.monthDayYear(day.date),
+        style = MaterialTheme.typography.bodyMedium,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    Spacer(Modifier.height(Indent.m))
+
+    LazyColumn(
+      modifier = Modifier.weight(1f).fillMaxWidth(),
+      verticalArrangement = Arrangement.spacedBy(Indent.xs),
+    ) {
+      if (habitsState.editorConfig.isNotEmpty()) {
+        items(habitsState.editorConfig, key = { it.tag }) { habit ->
+          val tag = habit.tag
+          val done = habitsState.editorSelections[tag] == true
+          HabitEditorRow(
+            label = habit.localizedLabel(demoMode),
             checked = done,
-            onCheckedChange = { checked ->
-              dispatch(HabitsAction.Editor.ToggleHabit(tag, checked))
-            },
+            onToggle = { dispatch(HabitsAction.Editor.ToggleHabit(tag, !done)) },
           )
-          Text(habit.localizedLabel(demoMode), style = MaterialTheme.typography.bodySmall)
         }
-      }
-    } else {
-      habitsState.editorSelections.forEach { (tag, done) ->
-        Row(verticalAlignment = Alignment.CenterVertically) {
-          Checkbox(
+      } else {
+        items(habitsState.editorSelections.entries.toList(), key = { it.key }) { (tag, done) ->
+          HabitEditorRow(
+            label = tag,
             checked = done,
-            onCheckedChange = { checked ->
-              dispatch(HabitsAction.Editor.ToggleHabit(tag, checked))
-            },
+            onToggle = { dispatch(HabitsAction.Editor.ToggleHabit(tag, !done)) },
           )
-          Text(tag, style = MaterialTheme.typography.bodySmall)
         }
       }
     }
-  }
-  habitsState.editorError?.let { error ->
-    val message =
-      when (error) {
-        is EditorError.NoHabitSelected -> stringResource(Res.string.msg_select_habit)
-        is EditorError.OperationFailed -> error.message
-      }
-    Text(message, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+
+    habitsState.editorError?.let { error ->
+      val message =
+        when (error) {
+          is EditorError.NoHabitSelected -> stringResource(Res.string.msg_select_habit)
+          is EditorError.OperationFailed -> error.message
+        }
+      Spacer(Modifier.height(Indent.xs))
+      Text(message, color = MaterialTheme.colorScheme.error, style = MaterialTheme.typography.bodySmall)
+    }
+
+    Spacer(Modifier.height(Indent.m))
+    HabitEditorActions(habitsState, dispatch)
   }
 }
 
 @Composable
-private fun HabitEditorConfirmButton(
+private fun HabitEditorRow(
+  label: String,
+  checked: Boolean,
+  onToggle: () -> Unit,
+) {
+  Surface(
+    onClick = onToggle,
+    modifier = Modifier.fillMaxWidth(),
+    color =
+      if (checked) {
+        MaterialTheme.colorScheme.primaryContainer
+      } else {
+        MaterialTheme.colorScheme.surfaceVariant
+      },
+    shape = MaterialTheme.shapes.medium,
+  ) {
+    Row(
+      modifier = Modifier.padding(horizontal = Indent.m, vertical = Indent.s),
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(Indent.m),
+    ) {
+      Checkbox(checked = checked, onCheckedChange = null)
+      Text(label, style = MaterialTheme.typography.bodyLarge)
+    }
+  }
+}
+
+@Composable
+private fun HabitEditorActions(
   habitsState: HabitsState,
   dispatch: (HabitsAction) -> Unit,
 ) {
-  Row(horizontalArrangement = Arrangement.spacedBy(Indent.xs)) {
+  Row(
+    modifier = Modifier.fillMaxWidth(),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
     if (habitsState.isEditing) {
       TextButton(
         onClick = { dispatch(HabitsAction.Editor.RequestDelete) },
@@ -129,17 +208,15 @@ private fun HabitEditorConfirmButton(
         Text(stringResource(Res.string.action_delete))
       }
     }
+    Spacer(Modifier.weight(1f))
+    TextButton(onClick = { dispatch(HabitsAction.Editor.CloseEditor) }) {
+      Text(stringResource(Res.string.action_cancel))
+    }
+    Spacer(Modifier.width(Indent.xs))
     Button(onClick = { dispatch(HabitsAction.Editor.ConfirmEditor) }) {
       val actionRes = if (habitsState.isEditing) Res.string.action_update else Res.string.action_create
       Text(stringResource(actionRes))
     }
-  }
-}
-
-@Composable
-private fun HabitEditorDismissButton(dispatch: (HabitsAction) -> Unit) {
-  TextButton(onClick = { dispatch(HabitsAction.Editor.CloseEditor) }) {
-    Text(stringResource(Res.string.action_cancel))
   }
 }
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -8,6 +8,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.core.ui.date.rememberDateFormatter
 import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
@@ -83,12 +84,14 @@ internal fun VibitsApp(
     )
   }
 
+  val dateFormatter = rememberDateFormatter()
+
   if (!wideLayout) {
     SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService, testLogs = testLogs)
   }
   MemoCreateDialog(state = memosState, dispatch = features.memos::send)
   MemoEditDialog(state = memosState, dispatch = features.memos::send)
-  HabitsDialogs(appState = appState, habitsState = habitsState, dispatch = features.habits::send)
+  HabitsDialogs(appState = appState, habitsState = habitsState, dateFormatter = dateFormatter, dispatch = features.habits::send)
 
   changelogEntries?.let { entries ->
     ChangelogDialog(


### PR DESCRIPTION
## Summary
- Replace small `AlertDialog` with responsive full-screen sheet (`Dialog` + `Surface`)
- Full-width clickable habit rows with background color change on selection
- Date subtitle via `DateFormatter.monthDayYear()`

## Changes
- **Wide layout:** Centered dialog (60% width, 80% height) with rounded corners
- **Narrow layout:** True full-screen, no rounded corners
- `HabitEditorRow`: entire row toggles via `Surface(onClick)`, checkbox is visual-only, `bodyLarge` typography
- `HabitEditorActions`: Delete left-aligned (edit mode), Cancel + Create/Update right-aligned
- `DeleteDayConfirmDialog` unchanged


🤖 Generated with [Claude Code](https://claude.com/claude-code)