### PR TITLE
Store desktop credentials in macOS Keychain

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePaths.kt
@@ -22,8 +22,6 @@ object DesktopStoragePaths {
 
   fun databasePath(): String = appDataDir().resolve("memos.db").toString()
 
-  fun localConfigPath(): String = appDataDir().resolve("local.properties").toString()
-
   fun environmentLabel(): String = environmentSuffix().ifBlank { "prod" }
 
   private fun appDataDir(): Path {

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/env/LocalConfigProvider.kt
@@ -1,6 +1,5 @@
 package space.be1ski.vibits.core.platform.env
 
-import space.be1ski.vibits.core.platform.app.DesktopStoragePaths
 import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.platform.logging.platformLog
 import java.io.File
@@ -9,15 +8,6 @@ import java.util.Properties
 private const val TAG = "LocalConfig"
 
 actual fun createLocalConfigProvider(): LocalConfigProvider {
-  val appDataConfigFile = File(DesktopStoragePaths.localConfigPath())
-  val appDataProperties = Properties()
-  if (appDataConfigFile.exists()) {
-    appDataConfigFile.inputStream().use { appDataProperties.load(it) }
-    platformLog(LogLevel.INFO, TAG, "Loaded ${appDataProperties.size} keys from $appDataConfigFile")
-  } else {
-    platformLog(LogLevel.DEBUG, TAG, "App data config not found: $appDataConfigFile")
-  }
-
   val localPropertiesFile = File("../local.properties")
   val localProperties = Properties()
   if (localPropertiesFile.exists()) {
@@ -28,19 +18,15 @@ actual fun createLocalConfigProvider(): LocalConfigProvider {
   }
 
   return LocalConfigProvider { key ->
-    // 1. Try app data dir config (~/Library/Application Support/Memos-prod/local.properties)
-    appDataProperties.getProperty(key)?.also {
-      platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from app data config")
+    // 1. Try relative local.properties (../local.properties — dev/Gradle only)
+    localProperties.getProperty(key)?.also {
+      platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from local.properties")
     }
-      // 2. Try relative local.properties (../local.properties — dev/Gradle only)
-      ?: localProperties.getProperty(key)?.also {
-        platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from local.properties")
-      }
-      // 3. Try ENV with dot notation (memos.baseUrl)
+      // 2. Try ENV with dot notation (memos.baseUrl)
       ?: System.getenv(key)?.also {
         platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from env")
       }
-      // 4. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
+      // 3. Try ENV with uppercase snake_case (MEMOS_BASE_URL)
       ?: System.getenv(key.replace('.', '_').uppercase())?.also {
         platformLog(LogLevel.DEBUG, TAG, "Resolved '$key' from env (UPPER_SNAKE)")
       }

--- a/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
+++ b/core/platform/src/desktopTest/kotlin/space/be1ski/vibits/core/platform/app/DesktopStoragePathsTest.kt
@@ -104,31 +104,6 @@ class DesktopStoragePathsTest {
   }
 
   @Test
-  fun `when localConfigPath called then returns path ending with local properties`() {
-    val path = DesktopStoragePaths.localConfigPath()
-
-    assertTrue(path.endsWith("local.properties"))
-  }
-
-  @Test
-  fun `when environment is set then localConfigPath includes environment in path`() {
-    System.setProperty(envProperty, "test")
-
-    val path = DesktopStoragePaths.localConfigPath()
-
-    assertTrue(path.contains("Memos-test"))
-  }
-
-  @Test
-  fun `when no environment set then localConfigPath includes prod in path`() {
-    System.clearProperty(envProperty)
-
-    val path = DesktopStoragePaths.localConfigPath()
-
-    assertTrue(path.contains("Memos-prod"))
-  }
-
-  @Test
   fun `when databasePath called then uses OS-specific app data directory`() {
     val path = DesktopStoragePaths.databasePath()
     val osName = System.getProperty("os.name").lowercase()

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">إعادة تعيين التطبيق</string>
     <string name="action_reset_settings_only">إعادة تعيين الإعدادات فقط</string>
     <string name="action_reset_with_memos">إعادة تعيين كل شيء (بما في ذلك الذكريات)</string>
+    <string name="action_restore_from_keychain">استعادة من سلسلة المفاتيح</string>
     <string name="action_save">حفظ</string>
     <string name="action_show_details">عرض التفاصيل</string>
     <string name="action_start_tracking">بدء التتبع</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Tətbiqi sıfırla</string>
     <string name="action_reset_settings_only">Yalnız tənzimləmələri sıfırla</string>
     <string name="action_reset_with_memos">Hər şeyi sıfırla (xatirələr daxil)</string>
+    <string name="action_restore_from_keychain">Açar zəncirindən bərpa et</string>
     <string name="action_save">Saxla</string>
     <string name="action_show_details">Detalları göstər</string>
     <string name="action_start_tracking">İzləməyə başla</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Скінуць праграму</string>
     <string name="action_reset_settings_only">Скінуць толькі налады</string>
     <string name="action_reset_with_memos">Скінуць усё (уключна з успамінамі)</string>
+    <string name="action_restore_from_keychain">Аднавіць з Звязкі ключоў</string>
     <string name="action_save">Захаваць</string>
     <string name="action_show_details">Паказаць дэталі</string>
     <string name="action_start_tracking">Пачаць адсочванне</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">App zurücksetzen</string>
     <string name="action_reset_settings_only">Nur Einstellungen zurücksetzen</string>
     <string name="action_reset_with_memos">Alles zurücksetzen (einschließlich Erinnerungen)</string>
+    <string name="action_restore_from_keychain">Aus Schlüsselbund wiederherstellen</string>
     <string name="action_save">Speichern</string>
     <string name="action_show_details">Details anzeigen</string>
     <string name="action_start_tracking">Tracking starten</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Restablecer app</string>
     <string name="action_reset_settings_only">Restablecer solo la configuración</string>
     <string name="action_reset_with_memos">Restablecer todo (incluidos los recuerdos)</string>
+    <string name="action_restore_from_keychain">Restaurar desde Llavero</string>
     <string name="action_save">Guardar</string>
     <string name="action_show_details">Mostrar detalles</string>
     <string name="action_start_tracking">Comenzar seguimiento</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Réinitialiser l\'app</string>
     <string name="action_reset_settings_only">Réinitialiser uniquement les paramètres</string>
     <string name="action_reset_with_memos">Tout réinitialiser (y compris les souvenirs)</string>
+    <string name="action_restore_from_keychain">Restaurer depuis le Trousseau</string>
     <string name="action_save">Enregistrer</string>
     <string name="action_show_details">Afficher les détails</string>
     <string name="action_start_tracking">Commencer le suivi</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">ऐप रीसेट करें</string>
     <string name="action_reset_settings_only">केवल सेटिंग्स रीसेट करें</string>
     <string name="action_reset_with_memos">सब कुछ रीसेट करें (यादों सहित)</string>
+    <string name="action_restore_from_keychain">कीचेन से पुनर्स्थापित करें</string>
     <string name="action_save">सेव करें</string>
     <string name="action_show_details">विवरण दिखाएं</string>
     <string name="action_start_tracking">ट्रैकिंग शुरू करें</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">アプリをリセット</string>
     <string name="action_reset_settings_only">設定のみをリセット</string>
     <string name="action_reset_with_memos">すべてをリセット（思い出を含む）</string>
+    <string name="action_restore_from_keychain">キーチェーンから復元</string>
     <string name="action_save">保存</string>
     <string name="action_show_details">詳細を表示</string>
     <string name="action_start_tracking">記録を開始</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">აპის გადატვირთვა</string>
     <string name="action_reset_settings_only">მხოლოდ პარამეტრების გადაყენება</string>
     <string name="action_reset_with_memos">ყველაფრის გადაყენება (მოგონებების ჩათვლით)</string>
+    <string name="action_restore_from_keychain">აღდგენა გასაღებების ჯაჭვიდან</string>
     <string name="action_save">შენახვა</string>
     <string name="action_show_details">დეტალების ჩვენება</string>
     <string name="action_start_tracking">თვალთვალის დაწყება</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Қолданбаны қалпына келтіру</string>
     <string name="action_reset_settings_only">Тек баптауларды қалпына келтіру</string>
     <string name="action_reset_with_memos">Бәрін қалпына келтіру (естеліктерді қоса)</string>
+    <string name="action_restore_from_keychain">Кілттер тізбегінен қалпына келтіру</string>
     <string name="action_save">Сақтау</string>
     <string name="action_show_details">Мәліметтерді көрсету</string>
     <string name="action_start_tracking">Бақылауды бастау</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -26,6 +26,7 @@
     <string name="action_reset_app">Колдонмону баштапкыга кайтаруу</string>
     <string name="action_reset_settings_only">Жөн гана жөндөөлөрдү калыбына келтирүү</string>
     <string name="action_reset_with_memos">Баарын калыбына келтирүү (эстеликтерди коштоп)</string>
+    <string name="action_restore_from_keychain">Ачкычтар чынжырынан калыбына келтирүү</string>
     <string name="action_save">Сактоо</string>
     <string name="action_show_details">Деталдарды көрсөтүү</string>
     <string name="action_start_tracking">Көзөмөлдөөнү баштоо</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Redefinir app</string>
     <string name="action_reset_settings_only">Redefinir apenas as configurações</string>
     <string name="action_reset_with_memos">Redefinir tudo (incluindo memórias)</string>
+    <string name="action_restore_from_keychain">Restaurar do Porta-chaves</string>
     <string name="action_save">Salvar</string>
     <string name="action_show_details">Mostrar detalhes</string>
     <string name="action_start_tracking">Iniciar rastreamento</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -26,6 +26,7 @@
     <string name="action_reset_app">Resetare aplicație</string>
     <string name="action_reset_settings_only">Resetează doar setările</string>
     <string name="action_reset_with_memos">Resetează totul (inclusiv memoriile)</string>
+    <string name="action_restore_from_keychain">Restaurare din Portchei</string>
     <string name="action_save">Salvează</string>
     <string name="action_show_details">Arată detalii</string>
     <string name="action_start_tracking">Începe urmărirea</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Сбросить приложение</string>
     <string name="action_reset_settings_only">Сбросить только настройки</string>
     <string name="action_reset_with_memos">Сбросить всё (включая воспоминания)</string>
+    <string name="action_restore_from_keychain">Восстановить из Связки ключей</string>
     <string name="action_save">Сохранить</string>
     <string name="action_show_details">Показать детали привычки</string>
     <string name="action_start_tracking">Начать отслеживание</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -26,6 +26,7 @@
     <string name="action_reset_app">Барқарор кардани барнома</string>
     <string name="action_reset_settings_only">Танҳо танзимотро барқарор кардан</string>
     <string name="action_reset_with_memos">Ҳамаро барқарор кардан (хотираҳоро низ)</string>
+    <string name="action_restore_from_keychain">Барқарор аз Занҷираи калидҳо</string>
     <string name="action_save">Захира кардан</string>
     <string name="action_show_details">Нишон додани тафсилот</string>
     <string name="action_start_tracking">Назоратро оғоз кардан</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -26,6 +26,7 @@
     <string name="action_reset_app">Programany täzele</string>
     <string name="action_reset_settings_only">Diňe sazlamalary täzeden düzmek</string>
     <string name="action_reset_with_memos">Ählisini täzeden düzmek (ýatlamalar bilen)</string>
+    <string name="action_restore_from_keychain">Açar zynjyryndan dikelt</string>
     <string name="action_save">Sakla</string>
     <string name="action_show_details">Jikme-jiklikleri görkez</string>
     <string name="action_start_tracking">Yzarlamagy başla</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Скинути додаток</string>
     <string name="action_reset_settings_only">Скинути лише налаштування</string>
     <string name="action_reset_with_memos">Скинути все (включно зі спогадами)</string>
+    <string name="action_restore_from_keychain">Відновити з В'язки ключів</string>
     <string name="action_save">Зберегти</string>
     <string name="action_show_details">Показати деталі</string>
     <string name="action_start_tracking">Почати відстеження</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Ilovani tiklash</string>
     <string name="action_reset_settings_only">Faqat sozlamalarni tiklash</string>
     <string name="action_reset_with_memos">Hammasini tiklash (xotiralarni ham)</string>
+    <string name="action_restore_from_keychain">Kalit zanjirisidan tiklash</string>
     <string name="action_save">Saqlash</string>
     <string name="action_show_details">Tafsilotlarni ko'rsatish</string>
     <string name="action_start_tracking">Kuzatuvni boshlash</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">重置应用</string>
     <string name="action_reset_settings_only">仅重置设置</string>
     <string name="action_reset_with_memos">重置所有内容（包括回忆）</string>
+    <string name="action_restore_from_keychain">从钥匙串恢复</string>
     <string name="action_save">保存</string>
     <string name="action_show_details">显示详情</string>
     <string name="action_start_tracking">开始记录</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -27,6 +27,7 @@
     <string name="action_reset_app">Reset app</string>
     <string name="action_reset_settings_only">Reset settings only</string>
     <string name="action_reset_with_memos">Reset everything (including memos)</string>
+    <string name="action_restore_from_keychain">Restore from Keychain</string>
     <string name="action_save">Save</string>
     <string name="action_show_details">Show habit details</string>
     <string name="action_start_tracking">Start tracking</string>

--- a/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
+++ b/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImpl.kt
@@ -29,4 +29,12 @@ class CredentialsRepositoryImpl(
     Log.i(TAG, "save() baseUrl='${trimmed.baseUrl.maskUrl()}'")
     credentialsStore.save(LocalCredentials(baseUrl = trimmed.baseUrl, token = trimmed.token))
   }
+
+  override fun loadFromSecureStorage(): Credentials? {
+    val local = credentialsStore.loadFromSecureStorage() ?: return null
+    Log.i(TAG, "loadFromSecureStorage() baseUrl='${local.baseUrl.maskUrl()}'")
+    return Credentials(baseUrl = local.baseUrl, token = local.token)
+  }
+
+  override fun isSecureStorageAvailable(): Boolean = credentialsStore.isSecureStorageAvailable()
 }

--- a/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/CredentialsStore.kt
+++ b/feature/auth/data/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/CredentialsStore.kt
@@ -6,6 +6,10 @@ interface CredentialsStore {
   fun load(): LocalCredentials
 
   fun save(credentials: LocalCredentials)
+
+  fun loadFromSecureStorage(): LocalCredentials? = null
+
+  fun isSecureStorageAvailable(): Boolean = false
 }
 
 expect fun createCredentialsStore(): CredentialsStore

--- a/feature/auth/data/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImplTest.kt
+++ b/feature/auth/data/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/data/CredentialsRepositoryImplTest.kt
@@ -53,4 +53,36 @@ class CredentialsRepositoryImplTest {
 
     assertEquals(LocalCredentials(baseUrl = longUrl, token = "token"), store.stored)
   }
+
+  @Test
+  fun `when loadFromSecureStorage with credentials then returns them`() {
+    val store =
+      FakeCredentialsStore(
+        secureStorageCredentials = LocalCredentials(baseUrl = "https://keychain.com", token = "keychain-token"),
+      )
+    val repository = CredentialsRepositoryImpl(store)
+
+    val result = repository.loadFromSecureStorage()
+
+    assertEquals(Credentials(baseUrl = "https://keychain.com", token = "keychain-token"), result)
+  }
+
+  @Test
+  fun `when loadFromSecureStorage without credentials then returns null`() {
+    val store = FakeCredentialsStore()
+    val repository = CredentialsRepositoryImpl(store)
+
+    val result = repository.loadFromSecureStorage()
+
+    assertEquals(null, result)
+  }
+
+  @Test
+  fun `when isSecureStorageAvailable then delegates to store`() {
+    val available = FakeCredentialsStore(secureStorageAvailable = true)
+    val unavailable = FakeCredentialsStore(secureStorageAvailable = false)
+
+    assertEquals(true, CredentialsRepositoryImpl(available).isSecureStorageAvailable())
+    assertEquals(false, CredentialsRepositoryImpl(unavailable).isSecureStorageAvailable())
+  }
 }

--- a/feature/auth/data/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/data/test/FakeCredentialsStore.kt
+++ b/feature/auth/data/src/commonTest/kotlin/space/be1ski/vibits/feature/auth/data/test/FakeCredentialsStore.kt
@@ -5,6 +5,8 @@ import space.be1ski.vibits.feature.auth.data.platform.CredentialsStore
 
 class FakeCredentialsStore(
   initial: LocalCredentials = LocalCredentials(baseUrl = "", token = ""),
+  private val secureStorageCredentials: LocalCredentials? = null,
+  private val secureStorageAvailable: Boolean = false,
 ) : CredentialsStore {
   var stored: LocalCredentials = initial
     private set
@@ -17,4 +19,8 @@ class FakeCredentialsStore(
     stored = credentials
     saveCalls += 1
   }
+
+  override fun loadFromSecureStorage(): LocalCredentials? = secureStorageCredentials
+
+  override fun isSecureStorageAvailable(): Boolean = secureStorageAvailable
 }

--- a/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/internal/MacOsKeychainCredentials.kt
+++ b/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/internal/MacOsKeychainCredentials.kt
@@ -1,0 +1,80 @@
+package space.be1ski.vibits.feature.auth.data.internal
+
+import space.be1ski.vibits.feature.auth.data.LocalCredentials
+
+private const val ACCOUNT_BASE_URL = "base_url"
+private const val ACCOUNT_TOKEN = "token"
+
+internal object MacOsKeychainCredentials {
+  fun load(service: String): LocalCredentials? {
+    val baseUrl = readKeychainPassword(service, ACCOUNT_BASE_URL)?.takeIf { it.isNotBlank() }
+    val token = readKeychainPassword(service, ACCOUNT_TOKEN)?.takeIf { it.isNotBlank() }
+    return if (baseUrl != null && token != null) {
+      LocalCredentials(baseUrl = baseUrl, token = token)
+    } else {
+      null
+    }
+  }
+
+  fun save(
+    service: String,
+    credentials: LocalCredentials,
+  ): Boolean {
+    val savedBaseUrl = writeKeychainPassword(service, ACCOUNT_BASE_URL, credentials.baseUrl)
+    val savedToken = writeKeychainPassword(service, ACCOUNT_TOKEN, credentials.token)
+    return savedBaseUrl && savedToken
+  }
+
+  private fun readKeychainPassword(
+    service: String,
+    account: String,
+  ): String? =
+    try {
+      val process =
+        Runtime.getRuntime().exec(
+          arrayOf(
+            "/usr/bin/security",
+            "find-generic-password",
+            "-s",
+            service,
+            "-a",
+            account,
+            "-w",
+          ),
+        )
+      val result =
+        process.inputStream
+          .bufferedReader()
+          .readText()
+          .trim()
+      val exitCode = process.waitFor()
+      if (exitCode == 0) result else null
+    } catch (_: Exception) {
+      null
+    }
+
+  private fun writeKeychainPassword(
+    service: String,
+    account: String,
+    password: String,
+  ): Boolean =
+    try {
+      val process =
+        Runtime.getRuntime().exec(
+          arrayOf(
+            "/usr/bin/security",
+            "add-generic-password",
+            "-s",
+            service,
+            "-a",
+            account,
+            "-w",
+            password,
+            "-U",
+          ),
+        )
+      process.waitFor() == 0
+    } catch (_: Exception) {
+      false
+    }
+}

--- a/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/DesktopCredentialsStore.kt
+++ b/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/DesktopCredentialsStore.kt
@@ -12,24 +12,19 @@ internal class DesktopCredentialsStore : CredentialsStore {
   private val prefs = Preferences.userRoot().node(service)
 
   override fun load(): LocalCredentials {
-    if (isMacOs) {
-      val keychain = MacOsKeychainCredentials.load(service)
-      if (keychain != null) return keychain
-    }
     val baseUrl = prefs.get("base_url", "").trim()
     val token = prefs.get("token", "").trim()
     return LocalCredentials(baseUrl = baseUrl, token = token)
   }
 
   override fun save(credentials: LocalCredentials) {
-    if (isMacOs && MacOsKeychainCredentials.save(service, credentials)) {
-      prefs.remove("base_url")
-      prefs.remove("token")
-      return
-    }
     prefs.put("base_url", credentials.baseUrl)
     prefs.put("token", credentials.token)
   }
+
+  override fun loadFromSecureStorage(): LocalCredentials? = if (isMacOs) MacOsKeychainCredentials.load(service) else null
+
+  override fun isSecureStorageAvailable(): Boolean = isMacOs
 }
 
 actual fun createCredentialsStore(): CredentialsStore = DesktopCredentialsStore()

--- a/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/DesktopCredentialsStore.kt
+++ b/feature/auth/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/auth/data/platform/DesktopCredentialsStore.kt
@@ -2,18 +2,31 @@ package space.be1ski.vibits.feature.auth.data.platform
 
 import space.be1ski.vibits.core.platform.app.DesktopStoragePaths
 import space.be1ski.vibits.feature.auth.data.LocalCredentials
+import space.be1ski.vibits.feature.auth.data.internal.MacOsKeychainCredentials
 import java.util.prefs.Preferences
 
+private val isMacOs = System.getProperty("os.name", "").lowercase().contains("mac")
+
 internal class DesktopCredentialsStore : CredentialsStore {
-  private val prefs = Preferences.userRoot().node(DesktopStoragePaths.preferencesNode())
+  private val service = DesktopStoragePaths.preferencesNode()
+  private val prefs = Preferences.userRoot().node(service)
 
   override fun load(): LocalCredentials {
+    if (isMacOs) {
+      val keychain = MacOsKeychainCredentials.load(service)
+      if (keychain != null) return keychain
+    }
     val baseUrl = prefs.get("base_url", "").trim()
     val token = prefs.get("token", "").trim()
     return LocalCredentials(baseUrl = baseUrl, token = token)
   }
 
   override fun save(credentials: LocalCredentials) {
+    if (isMacOs && MacOsKeychainCredentials.save(service, credentials)) {
+      prefs.remove("base_url")
+      prefs.remove("token")
+      return
+    }
     prefs.put("base_url", credentials.baseUrl)
     prefs.put("token", credentials.token)
   }

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/repository/CredentialsRepository.kt
@@ -6,4 +6,8 @@ interface CredentialsRepository {
   fun load(): Credentials
 
   fun save(credentials: Credentials)
+
+  fun loadFromSecureStorage(): Credentials?
+
+  fun isSecureStorageAvailable(): Boolean
 }

--- a/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/usecase/LoadKeychainCredentialsUseCase.kt
+++ b/feature/auth/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/usecase/LoadKeychainCredentialsUseCase.kt
@@ -1,0 +1,14 @@
+package space.be1ski.vibits.feature.auth.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.feature.auth.domain.model.Credentials
+import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
+
+@Inject
+class LoadKeychainCredentialsUseCase(
+  private val credentialsRepository: CredentialsRepository,
+) {
+  operator fun invoke(): Credentials? = credentialsRepository.loadFromSecureStorage()
+
+  fun isAvailable(): Boolean = credentialsRepository.isSecureStorageAvailable()
+}

--- a/feature/auth/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/test/FakeCredentialsRepository.kt
+++ b/feature/auth/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/auth/domain/test/FakeCredentialsRepository.kt
@@ -5,6 +5,8 @@ import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 
 class FakeCredentialsRepository(
   initial: Credentials = Credentials(baseUrl = "", token = ""),
+  private val secureStorageCredentials: Credentials? = null,
+  private val secureStorageAvailable: Boolean = false,
 ) : CredentialsRepository {
   var stored: Credentials = initial
     private set
@@ -17,4 +19,8 @@ class FakeCredentialsRepository(
     stored = credentials
     saveCount += 1
   }
+
+  override fun loadFromSecureStorage(): Credentials? = secureStorageCredentials
+
+  override fun isSecureStorageAvailable(): Boolean = secureStorageAvailable
 }

--- a/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepositoryTest.kt
+++ b/feature/memos/data/src/commonTest/kotlin/space/be1ski/vibits/feature/memos/data/ModeAwareMemosRepositoryTest.kt
@@ -512,4 +512,8 @@ private class FakeCredentialsRepository : CredentialsRepository {
   override fun load() = Credentials("", "")
 
   override fun save(credentials: Credentials) = Unit
+
+  override fun loadFromSecureStorage(): Credentials? = null
+
+  override fun isSecureStorageAvailable(): Boolean = false
 }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/di/ModeSelectionDependencies.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/di/ModeSelectionDependencies.kt
@@ -3,6 +3,7 @@ package space.be1ski.vibits.feature.mode.di
 import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase
 import space.be1ski.vibits.feature.auth.domain.usecase.LoadCredentialsUseCase
+import space.be1ski.vibits.feature.auth.domain.usecase.LoadKeychainCredentialsUseCase
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
 import space.be1ski.vibits.feature.mode.domain.usecase.SaveAppModeUseCase
@@ -12,6 +13,7 @@ class ModeSelectionDependencies(
   val connectionTester: ConnectionTester,
   val initializeCredentialsFromEnv: InitializeCredentialsFromEnvUseCase,
   val loadCredentials: LoadCredentialsUseCase,
+  val loadKeychainCredentials: LoadKeychainCredentialsUseCase,
   val saveCredentials: SaveCredentialsUseCase,
   val saveAppMode: SaveAppModeUseCase,
 )

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/di/ModeSelectionFeatureFactory.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/di/ModeSelectionFeatureFactory.kt
@@ -24,6 +24,7 @@ fun createModeSelectionFeature(
             connectionTester = dependencies.connectionTester,
             initializeCredentialsFromEnv = dependencies.initializeCredentialsFromEnv,
             loadCredentials = dependencies.loadCredentials,
+            loadKeychainCredentials = dependencies.loadKeychainCredentials,
             saveCredentials = dependencies.saveCredentials,
           ),
         modeHandler =

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/action/ModeSelectionAction.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/action/ModeSelectionAction.kt
@@ -6,9 +6,27 @@ import space.be1ski.vibits.core.platform.mode.AppMode
 sealed interface ModeSelectionAction : Action {
   /** Stored credentials detection actions. */
   sealed interface StoredCredentials : ModeSelectionAction {
-    data object Found : StoredCredentials
+    val isKeychainAvailable: Boolean
 
-    data object NotFound : StoredCredentials
+    data class Found(
+      override val isKeychainAvailable: Boolean,
+    ) : StoredCredentials
+
+    data class NotFound(
+      override val isKeychainAvailable: Boolean,
+    ) : StoredCredentials
+  }
+
+  /** Keychain restore actions. */
+  sealed interface Keychain : ModeSelectionAction {
+    data object Restore : Keychain
+
+    data class Loaded(
+      val baseUrl: String,
+      val token: String,
+    ) : Keychain
+
+    data object NotFound : Keychain
   }
 
   /** Quick online dialog actions. */

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionCredentialsEffectHandler.kt
@@ -9,6 +9,7 @@ import space.be1ski.vibits.feature.auth.domain.model.Credentials
 import space.be1ski.vibits.feature.auth.domain.model.isFilled
 import space.be1ski.vibits.feature.auth.domain.usecase.InitializeCredentialsFromEnvUseCase
 import space.be1ski.vibits.feature.auth.domain.usecase.LoadCredentialsUseCase
+import space.be1ski.vibits.feature.auth.domain.usecase.LoadKeychainCredentialsUseCase
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.memos.domain.repository.ConnectionTester
 import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
@@ -19,6 +20,7 @@ class ModeSelectionCredentialsEffectHandler(
   private val connectionTester: ConnectionTester,
   private val initializeCredentialsFromEnv: InitializeCredentialsFromEnvUseCase,
   private val loadCredentials: LoadCredentialsUseCase,
+  private val loadKeychainCredentials: LoadKeychainCredentialsUseCase,
   private val saveCredentials: SaveCredentialsUseCase,
 ) : EffectHandler<ModeSelectionEffect.Command.Credentials, ModeSelectionAction> {
   override fun invoke(command: ModeSelectionEffect.Command.Credentials): Flow<ModeSelectionAction> =
@@ -28,31 +30,34 @@ class ModeSelectionCredentialsEffectHandler(
       ModeSelectionEffect.Command.UseStoredCredentialsWithValidation -> handleUseStoredCredentials()
       is ModeSelectionEffect.Command.ValidateCredentials -> handleValidateCredentials(command)
       is ModeSelectionEffect.Command.SaveCredentials -> handleSaveCredentials(command)
+      ModeSelectionEffect.Command.LoadFromKeychain -> handleLoadFromKeychain()
     }
 
   private fun handleInitializeFromLocalConfig(): Flow<ModeSelectionAction> =
     actions {
       initializeCredentialsFromEnv()
+      val keychainAvailable = loadKeychainCredentials.isAvailable()
       // After initialization, check if credentials were loaded
       val credentials = loadCredentials()
       if (credentials.isFilled) {
         Log.d(TAG, "Stored credentials found after initialization")
-        emit(ModeSelectionAction.StoredCredentials.Found)
+        emit(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = keychainAvailable))
       } else {
         Log.d(TAG, "No stored credentials after initialization")
-        emit(ModeSelectionAction.StoredCredentials.NotFound)
+        emit(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = keychainAvailable))
       }
     }
 
   private fun handleCheckStoredCredentials(): Flow<ModeSelectionAction> =
     actions {
+      val keychainAvailable = loadKeychainCredentials.isAvailable()
       val credentials = loadCredentials()
       if (credentials.isFilled) {
         Log.d(TAG, "Stored credentials found")
-        emit(ModeSelectionAction.StoredCredentials.Found)
+        emit(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = keychainAvailable))
       } else {
         Log.d(TAG, "No stored credentials")
-        emit(ModeSelectionAction.StoredCredentials.NotFound)
+        emit(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = keychainAvailable))
       }
     }
 
@@ -79,5 +84,17 @@ class ModeSelectionCredentialsEffectHandler(
     actions {
       Log.d(TAG, "Saving credentials")
       saveCredentials(Credentials(command.baseUrl, command.token))
+    }
+
+  private fun handleLoadFromKeychain(): Flow<ModeSelectionAction> =
+    actions {
+      val credentials = loadKeychainCredentials()
+      if (credentials != null) {
+        Log.d(TAG, "Keychain credentials loaded: baseUrl=${credentials.baseUrl.maskUrl()}")
+        emit(ModeSelectionAction.Keychain.Loaded(baseUrl = credentials.baseUrl, token = credentials.token))
+      } else {
+        Log.d(TAG, "No keychain credentials found")
+        emit(ModeSelectionAction.Keychain.NotFound)
+      }
     }
 }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionEffect.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/effect/ModeSelectionEffect.kt
@@ -27,6 +27,8 @@ sealed interface ModeSelectionEffect {
       val token: String,
     ) : Credentials
 
+    data object LoadFromKeychain : Credentials
+
     data class SaveMode(
       val mode: AppMode,
     ) : Mode

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeKeychainReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeKeychainReducer.kt
@@ -1,0 +1,35 @@
+package space.be1ski.vibits.feature.mode.presentation.reducer
+
+import space.be1ski.vibits.core.elm.Reducer
+import space.be1ski.vibits.core.elm.reducer
+import space.be1ski.vibits.core.ui.form.CredentialValidationError
+import space.be1ski.vibits.feature.mode.presentation.action.ModeSelectionAction
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Command
+import space.be1ski.vibits.feature.mode.presentation.effect.ModeSelectionEffect.Notification
+import space.be1ski.vibits.feature.mode.presentation.state.ModeSelectionState
+
+internal val keychainReducer:
+  Reducer<ModeSelectionAction.Keychain, ModeSelectionState, Command, Notification> =
+  reducer { action, state ->
+    when (action) {
+      is ModeSelectionAction.Keychain.Restore -> {
+        state { state.copy(isValidating = true, error = null) }
+        command(Command.LoadFromKeychain)
+      }
+
+      is ModeSelectionAction.Keychain.Loaded -> {
+        state {
+          state.copy(
+            baseUrl = action.baseUrl,
+            token = action.token,
+            isValidating = false,
+            error = null,
+          )
+        }
+      }
+
+      is ModeSelectionAction.Keychain.NotFound -> {
+        state { state.copy(isValidating = false, error = CredentialValidationError.CONNECTION_FAILED) }
+      }
+    }
+  }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeSelectionReducer.kt
@@ -14,5 +14,6 @@ val modeSelectionReducer: Reducer<ModeSelectionAction, ModeSelectionState, ModeS
       is ModeSelectionAction.Input -> inputReducer(action, state)
       is ModeSelectionAction.Validation -> validationReducer(action, state)
       is ModeSelectionAction.Selection -> selectionReducer(action, state)
+      is ModeSelectionAction.Keychain -> keychainReducer(action, state)
     }
   }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeStoredCredentialsReducer.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/reducer/ModeStoredCredentialsReducer.kt
@@ -12,11 +12,22 @@ internal val storedCredentialsReducer:
   reducer { action, state ->
     when (action) {
       is ModeSelectionAction.StoredCredentials.Found -> {
-        state { state.copy(hasStoredCredentials = true, showQuickOnlineDialog = true) }
+        state {
+          state.copy(
+            hasStoredCredentials = true,
+            showQuickOnlineDialog = true,
+            isKeychainAvailable = action.isKeychainAvailable,
+          )
+        }
       }
 
       is ModeSelectionAction.StoredCredentials.NotFound -> {
-        state { state.copy(hasStoredCredentials = false) }
+        state {
+          state.copy(
+            hasStoredCredentials = false,
+            isKeychainAvailable = action.isKeychainAvailable,
+          )
+        }
       }
     }
   }

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/state/ModeSelectionState.kt
@@ -6,6 +6,7 @@ data class ModeSelectionState(
   val showCredentialsDialog: Boolean = false,
   val showQuickOnlineDialog: Boolean = false,
   val hasStoredCredentials: Boolean = false,
+  val isKeychainAvailable: Boolean = false,
   val baseUrl: String = "",
   val token: String = "",
   val isValidating: Boolean = false,

--- a/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
+++ b/feature/mode/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreen.kt
@@ -38,6 +38,7 @@ import space.be1ski.vibits.core.elm.Feature
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_cancel
+import space.be1ski.vibits.core.strings.generated.action_restore_from_keychain
 import space.be1ski.vibits.core.strings.generated.action_save
 import space.be1ski.vibits.core.strings.generated.action_use_saved
 import space.be1ski.vibits.core.strings.generated.mode_demo_desc
@@ -187,37 +188,7 @@ private fun CredentialsSetupDialog(
     onDismissRequest = { if (!state.isValidating) dispatch(ModeSelectionAction.Dialog.Dismiss) },
     modifier = Modifier.testTag(ModeSelectionTestTags.CREDENTIALS_DIALOG),
     title = { Text(stringResource(Res.string.mode_online_title)) },
-    text = {
-      Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
-        CredentialFields(
-          baseUrl = state.baseUrl,
-          token = state.token,
-          onBaseUrlChange = { dispatch(ModeSelectionAction.Input.UpdateBaseUrl(it)) },
-          onTokenChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
-          enabled = !state.isValidating,
-        )
-        if (state.error != null) {
-          Text(
-            text = credentialValidationErrorMessage(state.error),
-            color = MaterialTheme.colorScheme.error,
-            style = MaterialTheme.typography.bodySmall,
-          )
-          if (state.error == CredentialValidationError.CONNECTION_FAILED) {
-            Text(
-              text = stringResource(Res.string.msg_connection_failed_hint),
-              style = MaterialTheme.typography.bodySmall,
-              color = MaterialTheme.colorScheme.onSurfaceVariant,
-            )
-          }
-        } else {
-          Text(
-            stringResource(Res.string.msg_credentials_stored_locally),
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-          )
-        }
-      }
-    },
+    text = { CredentialsSetupDialogContent(state = state, dispatch = dispatch) },
     confirmButton = {
       Button(onClick = { dispatch(ModeSelectionAction.Validation.Submit) }, enabled = !state.isValidating) {
         if (state.isValidating) {
@@ -237,6 +208,50 @@ private fun CredentialsSetupDialog(
       }
     },
   )
+}
+
+@Composable
+private fun CredentialsSetupDialogContent(
+  state: ModeSelectionState,
+  dispatch: (ModeSelectionAction) -> Unit,
+) {
+  Column(verticalArrangement = Arrangement.spacedBy(Indent.s)) {
+    CredentialFields(
+      baseUrl = state.baseUrl,
+      token = state.token,
+      onBaseUrlChange = { dispatch(ModeSelectionAction.Input.UpdateBaseUrl(it)) },
+      onTokenChange = { dispatch(ModeSelectionAction.Input.UpdateToken(it)) },
+      enabled = !state.isValidating,
+    )
+    if (state.error != null) {
+      Text(
+        text = credentialValidationErrorMessage(state.error),
+        color = MaterialTheme.colorScheme.error,
+        style = MaterialTheme.typography.bodySmall,
+      )
+      if (state.error == CredentialValidationError.CONNECTION_FAILED) {
+        Text(
+          text = stringResource(Res.string.msg_connection_failed_hint),
+          style = MaterialTheme.typography.bodySmall,
+          color = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+      }
+    } else {
+      Text(
+        stringResource(Res.string.msg_credentials_stored_locally),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+    if (state.isKeychainAvailable) {
+      TextButton(
+        onClick = { dispatch(ModeSelectionAction.Keychain.Restore) },
+        enabled = !state.isValidating,
+      ) {
+        Text(stringResource(Res.string.action_restore_from_keychain))
+      }
+    }
+  }
 }
 
 @Composable

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionEffectHandlerTest.kt
@@ -3,6 +3,7 @@ import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.feature.auth.domain.test.FakeCredentialsRepository
+import space.be1ski.vibits.feature.auth.domain.usecase.LoadKeychainCredentialsUseCase
 import space.be1ski.vibits.feature.auth.domain.usecase.SaveCredentialsUseCase
 import space.be1ski.vibits.feature.mode.domain.test.FakeAppModeRepository
 import space.be1ski.vibits.feature.mode.domain.usecase.SaveAppModeUseCase
@@ -82,7 +83,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.InitializeFromLocalConfig).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = false)), actions)
     }
 
   @Test
@@ -96,7 +97,18 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.InitializeFromLocalConfig).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = false)), actions)
+    }
+
+  @Test
+  fun `when InitializeFromLocalConfig then passes keychain availability`() =
+    runTest {
+      val credentialsRepo = FakeCredentialsRepository(secureStorageAvailable = true)
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(Command.InitializeFromLocalConfig).toList()
+
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = true)), actions)
     }
 
   @Test
@@ -114,7 +126,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.CheckStoredCredentials).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = false)), actions)
     }
 
   @Test
@@ -125,7 +137,7 @@ class ModeSelectionEffectHandlerTest {
 
       val actions = handler(Command.CheckStoredCredentials).toList()
 
-      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound), actions)
+      assertEquals(listOf(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = false)), actions)
     }
 
   @Test
@@ -164,6 +176,37 @@ class ModeSelectionEffectHandlerTest {
       assertEquals(listOf(ModeSelectionAction.Validation.Failed), actions)
     }
 
+  @Test
+  fun `when LoadFromKeychain with credentials then emits KeychainLoaded`() =
+    runTest {
+      val credentialsRepo =
+        FakeCredentialsRepository(
+          secureStorageCredentials =
+            space.be1ski.vibits.feature.auth.domain.model.Credentials(
+              baseUrl = "https://keychain.com",
+              token = "keychain-token",
+            ),
+        )
+      val handler = createHandler(credentialsRepository = credentialsRepo)
+
+      val actions = handler(Command.LoadFromKeychain).toList()
+
+      assertEquals(
+        listOf(ModeSelectionAction.Keychain.Loaded(baseUrl = "https://keychain.com", token = "keychain-token")),
+        actions,
+      )
+    }
+
+  @Test
+  fun `when LoadFromKeychain without credentials then emits KeychainNotFound`() =
+    runTest {
+      val handler = createHandler()
+
+      val actions = handler(Command.LoadFromKeychain).toList()
+
+      assertEquals(listOf(ModeSelectionAction.Keychain.NotFound), actions)
+    }
+
   private fun createHandler(
     connectionResult: Result<Unit> = Result.success(Unit),
     credentialsRepository: FakeCredentialsRepository = FakeCredentialsRepository(),
@@ -187,6 +230,7 @@ class ModeSelectionEffectHandlerTest {
           loadCredentials =
             space.be1ski.vibits.feature.auth.domain.usecase
               .LoadCredentialsUseCase(credentialsRepository),
+          loadKeychainCredentials = LoadKeychainCredentialsUseCase(credentialsRepository),
           saveCredentials = SaveCredentialsUseCase(credentialsRepository),
         ),
       modeHandler =

--- a/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
+++ b/feature/mode/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/mode/presentation/ModeSelectionReducerTest.kt
@@ -207,18 +207,36 @@ class ModeSelectionReducerTest {
   @Test
   fun `when StoredCredentials Found then sets flag and shows quick online dialog`() =
     modeSelectionReducer.test(ModeSelectionState()) {
-      send(ModeSelectionAction.StoredCredentials.Found)
+      send(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = false))
 
-      assertState { hasStoredCredentials && showQuickOnlineDialog }
+      assertState { hasStoredCredentials && showQuickOnlineDialog && !isKeychainAvailable }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when StoredCredentials Found with keychain then sets keychainAvailable`() =
+    modeSelectionReducer.test(ModeSelectionState()) {
+      send(ModeSelectionAction.StoredCredentials.Found(isKeychainAvailable = true))
+
+      assertState { hasStoredCredentials && showQuickOnlineDialog && isKeychainAvailable }
       assertNoEffects()
     }
 
   @Test
   fun `when StoredCredentials NotFound then clears flag`() =
     modeSelectionReducer.test(ModeSelectionState(hasStoredCredentials = true)) {
-      send(ModeSelectionAction.StoredCredentials.NotFound)
+      send(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = false))
 
-      assertState { !hasStoredCredentials }
+      assertState { !hasStoredCredentials && !isKeychainAvailable }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when StoredCredentials NotFound with keychain then sets keychainAvailable`() =
+    modeSelectionReducer.test(ModeSelectionState()) {
+      send(ModeSelectionAction.StoredCredentials.NotFound(isKeychainAvailable = true))
+
+      assertState { !hasStoredCredentials && isKeychainAvailable }
       assertNoEffects()
     }
 
@@ -258,5 +276,37 @@ class ModeSelectionReducerTest {
 
       assertState { !showQuickOnlineDialog }
       assertCommandCount(1)
+    }
+
+  @Test
+  fun `when Keychain Restore then starts validating and loads from keychain`() =
+    modeSelectionReducer.test(ModeSelectionState(showCredentialsDialog = true)) {
+      send(ModeSelectionAction.Keychain.Restore)
+
+      assertState { isValidating && error == null }
+      assertCommands(Command.LoadFromKeychain)
+    }
+
+  @Test
+  fun `when Keychain Loaded then fills credentials and stops validating`() =
+    modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
+      send(ModeSelectionAction.Keychain.Loaded(baseUrl = "https://memos.example.com", token = "secret-token"))
+
+      assertState {
+        baseUrl == "https://memos.example.com" &&
+          token == "secret-token" &&
+          !isValidating &&
+          error == null
+      }
+      assertNoEffects()
+    }
+
+  @Test
+  fun `when Keychain NotFound then stops validating and shows error`() =
+    modeSelectionReducer.test(ModeSelectionState(isValidating = true)) {
+      send(ModeSelectionAction.Keychain.NotFound)
+
+      assertState { !isValidating && error == CredentialValidationError.CONNECTION_FAILED }
+      assertNoEffects()
     }
 }

--- a/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
+++ b/feature/mode/presentation/src/desktopTest/kotlin/space/be1ski/vibits/feature/mode/presentation/view/ModeSelectionScreenshotTest.kt
@@ -61,4 +61,20 @@ class ModeSelectionScreenshotTest {
         ),
       )
     }
+
+  @Test
+  fun `when credentials dialog with keychain available then captures keychain button`() =
+    captureAllVariants(
+      "mode_selection_credentials_keychain",
+      assertions = { onNodeWithTag(ModeSelectionTestTags.CREDENTIALS_DIALOG).assertIsDisplayed() },
+    ) {
+      ModeSelectionScreen(
+        createFeature(
+          ModeSelectionState(
+            showCredentialsDialog = true,
+            isKeychainAvailable = true,
+          ),
+        ),
+      )
+    }
 }


### PR DESCRIPTION
## Summary
- Make Keychain access explicit: no more macOS system dialog on first launch
- Add "Restore from Keychain" button in credentials dialog (macOS only)
- Revert auto-Keychain from `DesktopCredentialsStore.load()`/`save()` — now Preferences only
- Add `loadFromSecureStorage()` and `isSecureStorageAvailable()` to `CredentialsStore`/`CredentialsRepository`
- New `LoadKeychainCredentialsUseCase` wired through mode TEA layer (actions, reducer, effect handler)
- Localized `action_restore_from_keychain` string in all 20 locales

## Test plan
- [x] `./gradlew checkJvm` passes
- [ ] `./gradlew :app:desktop:run` — mode selection screen appears, no Keychain dialog on launch
- [ ] Click "Online" → credentials dialog shows "Restore from Keychain" button
- [ ] Click button → macOS prompts → credentials fill in → submit → connected
- [ ] On non-macOS desktop: button not visible
- [ ] `security add-generic-password -s "space.be1ski.vibits" -a "token" -w "$TOKEN" -U` seeds credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)