### PR TITLE
Fix app restart to pass full command line arguments

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -20,15 +20,12 @@ actual class AppUpdater {
 
   actual fun restart() {
     try {
-      val command =
-        ProcessHandle
-          .current()
-          .info()
-          .command()
-          .orElse(null)
-      if (command != null) {
-        ProcessBuilder(command).start()
-      }
+      val info = ProcessHandle.current().info()
+      val command = info.command().orElse(null) ?: return
+      val arguments = info.arguments().orElse(null)
+      val fullCommand =
+        if (arguments != null) listOf(command) + arguments.toList() else listOf(command)
+      ProcessBuilder(fullCommand).start()
     } finally {
       exitProcess(0)
     }


### PR DESCRIPTION
## Summary
- Pass full command line (command + arguments) when restarting the app, not just the executable path
- Fixes restart in dev mode where the JVM needs classpath and main class arguments to start properly

## Test plan
- [ ] Run via `./gradlew :app:desktop:run`, trigger restart — app should relaunch
- [ ] Verify packaged app restart still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)