### PR TITLE
Run brew update before upgrade to refresh cask index

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -8,11 +8,16 @@ actual class AppUpdater {
   actual suspend fun upgrade(): Boolean =
     withContext(Dispatchers.IO) {
       try {
-        val process =
+        val update =
+          ProcessBuilder("brew", "update")
+            .redirectErrorStream(true)
+            .start()
+        update.waitFor()
+        val upgrade =
           ProcessBuilder("brew", "upgrade", "--cask", "vibits")
             .redirectErrorStream(true)
             .start()
-        process.waitFor() == 0
+        upgrade.waitFor() == 0
       } catch (_: Exception) {
         false
       }


### PR DESCRIPTION
## Summary
- Run `brew update` before `brew upgrade --cask vibits` so the cask index is fresh
- Without this, brew thinks the installed version is already the latest and returns a non-zero exit code

## Test plan
- [x] Tested manually — upgrade now works after a new release is published

🤖 Generated with [Claude Code](https://claude.com/claude-code)