### PR TITLE
Add new version available indicator in desktop sidebar

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -50,5 +50,6 @@ compose.desktop {
 tasks.matching { it.name == "run" || it.name == "desktopRun" }.configureEach {
   doFirst {
     (this as? JavaExec)?.systemProperty("vibits.env", "dev")
+    (this as? JavaExec)?.systemProperty("memos.version", appVersion)
   }
 }

--- a/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.core.platform.app
+
+actual class AppUpdater {
+  actual suspend fun upgrade(): Boolean = false
+
+  actual fun restart() = Unit
+}

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.core.platform.app
+
+expect class AppUpdater() {
+  suspend fun upgrade(): Boolean
+
+  fun restart()
+}

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -1,0 +1,36 @@
+package space.be1ski.vibits.core.platform.app
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kotlin.system.exitProcess
+
+actual class AppUpdater {
+  actual suspend fun upgrade(): Boolean =
+    withContext(Dispatchers.IO) {
+      try {
+        val process =
+          ProcessBuilder("brew", "upgrade", "--cask", "vibits")
+            .redirectErrorStream(true)
+            .start()
+        process.waitFor() == 0
+      } catch (_: Exception) {
+        false
+      }
+    }
+
+  actual fun restart() {
+    try {
+      val command =
+        ProcessHandle
+          .current()
+          .info()
+          .command()
+          .orElse(null)
+      if (command != null) {
+        ProcessBuilder(command).start()
+      }
+    } finally {
+      exitProcess(0)
+    }
+  }
+}

--- a/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.core.platform.app
+
+actual class AppUpdater {
+  actual suspend fun upgrade(): Boolean = false
+
+  actual fun restart() = Unit
+}

--- a/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.core.platform.app
+
+actual class AppUpdater {
+  actual suspend fun upgrade(): Boolean = false
+
+  actual fun restart() = Unit
+}

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">فشلت المزامنة: %1$s</string>
     <string name="msg_syncing">جارٍ المزامنة...</string>
     <string name="title_sync_conflict">تعارض المزامنة</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s متاح</string>
+    <string name="action_upgrade">تحديث</string>
+    <string name="label_upgrading">جارٍ التحديث…</string>
+    <string name="action_restart_to_update">إعادة التشغيل للتحديث</string>
+    <string name="label_upgrade_failed">فشل التحديث</string>
+    <string name="action_retry">إعادة المحاولة</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Sinxronizasiya uğursuz oldu: %1$s</string>
     <string name="msg_syncing">Sinxronizasiya edilir...</string>
     <string name="title_sync_conflict">Sinxronizasiya ziddiyyəti</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s mövcuddur</string>
+    <string name="action_upgrade">Yeniləmək</string>
+    <string name="label_upgrading">Yenilənir…</string>
+    <string name="action_restart_to_update">Yeniləmək üçün yenidən başladın</string>
+    <string name="label_upgrade_failed">Yeniləmə uğursuz oldu</string>
+    <string name="action_retry">Yenidən cəhd</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Памылка сінхранізацыі: %1$s</string>
     <string name="msg_syncing">Сінхранізацыя...</string>
     <string name="title_sync_conflict">Канфлікт сінхранізацыі</string>
+    <!-- Update -->
+    <string name="label_update_available">Даступна v%1$s</string>
+    <string name="action_upgrade">Абнавіць</string>
+    <string name="label_upgrading">Абнаўленне…</string>
+    <string name="action_restart_to_update">Перазапусціць</string>
+    <string name="label_upgrade_failed">Памылка абнаўлення</string>
+    <string name="action_retry">Паўтарыць</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Synchronisierung fehlgeschlagen: %1$s</string>
     <string name="msg_syncing">Synchronisiere...</string>
     <string name="title_sync_conflict">Synchronisierungskonflikt</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s verfügbar</string>
+    <string name="action_upgrade">Aktualisieren</string>
+    <string name="label_upgrading">Aktualisierung…</string>
+    <string name="action_restart_to_update">Neu starten zum Aktualisieren</string>
+    <string name="label_upgrade_failed">Aktualisierung fehlgeschlagen</string>
+    <string name="action_retry">Erneut versuchen</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Error de sincronización: %1$s</string>
     <string name="msg_syncing">Sincronizando...</string>
     <string name="title_sync_conflict">Conflicto de sincronización</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s disponible</string>
+    <string name="action_upgrade">Actualizar</string>
+    <string name="label_upgrading">Actualizando…</string>
+    <string name="action_restart_to_update">Reiniciar para actualizar</string>
+    <string name="label_upgrade_failed">Error de actualización</string>
+    <string name="action_retry">Reintentar</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Échec de la synchronisation : %1$s</string>
     <string name="msg_syncing">Synchronisation...</string>
     <string name="title_sync_conflict">Conflit de synchronisation</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s disponible</string>
+    <string name="action_upgrade">Mettre à jour</string>
+    <string name="label_upgrading">Mise à jour…</string>
+    <string name="action_restart_to_update">Redémarrer pour mettre à jour</string>
+    <string name="label_upgrade_failed">Échec de la mise à jour</string>
+    <string name="action_retry">Réessayer</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">सिंक विफल: %1$s</string>
     <string name="msg_syncing">सिंक हो रहा है...</string>
     <string name="title_sync_conflict">सिंक विरोध</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s उपलब्ध</string>
+    <string name="action_upgrade">अपग्रेड</string>
+    <string name="label_upgrading">अपग्रेड हो रहा है…</string>
+    <string name="action_restart_to_update">अपडेट के लिए पुनः आरंभ करें</string>
+    <string name="label_upgrade_failed">अपग्रेड विफल</string>
+    <string name="action_retry">पुनः प्रयास</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">同期に失敗しました：%1$s</string>
     <string name="msg_syncing">同期中...</string>
     <string name="title_sync_conflict">同期の競合</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s が利用可能</string>
+    <string name="action_upgrade">アップグレード</string>
+    <string name="label_upgrading">アップグレード中…</string>
+    <string name="action_restart_to_update">再起動して更新</string>
+    <string name="label_upgrade_failed">アップグレード失敗</string>
+    <string name="action_retry">再試行</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">სინქრონიზაცია ვერ მოხერხდა: %1$s</string>
     <string name="msg_syncing">მიმდინარეობს სინქრონიზაცია...</string>
     <string name="title_sync_conflict">სინქრონიზაციის კონფლიქტი</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s ხელმისაწვდომია</string>
+    <string name="action_upgrade">განახლება</string>
+    <string name="label_upgrading">განახლება…</string>
+    <string name="action_restart_to_update">გადატვირთეთ განახლებისთვის</string>
+    <string name="label_upgrade_failed">განახლება ვერ მოხერხდა</string>
+    <string name="action_retry">ხელახლა ცდა</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Синхрондау сәтсіз аяқталды: %1$s</string>
     <string name="msg_syncing">Синхрондалуда...</string>
     <string name="title_sync_conflict">Синхрондау қайшылығы</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s қол жетімді</string>
+    <string name="action_upgrade">Жаңарту</string>
+    <string name="label_upgrading">Жаңартылуда…</string>
+    <string name="action_restart_to_update">Жаңарту үшін қайта іске қосу</string>
+    <string name="label_upgrade_failed">Жаңарту сәтсіз</string>
+    <string name="action_retry">Қайталау</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Шайкештирүү ийгиликсиз: %1$s</string>
     <string name="msg_syncing">Шайкештирүүдө...</string>
     <string name="title_sync_conflict">Шайкештирүү карама-каршылыгы</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s жеткиликтүү</string>
+    <string name="action_upgrade">Жаңыртуу</string>
+    <string name="label_upgrading">Жаңыртылууда…</string>
+    <string name="action_restart_to_update">Жаңыртуу үчүн кайра баштоо</string>
+    <string name="label_upgrade_failed">Жаңыртуу ишке ашкан жок</string>
+    <string name="action_retry">Кайталоо</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Falha na sincronização: %1$s</string>
     <string name="msg_syncing">Sincronizando...</string>
     <string name="title_sync_conflict">Conflito de sincronização</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s disponível</string>
+    <string name="action_upgrade">Atualizar</string>
+    <string name="label_upgrading">Atualizando…</string>
+    <string name="action_restart_to_update">Reiniciar para atualizar</string>
+    <string name="label_upgrade_failed">Falha na atualização</string>
+    <string name="action_retry">Tentar novamente</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Sincronizare eșuată: %1$s</string>
     <string name="msg_syncing">Sincronizare...</string>
     <string name="title_sync_conflict">Conflict de sincronizare</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s disponibilă</string>
+    <string name="action_upgrade">Actualizare</string>
+    <string name="label_upgrading">Se actualizează…</string>
+    <string name="action_restart_to_update">Reporniți pentru actualizare</string>
+    <string name="label_upgrade_failed">Actualizare eșuată</string>
+    <string name="action_retry">Reîncercați</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Ошибка синхронизации: %1$s</string>
     <string name="msg_syncing">Синхронизация...</string>
     <string name="title_sync_conflict">Конфликт синхронизации</string>
+    <!-- Update -->
+    <string name="label_update_available">Доступна v%1$s</string>
+    <string name="action_upgrade">Обновить</string>
+    <string name="label_upgrading">Обновление…</string>
+    <string name="action_restart_to_update">Перезапустить</string>
+    <string name="label_upgrade_failed">Ошибка обновления</string>
+    <string name="action_retry">Повторить</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Ҳамоҳангсозӣ ноком шуд: %1$s</string>
     <string name="msg_syncing">Ҳамоҳангсозӣ...</string>
     <string name="title_sync_conflict">Ихтилофи ҳамоҳангсозӣ</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s дастрас аст</string>
+    <string name="action_upgrade">Навсозӣ</string>
+    <string name="label_upgrading">Навсозӣ…</string>
+    <string name="action_restart_to_update">Барои навсозӣ аз нав оғоз кунед</string>
+    <string name="label_upgrade_failed">Навсозӣ нашуд</string>
+    <string name="action_retry">Такрор</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Sinhronizasiýa şowsuz: %1$s</string>
     <string name="msg_syncing">Sinhronizasiýa edilýär...</string>
     <string name="title_sync_conflict">Sinhronizasiýa gapma-garşylygy</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s elýeterli</string>
+    <string name="action_upgrade">Täzelemek</string>
+    <string name="label_upgrading">Täzelenýär…</string>
+    <string name="action_restart_to_update">Täzelemek üçin täzeden başlaň</string>
+    <string name="label_upgrade_failed">Täzeleme şowsuz</string>
+    <string name="action_retry">Gaýtadan synanyşyň</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Помилка синхронізації: %1$s</string>
     <string name="msg_syncing">Синхронізація...</string>
     <string name="title_sync_conflict">Конфлікт синхронізації</string>
+    <!-- Update -->
+    <string name="label_update_available">Доступна v%1$s</string>
+    <string name="action_upgrade">Оновити</string>
+    <string name="label_upgrading">Оновлення…</string>
+    <string name="action_restart_to_update">Перезапустити</string>
+    <string name="label_upgrade_failed">Помилка оновлення</string>
+    <string name="action_retry">Повторити</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Sinxronlash muvaffaqiyatsiz: %1$s</string>
     <string name="msg_syncing">Sinxronlanmoqda...</string>
     <string name="title_sync_conflict">Sinxronlash ziddiyati</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s mavjud</string>
+    <string name="action_upgrade">Yangilash</string>
+    <string name="label_upgrading">Yangilanmoqda…</string>
+    <string name="action_restart_to_update">Yangilash uchun qayta ishga tushiring</string>
+    <string name="label_upgrade_failed">Yangilash xatosi</string>
+    <string name="action_retry">Qayta urinish</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">同步失败：%1$s</string>
     <string name="msg_syncing">同步中...</string>
     <string name="title_sync_conflict">同步冲突</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s 可用</string>
+    <string name="action_upgrade">升级</string>
+    <string name="label_upgrading">升级中…</string>
+    <string name="action_restart_to_update">重启以更新</string>
+    <string name="label_upgrade_failed">升级失败</string>
+    <string name="action_retry">重试</string>
 </resources>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -270,4 +270,11 @@
     <string name="msg_sync_failed">Sync failed: %1$s</string>
     <string name="msg_syncing">Syncing...</string>
     <string name="title_sync_conflict">Sync conflict</string>
+    <!-- Update -->
+    <string name="label_update_available">v%1$s available</string>
+    <string name="action_upgrade">Upgrade</string>
+    <string name="label_upgrading">Upgrading…</string>
+    <string name="action_restart_to_update">Restart to update</string>
+    <string name="label_upgrade_failed">Upgrade failed</string>
+    <string name="action_retry">Retry</string>
 </resources>

--- a/feature/changelog/data/src/androidMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.android.kt
+++ b/feature/changelog/data/src/androidMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.android.kt
@@ -1,0 +1,6 @@
+package space.be1ski.vibits.feature.changelog.data.platform
+
+import space.be1ski.vibits.feature.changelog.data.DefaultInstallationSource
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+actual fun createInstallationSource(): InstallationSource = DefaultInstallationSource()

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/DefaultInstallationSource.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/DefaultInstallationSource.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+class DefaultInstallationSource : InstallationSource {
+  override fun isHomebrew(): Boolean = false
+}

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.kt
@@ -1,0 +1,5 @@
+package space.be1ski.vibits.feature.changelog.data.platform
+
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+expect fun createInstallationSource(): InstallationSource

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/DefaultInstallationSourceTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/DefaultInstallationSourceTest.kt
@@ -1,0 +1,13 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+
+class DefaultInstallationSourceTest {
+  @Test
+  fun `when isHomebrew then returns false`() {
+    val source = DefaultInstallationSource()
+
+    assertFalse(source.isHomebrew())
+  }
+}

--- a/feature/changelog/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/changelog/data/DesktopInstallationSource.kt
+++ b/feature/changelog/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/changelog/data/DesktopInstallationSource.kt
@@ -1,0 +1,15 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+import java.nio.file.Files
+import java.nio.file.Path
+
+class DesktopInstallationSource : InstallationSource {
+  override fun isHomebrew(): Boolean =
+    try {
+      Files.exists(Path.of("/opt/homebrew/Caskroom/vibits")) ||
+        Files.exists(Path.of("/usr/local/Caskroom/vibits"))
+    } catch (_: Exception) {
+      false
+    }
+}

--- a/feature/changelog/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.desktop.kt
+++ b/feature/changelog/data/src/desktopMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.desktop.kt
@@ -1,0 +1,6 @@
+package space.be1ski.vibits.feature.changelog.data.platform
+
+import space.be1ski.vibits.feature.changelog.data.DesktopInstallationSource
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+actual fun createInstallationSource(): InstallationSource = DesktopInstallationSource()

--- a/feature/changelog/data/src/desktopTest/kotlin/space/be1ski/vibits/feature/changelog/data/DesktopInstallationSourceTest.kt
+++ b/feature/changelog/data/src/desktopTest/kotlin/space/be1ski/vibits/feature/changelog/data/DesktopInstallationSourceTest.kt
@@ -1,0 +1,13 @@
+package space.be1ski.vibits.feature.changelog.data
+
+import kotlin.test.Test
+import kotlin.test.assertIs
+
+class DesktopInstallationSourceTest {
+  @Test
+  fun `when isHomebrew then returns boolean`() {
+    val source = DesktopInstallationSource()
+
+    assertIs<Boolean>(source.isHomebrew())
+  }
+}

--- a/feature/changelog/data/src/iosMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.ios.kt
+++ b/feature/changelog/data/src/iosMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.ios.kt
@@ -1,0 +1,6 @@
+package space.be1ski.vibits.feature.changelog.data.platform
+
+import space.be1ski.vibits.feature.changelog.data.DefaultInstallationSource
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+actual fun createInstallationSource(): InstallationSource = DefaultInstallationSource()

--- a/feature/changelog/data/src/wasmJsMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.wasmJs.kt
+++ b/feature/changelog/data/src/wasmJsMain/kotlin/space/be1ski/vibits/feature/changelog/data/platform/InstallationSourceFactory.wasmJs.kt
@@ -1,0 +1,6 @@
+package space.be1ski.vibits.feature.changelog.data.platform
+
+import space.be1ski.vibits.feature.changelog.data.DefaultInstallationSource
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+actual fun createInstallationSource(): InstallationSource = DefaultInstallationSource()

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/UpdateAvailability.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/UpdateAvailability.kt
@@ -1,0 +1,7 @@
+package space.be1ski.vibits.feature.changelog.domain.model
+
+data class UpdateAvailability(
+  val latestVersion: String,
+  val currentVersion: String,
+  val isHomebrewInstallation: Boolean,
+)

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparison.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparison.kt
@@ -1,0 +1,21 @@
+package space.be1ski.vibits.feature.changelog.domain.model
+
+fun parseVersion(version: String): List<Int>? {
+  val cleaned = version.removePrefix("v")
+  val parts = cleaned.split(".")
+  val numbers = parts.mapNotNull { it.toIntOrNull() }
+  return if (numbers.size == parts.size && numbers.isNotEmpty()) numbers else null
+}
+
+fun compareVersions(
+  a: List<Int>,
+  b: List<Int>,
+): Int {
+  val maxLen = maxOf(a.size, b.size)
+  for (i in 0 until maxLen) {
+    val partA = a.getOrElse(i) { 0 }
+    val partB = b.getOrElse(i) { 0 }
+    if (partA != partB) return partA.compareTo(partB)
+  }
+  return 0
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/InstallationSource.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/repository/InstallationSource.kt
@@ -1,0 +1,5 @@
+package space.be1ski.vibits.feature.changelog.domain.repository
+
+fun interface InstallationSource {
+  fun isHomebrew(): Boolean
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCase.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCase.kt
@@ -1,0 +1,58 @@
+package space.be1ski.vibits.feature.changelog.domain.usecase
+
+import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
+import space.be1ski.vibits.core.utils.logging.Log
+import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
+import space.be1ski.vibits.feature.changelog.domain.model.compareVersions
+import space.be1ski.vibits.feature.changelog.domain.model.parseVersion
+import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+private const val TAG = "UpdateCheck"
+private const val VERSION_PAD_LENGTH = 10
+
+@Inject
+class CheckForUpdateUseCase(
+  private val changelogRepository: ChangelogRepository,
+  private val installationSource: InstallationSource,
+) {
+  suspend operator fun invoke(currentVersion: String): UpdateAvailability? {
+    if (currentVersion == "dev" || currentVersion == "web") {
+      Log.d(TAG, "Skipping update check for version: $currentVersion")
+      return null
+    }
+    return parseVersion(currentVersion)?.let { currentParsed ->
+      fetchLatestRelease()?.toUpdateAvailability(currentVersion, currentParsed)
+    }
+  }
+
+  private fun Pair<String, List<Int>>.toUpdateAvailability(
+    currentVersion: String,
+    currentParsed: List<Int>,
+  ): UpdateAvailability? {
+    val (latestVersion, latestParsed) = this
+    if (compareVersions(latestParsed, currentParsed) <= 0) return null
+    val cleanLatest = latestVersion.removePrefix("v")
+    Log.i(TAG, "Update available: $currentVersion → $cleanLatest")
+    return UpdateAvailability(
+      latestVersion = cleanLatest,
+      currentVersion = currentVersion,
+      isHomebrewInstallation = installationSource.isHomebrew(),
+    )
+  }
+
+  private suspend fun fetchLatestRelease(): Pair<String, List<Int>>? {
+    val releases =
+      runSuspendCatching { changelogRepository.getReleases() }
+        .onFailure { Log.e(TAG, "Failed to fetch releases", it) }
+        .getOrNull() ?: return null
+
+    return releases
+      .mapNotNull { entry ->
+        parseVersion(entry.version)?.let { parsed -> entry.version to parsed }
+      }.maxByOrNull { (_, parsed) ->
+        parsed.joinToString(".") { it.toString().padStart(VERSION_PAD_LENGTH, '0') }
+      }
+  }
+}

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCase.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCase.kt
@@ -4,6 +4,8 @@ import dev.zacsweers.metro.Inject
 import space.be1ski.vibits.core.utils.coroutines.runSuspendCatching
 import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.model.compareVersions
+import space.be1ski.vibits.feature.changelog.domain.model.parseVersion
 import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
 import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
 
@@ -71,24 +73,4 @@ class GetChangelogUseCase(
     }
     return filtered
   }
-}
-
-internal fun parseVersion(version: String): List<Int>? {
-  val cleaned = version.removePrefix("v")
-  val parts = cleaned.split(".")
-  val numbers = parts.mapNotNull { it.toIntOrNull() }
-  return if (numbers.size == parts.size && numbers.isNotEmpty()) numbers else null
-}
-
-internal fun compareVersions(
-  a: List<Int>,
-  b: List<Int>,
-): Int {
-  val maxLen = maxOf(a.size, b.size)
-  for (i in 0 until maxLen) {
-    val partA = a.getOrElse(i) { 0 }
-    val partB = b.getOrElse(i) { 0 }
-    if (partA != partB) return partA.compareTo(partB)
-  }
-  return 0
 }

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparisonTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparisonTest.kt
@@ -65,4 +65,19 @@ class VersionComparisonTest {
   fun `when compareVersions with patch difference then detects correctly`() {
     assertTrue(compareVersions(listOf(1, 0, 1), listOf(1, 0)) > 0)
   }
+
+  @Test
+  fun `when parseVersion with single zero then returns list`() {
+    assertEquals(listOf(0), parseVersion("0"))
+  }
+
+  @Test
+  fun `when compareVersions with single element lists then compares correctly`() {
+    assertTrue(compareVersions(listOf(2), listOf(1)) > 0)
+  }
+
+  @Test
+  fun `when compareVersions with empty padded parts equal then returns zero`() {
+    assertEquals(0, compareVersions(listOf(1), listOf(1, 0, 0)))
+  }
 }

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparisonTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/model/VersionComparisonTest.kt
@@ -1,0 +1,68 @@
+package space.be1ski.vibits.feature.changelog.domain.model
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class VersionComparisonTest {
+  @Test
+  fun `when parseVersion with semver then returns parts`() {
+    assertEquals(listOf(1, 2, 3), parseVersion("1.2.3"))
+  }
+
+  @Test
+  fun `when parseVersion with v prefix then strips prefix`() {
+    assertEquals(listOf(1, 2, 3), parseVersion("v1.2.3"))
+  }
+
+  @Test
+  fun `when parseVersion with two parts then returns two parts`() {
+    assertEquals(listOf(1, 0), parseVersion("1.0"))
+  }
+
+  @Test
+  fun `when parseVersion with invalid then returns null`() {
+    assertNull(parseVersion("invalid"))
+  }
+
+  @Test
+  fun `when parseVersion with empty then returns null`() {
+    assertNull(parseVersion(""))
+  }
+
+  @Test
+  fun `when parseVersion with beta suffix then returns null`() {
+    assertNull(parseVersion("1.2.beta"))
+  }
+
+  @Test
+  fun `when compareVersions with greater then returns positive`() {
+    assertTrue(compareVersions(listOf(1, 1, 0), listOf(1, 0, 0)) > 0)
+  }
+
+  @Test
+  fun `when compareVersions with lesser then returns negative`() {
+    assertTrue(compareVersions(listOf(1, 0, 0), listOf(1, 1, 0)) < 0)
+  }
+
+  @Test
+  fun `when compareVersions with equal then returns zero`() {
+    assertEquals(0, compareVersions(listOf(1, 0, 0), listOf(1, 0, 0)))
+  }
+
+  @Test
+  fun `when compareVersions with major difference then major wins`() {
+    assertTrue(compareVersions(listOf(2, 0), listOf(1, 9, 9)) > 0)
+  }
+
+  @Test
+  fun `when compareVersions with different lengths then pads with zero`() {
+    assertEquals(0, compareVersions(listOf(1, 0), listOf(1, 0, 0)))
+  }
+
+  @Test
+  fun `when compareVersions with patch difference then detects correctly`() {
+    assertTrue(compareVersions(listOf(1, 0, 1), listOf(1, 0)) > 0)
+  }
+}

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
@@ -1,0 +1,137 @@
+package space.be1ski.vibits.feature.changelog.domain.usecase
+
+import kotlinx.coroutines.test.runTest
+import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.test.FakeChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.test.FakeInstallationSource
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class CheckForUpdateUseCaseTest {
+  private val repository = FakeChangelogRepository()
+  private val installationSource = FakeInstallationSource()
+  private val useCase = CheckForUpdateUseCase(repository, installationSource)
+
+  @Test
+  fun `when current is dev then returns null`() =
+    runTest {
+      assertNull(useCase("dev"))
+      assertEquals(0, repository.getReleaseCalls)
+    }
+
+  @Test
+  fun `when current is web then returns null`() =
+    runTest {
+      assertNull(useCase("web"))
+      assertEquals(0, repository.getReleaseCalls)
+    }
+
+  @Test
+  fun `when no releases then returns null`() =
+    runTest {
+      repository.releasesResult = Result.success(emptyList())
+
+      assertNull(useCase("1.0.0"))
+    }
+
+  @Test
+  fun `when latest equals current then returns null`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("1.0.0", "Release", "body", "2026-01-01")),
+        )
+
+      assertNull(useCase("1.0.0"))
+    }
+
+  @Test
+  fun `when latest less than current then returns null`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("0.9.0", "Release", "body", "2026-01-01")),
+        )
+
+      assertNull(useCase("1.0.0"))
+    }
+
+  @Test
+  fun `when latest greater than current then returns update availability`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("1.0.0", "Old", "body", "2026-01-01"),
+            ChangelogEntry("1.5.0", "New", "body", "2026-02-01"),
+          ),
+        )
+
+      val result = useCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("1.5.0", result.latestVersion)
+      assertEquals("1.0.0", result.currentVersion)
+      assertFalse(result.isHomebrewInstallation)
+    }
+
+  @Test
+  fun `when latest has v prefix then strips it`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("v2.0.0", "Release", "body", "2026-01-01")),
+        )
+
+      val result = useCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("2.0.0", result.latestVersion)
+    }
+
+  @Test
+  fun `when fetch fails then returns null`() =
+    runTest {
+      repository.releasesResult = Result.failure(RuntimeException("Network error"))
+
+      assertNull(useCase("1.0.0"))
+    }
+
+  @Test
+  fun `when homebrew then isHomebrewInstallation is true`() =
+    runTest {
+      val homebrewSource = FakeInstallationSource(homebrew = true)
+      val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01")),
+        )
+
+      val result = homebrewUseCase("1.0.0")
+
+      assertNotNull(result)
+      assertTrue(result.isHomebrewInstallation)
+    }
+
+  @Test
+  fun `when multiple releases then picks the latest`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("1.1.0", "Minor", "body", "2026-01-01"),
+            ChangelogEntry("2.0.0", "Major", "body", "2026-02-01"),
+            ChangelogEntry("1.5.0", "Mid", "body", "2026-01-15"),
+          ),
+        )
+
+      val result = useCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("2.0.0", result.latestVersion)
+    }
+}

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
@@ -118,6 +118,31 @@ class CheckForUpdateUseCaseTest {
     }
 
   @Test
+  fun `when current version is unparseable then returns null`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01")),
+        )
+
+      assertNull(useCase("invalid-version"))
+    }
+
+  @Test
+  fun `when all releases have unparseable versions then returns null`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("beta1", "Beta", "body", "2026-01-01"),
+            ChangelogEntry("rc-2", "RC", "body", "2026-01-15"),
+          ),
+        )
+
+      assertNull(useCase("1.0.0"))
+    }
+
+  @Test
   fun `when multiple releases then picks the latest`() =
     runTest {
       repository.releasesResult =

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCaseTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/GetChangelogUseCaseTest.kt
@@ -3,6 +3,8 @@ package space.be1ski.vibits.feature.changelog.domain.usecase
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.test.runTest
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.model.compareVersions
+import space.be1ski.vibits.feature.changelog.domain.model.parseVersion
 import space.be1ski.vibits.feature.changelog.domain.test.FakeChangelogRepository
 import space.be1ski.vibits.feature.changelog.domain.test.FakeLastSeenVersionStore
 import kotlin.test.Test

--- a/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeInstallationSource.kt
+++ b/feature/changelog/domain/testing/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/test/FakeInstallationSource.kt
@@ -1,0 +1,9 @@
+package space.be1ski.vibits.feature.changelog.domain.test
+
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
+
+class FakeInstallationSource(
+  private val homebrew: Boolean = false,
+) : InstallationSource {
+  override fun isHomebrew(): Boolean = homebrew
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppDependencies.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppDependencies.kt
@@ -1,7 +1,9 @@
 package space.be1ski.vibits.feature.homescreen.di
 
 import dev.zacsweers.metro.Inject
+import space.be1ski.vibits.core.platform.app.AppUpdater
 import space.be1ski.vibits.core.platform.locale.LocaleProvider
+import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
 import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.di.HabitsDependencies
 import space.be1ski.vibits.feature.homescreen.domain.usecase.LoadAppDetailsUseCase
@@ -26,6 +28,8 @@ class AppDependencies(
   val fixInvalidOnlineMode: FixInvalidOnlineModeUseCase,
   val saveTimeRangeTab: SaveTimeRangeTabUseCase,
   val getChangelog: GetChangelogUseCase,
+  val checkForUpdate: CheckForUpdateUseCase,
+  val appUpdater: AppUpdater,
   val loadAppDetails: LoadAppDetailsUseCase,
   val loadAppMode: LoadAppModeUseCase,
   val shouldShowOnboarding: ShouldShowOnboardingUseCase,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/di/AppGraph.kt
@@ -12,6 +12,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import space.be1ski.vibits.core.env.BuildConfig
 import space.be1ski.vibits.core.platform.app.AppDetailsProvider
+import space.be1ski.vibits.core.platform.app.AppUpdater
 import space.be1ski.vibits.core.platform.di.AppScope
 import space.be1ski.vibits.core.platform.env.LocalConfigProvider
 import space.be1ski.vibits.core.platform.env.createLocalConfigProvider
@@ -27,7 +28,9 @@ import space.be1ski.vibits.feature.auth.domain.repository.CredentialsRepository
 import space.be1ski.vibits.feature.changelog.data.ChangelogRepositoryImpl
 import space.be1ski.vibits.feature.changelog.data.GitHubReleasesApi
 import space.be1ski.vibits.feature.changelog.data.LastSeenVersionStoreImpl
+import space.be1ski.vibits.feature.changelog.data.platform.createInstallationSource
 import space.be1ski.vibits.feature.changelog.domain.repository.ChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.repository.InstallationSource
 import space.be1ski.vibits.feature.changelog.domain.repository.LastSeenVersionStore
 import space.be1ski.vibits.feature.memos.data.ConnectionTesterImpl
 import space.be1ski.vibits.feature.memos.data.MemoStorageManagerImpl
@@ -150,6 +153,14 @@ abstract class AppGraph {
   @Provides
   @SingleIn(AppScope::class)
   fun gitHubReleasesApi(httpClient: HttpClient): GitHubReleasesApi = GitHubReleasesApi(httpClient, BuildConfig.RELEASES_URL)
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun installationSource(): InstallationSource = createInstallationSource()
+
+  @Provides
+  @SingleIn(AppScope::class)
+  fun appUpdater(): AppUpdater = AppUpdater()
 
   // Repository bindings (explicit @Binds needed for native targets due to KT-75865)
   @Binds

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -14,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.platform.app.AppUpdater
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.strings.generated.Res
@@ -21,6 +22,7 @@ import space.be1ski.vibits.core.strings.generated.msg_state_loading
 import space.be1ski.vibits.core.strings.generated.title_state_loading
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.StatePanel
+import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
 import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
@@ -71,6 +73,8 @@ internal fun AppContent(
   exportService: ExportService,
   currentVersion: String,
   getChangelog: GetChangelogUseCase,
+  checkForUpdate: CheckForUpdateUseCase? = null,
+  appUpdater: AppUpdater? = null,
   onResetApp: () -> Unit,
   onThemeChanged: (AppTheme) -> Unit,
   onLanguageChanged: (AppLanguage) -> Unit,
@@ -93,6 +97,8 @@ internal fun AppContent(
           exportService = exportService,
           currentVersion = currentVersion,
           getChangelog = getChangelog,
+          checkForUpdate = checkForUpdate,
+          appUpdater = appUpdater,
           onResetApp = onResetApp,
           onThemeChanged = onThemeChanged,
           onLanguageChanged = onLanguageChanged,
@@ -107,6 +113,8 @@ internal fun AppContent(
         exportService = exportService,
         currentVersion = currentVersion,
         getChangelog = getChangelog,
+        checkForUpdate = checkForUpdate,
+        appUpdater = appUpdater,
         onResetApp = onResetApp,
         onThemeChanged = onThemeChanged,
         onLanguageChanged = onLanguageChanged,
@@ -125,6 +133,8 @@ private fun AppWithLoadingScreen(
   exportService: ExportService,
   currentVersion: String,
   getChangelog: GetChangelogUseCase,
+  checkForUpdate: CheckForUpdateUseCase?,
+  appUpdater: AppUpdater?,
   onResetApp: () -> Unit,
   onThemeChanged: (AppTheme) -> Unit,
   onLanguageChanged: (AppLanguage) -> Unit,
@@ -142,6 +152,8 @@ private fun AppWithLoadingScreen(
       exportService = exportService,
       currentVersion = currentVersion,
       getChangelog = getChangelog,
+      checkForUpdate = checkForUpdate,
+      appUpdater = appUpdater,
       onResetApp = onResetApp,
       onThemeChanged = onThemeChanged,
       onLanguageChanged = onLanguageChanged,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -76,6 +76,8 @@ fun AppRoot(
           exportService = dependencies.settingsDependencies.exportService,
           currentVersion = currentVersion,
           getChangelog = dependencies.getChangelog,
+          checkForUpdate = dependencies.checkForUpdate,
+          appUpdater = dependencies.appUpdater,
           onResetApp = {
             resetApp(
               dependencies = dependencies,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellTestTags.kt
@@ -13,4 +13,5 @@ object AppShellTestTags {
   const val SIDEBAR_TRACK_TODAY = "desktop_track_today"
   const val SIDEBAR_NEW_MEMO = "desktop_new_memo"
   const val SIDEBAR_SETTINGS = "desktop_settings"
+  const val SIDEBAR_UPDATE_PILL = "desktop_update_pill"
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
@@ -27,6 +27,7 @@ import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Refresh
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material.icons.filled.Tune
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -51,10 +52,16 @@ import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.action_refresh
+import space.be1ski.vibits.core.strings.generated.action_restart_to_update
+import space.be1ski.vibits.core.strings.generated.action_retry
 import space.be1ski.vibits.core.strings.generated.action_track_today
+import space.be1ski.vibits.core.strings.generated.action_upgrade
 import space.be1ski.vibits.core.strings.generated.app_name
 import space.be1ski.vibits.core.strings.generated.format_habits_progress
 import space.be1ski.vibits.core.strings.generated.label_habits_config
+import space.be1ski.vibits.core.strings.generated.label_update_available
+import space.be1ski.vibits.core.strings.generated.label_upgrade_failed
+import space.be1ski.vibits.core.strings.generated.label_upgrading
 import space.be1ski.vibits.core.strings.generated.nav_feed
 import space.be1ski.vibits.core.strings.generated.nav_habits
 import space.be1ski.vibits.core.strings.generated.nav_memos
@@ -62,6 +69,7 @@ import space.be1ski.vibits.core.strings.generated.nav_settings
 import space.be1ski.vibits.core.strings.generated.title_new_memo
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.platform.hoverAware
+import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
@@ -85,6 +93,10 @@ internal fun DesktopSidebar(
   onShowCreateMemoDialog: () -> Unit,
   onSettingsClick: () -> Unit,
   dispatchMemos: (MemosAction) -> Unit,
+  updateAvailability: UpdateAvailability? = null,
+  upgradeState: UpgradeState = UpgradeState.IDLE,
+  onUpgrade: () -> Unit = {},
+  onRestart: () -> Unit = {},
 ) {
   Surface(
     modifier = Modifier.width(SIDEBAR_WIDTH).fillMaxHeight(),
@@ -94,6 +106,14 @@ internal fun DesktopSidebar(
       SidebarHeader(memosState, dispatchMemos)
       SidebarNavigation(appState, onAppAction, onClearSelection, onFeedScrollToTop)
       Spacer(modifier = Modifier.weight(1f))
+      if (updateAvailability != null) {
+        UpdatePill(
+          updateAvailability = updateAvailability,
+          upgradeState = upgradeState,
+          onUpgrade = onUpgrade,
+          onRestart = onRestart,
+        )
+      }
       SidebarActions(
         selectedScreen = appState.selectedScreen,
         todayHabits = todayHabits,
@@ -336,6 +356,85 @@ private fun RowScope.SidebarNavItemLabel(
         color = contentColor.copy(alpha = 0.7f),
         maxLines = 1,
         overflow = TextOverflow.Ellipsis,
+      )
+    }
+  }
+}
+
+@Composable
+private fun UpdatePill(
+  updateAvailability: UpdateAvailability,
+  upgradeState: UpgradeState,
+  onUpgrade: () -> Unit,
+  onRestart: () -> Unit,
+) {
+  val shape = RoundedCornerShape(Indent.xs)
+  Row(
+    modifier =
+      Modifier
+        .fillMaxWidth()
+        .clip(shape)
+        .background(MaterialTheme.colorScheme.primaryContainer.copy(alpha = 0.5f), shape)
+        .testTag(AppShellTestTags.SIDEBAR_UPDATE_PILL)
+        .padding(horizontal = Indent.s, vertical = Indent.xs),
+    horizontalArrangement = Arrangement.spacedBy(Indent.xs),
+    verticalAlignment = Alignment.CenterVertically,
+  ) {
+    UpdatePillContent(updateAvailability, upgradeState, onUpgrade, onRestart)
+  }
+}
+
+@Composable
+private fun RowScope.UpdatePillContent(
+  updateAvailability: UpdateAvailability,
+  upgradeState: UpgradeState,
+  onUpgrade: () -> Unit,
+  onRestart: () -> Unit,
+) {
+  when (upgradeState) {
+    UpgradeState.IDLE -> {
+      Text(
+        stringResource(Res.string.label_update_available, updateAvailability.latestVersion),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onPrimaryContainer,
+        modifier = Modifier.weight(1f),
+      )
+      if (updateAvailability.isHomebrewInstallation) {
+        Text(
+          stringResource(Res.string.action_upgrade),
+          style = MaterialTheme.typography.labelSmall,
+          color = MaterialTheme.colorScheme.primary,
+          modifier = Modifier.clickable(onClick = onUpgrade),
+        )
+      }
+    }
+    UpgradeState.UPGRADING -> {
+      CircularProgressIndicator(modifier = Modifier.size(14.dp), strokeWidth = 2.dp)
+      Text(
+        stringResource(Res.string.label_upgrading),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onPrimaryContainer,
+      )
+    }
+    UpgradeState.DONE ->
+      Text(
+        stringResource(Res.string.action_restart_to_update),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.clickable(onClick = onRestart),
+      )
+    UpgradeState.FAILED -> {
+      Text(
+        stringResource(Res.string.label_upgrade_failed),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.error,
+        modifier = Modifier.weight(1f),
+      )
+      Text(
+        stringResource(Res.string.action_retry),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = Modifier.clickable(onClick = onUpgrade),
       )
     }
   }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/UpgradeState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/UpgradeState.kt
@@ -1,0 +1,8 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+enum class UpgradeState {
+  IDLE,
+  UPGRADING,
+  DONE,
+  FAILED,
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -6,8 +6,11 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
+import space.be1ski.vibits.core.platform.app.AppUpdater
 import space.be1ski.vibits.core.platform.date.currentLocalDate
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.ui.celebration.CelebrationAnimation
@@ -16,6 +19,8 @@ import space.be1ski.vibits.core.ui.date.rememberDateFormatter
 import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
+import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
 import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.presentation.view.components.rememberHabitsConfigTimeline
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
@@ -33,6 +38,8 @@ internal fun VibitsApp(
   exportService: ExportService,
   currentVersion: String,
   getChangelog: GetChangelogUseCase,
+  checkForUpdate: CheckForUpdateUseCase? = null,
+  appUpdater: AppUpdater? = null,
   testLogs: List<LogEntry>? = null,
   onResetApp: () -> Unit = {},
   onThemeChanged: (AppTheme) -> Unit = {},
@@ -48,6 +55,7 @@ internal fun VibitsApp(
   val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
   val todayHabits = rememberTodayHabits(habitsTimeline, memosState.memos, timeZone, today)
 
+  val coroutineScope = rememberCoroutineScope()
   var celebrationAnimation by remember { mutableStateOf<CelebrationAnimation?>(null) }
   val allJustCompleted = rememberAllHabitsJustCompleted(todayHabits, justFinishedOnboarding)
   LaunchedEffect(allJustCompleted) {
@@ -55,11 +63,19 @@ internal fun VibitsApp(
   }
 
   var changelogEntries by remember { mutableStateOf<List<ChangelogEntry>?>(null) }
+  var updateAvailability by remember { mutableStateOf<UpdateAvailability?>(null) }
+  var upgradeState by remember { mutableStateOf(UpgradeState.IDLE) }
 
   LaunchedEffect(Unit) {
     val entries = getChangelog(currentVersion)
     if (entries.isNotEmpty()) {
       changelogEntries = entries
+    }
+  }
+
+  LaunchedEffect(Unit) {
+    if (checkForUpdate != null) {
+      updateAvailability = checkForUpdate(currentVersion)
     }
   }
 
@@ -88,6 +104,17 @@ internal fun VibitsApp(
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
       exportService = exportService,
       testLogs = testLogs,
+      updateAvailability = updateAvailability,
+      upgradeState = upgradeState,
+      onUpgrade = {
+        if (appUpdater != null) {
+          upgradeState = UpgradeState.UPGRADING
+          coroutineScope.launch {
+            upgradeState = if (appUpdater.upgrade()) UpgradeState.DONE else UpgradeState.FAILED
+          }
+        }
+      },
+      onRestart = { appUpdater?.restart() },
     )
   } else {
     VibitsAppScaffold(

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
@@ -23,6 +23,7 @@ import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.msg_fill_all_fields
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.utils.logging.LogEntry
+import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
 import space.be1ski.vibits.feature.habits.domain.usecase.EarliestMemoDateUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.IsActivityRangeBeforeUseCase
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
@@ -55,6 +56,10 @@ internal fun VibitsDesktopShell(
   syncDebounceSeconds: Int,
   exportService: ExportService,
   testLogs: List<LogEntry>? = null,
+  updateAvailability: UpdateAvailability? = null,
+  upgradeState: UpgradeState = UpgradeState.IDLE,
+  onUpgrade: () -> Unit = {},
+  onRestart: () -> Unit = {},
 ) {
   val shell = rememberAppShellState(features, appState, memosState, habitsState)
 
@@ -100,6 +105,10 @@ internal fun VibitsDesktopShell(
           )
         },
         dispatchMemos = features.memos::send,
+        updateAvailability = updateAvailability,
+        upgradeState = upgradeState,
+        onUpgrade = onUpgrade,
+        onRestart = onRestart,
       )
       VerticalDivider()
       Box(

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -23,8 +23,11 @@ import space.be1ski.vibits.core.ui.test.saveScreenshot
 import space.be1ski.vibits.core.ui.theme.VibitsTheme
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
+import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
 import space.be1ski.vibits.feature.changelog.domain.test.FakeChangelogRepository
+import space.be1ski.vibits.feature.changelog.domain.test.FakeInstallationSource
 import space.be1ski.vibits.feature.changelog.domain.test.FakeLastSeenVersionStore
+import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
 import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
@@ -193,6 +196,7 @@ class AppScreenshotTest {
     wideLayout: Boolean = true,
     currentVersion: String = "dev",
     getChangelog: GetChangelogUseCase = fakeGetChangelog,
+    checkForUpdate: CheckForUpdateUseCase? = null,
     testLogs: List<LogEntry>? = null,
   ) {
     val features =
@@ -211,6 +215,7 @@ class AppScreenshotTest {
           exportService = fakeExportService,
           currentVersion = currentVersion,
           getChangelog = getChangelog,
+          checkForUpdate = checkForUpdate,
           testLogs = testLogs,
         )
       }
@@ -226,6 +231,7 @@ class AppScreenshotTest {
     wideLayout: Boolean = true,
     currentVersion: String = "dev",
     getChangelog: GetChangelogUseCase = fakeGetChangelog,
+    checkForUpdate: CheckForUpdateUseCase? = null,
     testLogs: List<LogEntry>? = null,
   ) {
     val platform = if (wideLayout) "wide" else "compact"
@@ -238,6 +244,7 @@ class AppScreenshotTest {
       wideLayout = wideLayout,
       currentVersion = currentVersion,
       getChangelog = getChangelog,
+      checkForUpdate = checkForUpdate,
       testLogs = testLogs,
     )
     saveScreenshot("${platform}_light_$name")
@@ -250,6 +257,7 @@ class AppScreenshotTest {
       wideLayout = wideLayout,
       currentVersion = currentVersion,
       getChangelog = getChangelog,
+      checkForUpdate = checkForUpdate,
       testLogs = testLogs,
     )
     saveScreenshot("${platform}_dark_$name")
@@ -776,6 +784,32 @@ class AppScreenshotTest {
       Thread.sleep(LOTTIE_LOAD_DELAY_MS)
       waitForIdle()
       saveScreenshot("${platform}_${theme}_app_celebration_confetti")
+    }
+  }
+
+  // endregion
+
+  // region Update pill
+
+  @Test
+  fun `when update available then captures update pill`() {
+    val fakeCheckForUpdate =
+      CheckForUpdateUseCase(
+        FakeChangelogRepository().apply {
+          releasesResult =
+            Result.success(
+              listOf(ChangelogEntry("2.0.0", "Major Update", "New features", "2026-03-01")),
+            )
+        },
+        FakeInstallationSource(homebrew = true),
+      )
+    runWideUiTest {
+      captureApp(
+        "app_update_pill",
+        appState = habitsAppState(),
+        currentVersion = "1.0.0",
+        checkForUpdate = fakeCheckForUpdate,
+      )
     }
   }
 


### PR DESCRIPTION
## Summary
- Show update pill in desktop sidebar when a newer GitHub release exists
- Homebrew cask users get an "Upgrade" button that runs `brew upgrade --cask vibits` with progress and restart prompt
- Non-Homebrew users see version availability text only

## Changes
- Extract `parseVersion`/`compareVersions` to `VersionComparison.kt` (public)
- Add `CheckForUpdateUseCase`, `UpdateAvailability` model, `InstallationSource` interface
- Add `DesktopInstallationSource` — detects Homebrew cask via `/opt/homebrew/Caskroom/vibits`
- Add `AppUpdater` expect/actual — desktop runs `brew upgrade --cask vibits` + restart
- Add `UpdatePill` composable in `DesktopSidebar` with states: idle, upgrading, done, failed
- Wire through DI (`AppGraph`, `AppDependencies`) and view chain
- Add 6 localized strings across all 20 locales
- Add 22 new unit tests (`CheckForUpdateUseCaseTest`, `VersionComparisonTest`)
- Add screenshot test with update pill visible

## Test plan
- [x] `checkJvm` passes
- [x] All domain tests pass
- [x] Screenshot tests pass (update pill visible in both themes)
- [x] Manual test: desktop app with version 1.0.0 shows pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)