### PR TITLE
Fix Android versionCode semver calculation

### DIFF
--- a/app/android/build.gradle.kts
+++ b/app/android/build.gradle.kts
@@ -31,7 +31,13 @@ android {
     applicationId = "space.be1ski.vibits"
     minSdk = sdkMin
     targetSdk = sdkTarget
-    versionCode = appVersion.replace(".", "").toIntOrNull() ?: 1
+    versionCode =
+      appVersion.split(".").let { parts ->
+        val major = parts.getOrNull(0)?.toIntOrNull() ?: 0
+        val minor = parts.getOrNull(1)?.toIntOrNull() ?: 0
+        val patch = parts.getOrNull(2)?.toIntOrNull() ?: 0
+        major * 10_000 + minor * 100 + patch
+      }
     versionName = appVersion
   }
 


### PR DESCRIPTION
## Summary
- Fix versionCode formula so semantic version ordering is preserved

## Changes
- Replace `appVersion.replace(".", "").toInt()` with `MAJOR * 10000 + MINOR * 100 + PATCH`
- Old: `1.0.93` → `1093`, `1.2.4` → `124` (broken: 124 < 1093)
- New: `1.0.93` → `10093`, `1.2.4` → `10204` (correct: 10204 > 10093)

## Test plan
- [x] `assembleDebug` builds successfully with `-PappVersion=1.2.4`


🤖 Generated with [Claude Code](https://claude.com/claude-code)