### PR TITLE
Fix web app layout breaking on mobile devices

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ kotlin-js-store/
 vibits-*.json
 *.class
 META-INF/
+xcuserdata/
 /.ralphrc
 /.ralph/
 /fix_plan.md

--- a/README.md
+++ b/README.md
@@ -47,5 +47,6 @@ app/          — Platform entry points (android, desktop, ios, web)
 ## CI/CD
 CI runs `checkJvm` (Linux) and `checkIos` (macOS). [Release workflow](https://github.com/be1ski/vibits/actions/workflows/release.yml) builds and publishes in parallel:
 - **Android APK** → GitHub Releases + Firebase App Distribution
-- **macOS DMG / Windows MSI** → GitHub Releases
+- **macOS DMG** → GitHub Releases + Homebrew
+- **Windows MSI** → GitHub Releases
 - **Web** → GitHub Releases + GitHub Pages

--- a/app/web/src/wasmJsMain/resources/index.html
+++ b/app/web/src/wasmJsMain/resources/index.html
@@ -22,18 +22,22 @@
       }
       #root {
         box-sizing: border-box;
+        width: 100vw;
+        height: 100dvh;
         padding-top: env(safe-area-inset-top);
         padding-bottom: env(safe-area-inset-bottom);
       }
-      @media (max-aspect-ratio: 1/1) {
+      @media (min-width: 900px) and (max-aspect-ratio: 1/1) {
         #root {
+          width: auto;
           aspect-ratio: 9 / 19.5;
           height: 100vh;
           max-width: 100vw;
         }
       }
-      @media (min-aspect-ratio: 1/1) {
+      @media (min-width: 900px) and (min-aspect-ratio: 1/1) {
         #root {
+          width: auto;
           aspect-ratio: 9 / 7;
           height: 100vh;
           max-width: 100vw;


### PR DESCRIPTION
## Summary
- Use `100dvh` instead of `100vh` for root container height to correctly handle mobile browser URL bar
- Restrict `aspect-ratio` CSS constraints to viewports >= 900px, so mobile devices fill the full screen
- Prevents mobile web from accidentally triggering the desktop sidebar layout

## Test plan
- [ ] Open web app on mobile phone in portrait — should show bottom nav, no sidebar
- [ ] Rotate to landscape — should still show compact layout, no sidebar
- [ ] Open on desktop browser — aspect-ratio constraints still apply as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)