### PR TITLE
Fix GUI-launched desktop app reading env credentials

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
@@ -22,6 +22,8 @@ object DesktopStoragePaths {
 
   fun databasePath(): String = appDataDir().resolve("memos.db").toString()
 
+  fun localConfigPath(): String = appDataDir().resolve("local.properties").toString()
+
   fun environmentLabel(): String = environmentSuffix().ifBlank { "prod" }
 
   private fun appDataDir(): Path {

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
@@ -1,21 +1,30 @@
 package space.be1ski.vibits.core.platform.env
 
+import space.be1ski.vibits.core.platform.app.DesktopStoragePaths
 import java.io.File
 import java.util.Properties
 
 actual fun createLocalConfigProvider(): LocalConfigProvider {
-  val properties = Properties()
+  val appDataProperties = Properties()
+  val appDataConfigFile = File(DesktopStoragePaths.localConfigPath())
+  if (appDataConfigFile.exists()) {
+    appDataConfigFile.inputStream().use { appDataProperties.load(it) }
+  }
+
+  val localProperties = Properties()
   val localPropertiesFile = File("../local.properties")
   if (localPropertiesFile.exists()) {
-    localPropertiesFile.inputStream().use { properties.load(it) }
+    localPropertiesFile.inputStream().use { localProperties.load(it) }
   }
 
   return LocalConfigProvider { key ->
-    // 1. Try local.properties with dot notation (memos.baseUrl)
-    properties.getProperty(key)
-      // 2. Try ENV with dot notation (memos.baseUrl)
+    // 1. Try app data dir config (~/Library/Application Support/Memos-prod/local.properties)
+    appDataProperties.getProperty(key)
+      // 2. Try relative local.properties (../local.properties — dev/Gradle only)
+      ?: localProperties.getProperty(key)
+      // 3. Try ENV with dot notation (memos.baseUrl)
       ?: System.getenv(key)
-      // 3. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
+      // 4. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
       ?: System.getenv(key.replace('.', '_').uppercase())
   }
 }

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
@@ -1,30 +1,48 @@
 package space.be1ski.vibits.core.platform.env
 
 import space.be1ski.vibits.core.platform.app.DesktopStoragePaths
+import space.be1ski.vibits.core.platform.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.platformLog
 import java.io.File
 import java.util.Properties
 
+private const val TAG = "LocalConfig"
+
 actual fun createLocalConfigProvider(): LocalConfigProvider {
-  val appDataProperties = Properties()
   val appDataConfigFile = File(DesktopStoragePaths.localConfigPath())
+  val appDataProperties = Properties()
   if (appDataConfigFile.exists()) {
     appDataConfigFile.inputStream().use { appDataProperties.load(it) }
+    platformLog(LogLevel.INFO, TAG, "Loaded ${appDataProperties.size} keys from $appDataConfigFile")
+  } else {
+    platformLog(LogLevel.DEBUG, TAG, "App data config not found: $appDataConfigFile")
   }
 
-  val localProperties = Properties()
   val localPropertiesFile = File("../local.properties")
+  val localProperties = Properties()
   if (localPropertiesFile.exists()) {
     localPropertiesFile.inputStream().use { localProperties.load(it) }
+    platformLog(LogLevel.INFO, TAG, "Loaded ${localProperties.size} keys from $localPropertiesFile")
+  } else {
+    platformLog(LogLevel.DEBUG, TAG, "Local properties not found: $localPropertiesFile")
   }
 
   return LocalConfigProvider { key ->
     // 1. Try app data dir config (~/Library/Application Support/Memos-prod/local.properties)
-    appDataProperties.getProperty(key)
+    appDataProperties.getProperty(key)?.also {
+      platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from app data config")
+    }
       // 2. Try relative local.properties (../local.properties — dev/Gradle only)
-      ?: localProperties.getProperty(key)
+      ?: localProperties.getProperty(key)?.also {
+        platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from local.properties")
+      }
       // 3. Try ENV with dot notation (memos.baseUrl)
-      ?: System.getenv(key)
+      ?: System.getenv(key)?.also {
+        platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from env")
+      }
       // 4. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
-      ?: System.getenv(key.replace('.', '_').uppercase())
+      ?: System.getenv(key.replace('.', '_').uppercase())?.also {
+        platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from env (UPPER_SNAKE)")
+      }
   }
 }

--- a/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
+++ b/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
@@ -104,6 +104,31 @@ class DesktopStoragePathsTest {
   }
 
   @Test
+  fun `when localConfigPath called then returns path ending with local properties`() {
+    val path = DesktopStoragePaths.localConfigPath()
+
+    assertTrue(path.endsWith("local.properties"))
+  }
+
+  @Test
+  fun `when environment is set then localConfigPath includes environment in path`() {
+    System.setProperty(envProperty, "test")
+
+    val path = DesktopStoragePaths.localConfigPath()
+
+    assertTrue(path.contains("Memos-test"))
+  }
+
+  @Test
+  fun `when no environment set then localConfigPath includes prod in path`() {
+    System.clearProperty(envProperty)
+
+    val path = DesktopStoragePaths.localConfigPath()
+
+    assertTrue(path.contains("Memos-prod"))
+  }
+
+  @Test
   fun `when databasePath called then uses OS-specific app data directory`() {
     val path = DesktopStoragePaths.databasePath()
     val osName = System.getProperty("os.name").lowercase()


### PR DESCRIPTION
## Summary
- Add `localConfigPath()` to `DesktopStoragePaths` exposing config file path in the app data directory
- Update `LocalConfigProvider` to check app data dir config (`~/Library/Application Support/Memos-prod/local.properties`) before the relative `../local.properties` fallback and env vars
- macOS GUI apps (Spotlight/Dock) don't inherit shell env vars, so `MEMOS_BASE_URL`/`MEMOS_TOKEN` were invisible to the Homebrew-installed app

## Test plan
- [x] `./gradlew checkJvm` passes
- [ ] Create `~/Library/Application Support/Memos-prod/local.properties` with `memos.baseUrl` and `memos.token`
- [ ] Launch Homebrew version from Spotlight → "Quick Online" dialog should appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)