### PR TITLE
Use full path to brew binary for upgrade

### DIFF
--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -2,19 +2,26 @@ package space.be1ski.vibits.core.platform.app
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.nio.file.Files
+import java.nio.file.Path
 import kotlin.system.exitProcess
+
+private val BREW_PATHS = listOf("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
+
+private fun findBrew(): String? = BREW_PATHS.firstOrNull { Files.exists(Path.of(it)) }
 
 actual class AppUpdater {
   actual suspend fun upgrade(): Boolean =
     withContext(Dispatchers.IO) {
       try {
+        val brew = findBrew() ?: return@withContext false
         val update =
-          ProcessBuilder("brew", "update")
+          ProcessBuilder(brew, "update")
             .redirectErrorStream(true)
             .start()
         update.waitFor()
         val upgrade =
-          ProcessBuilder("brew", "upgrade", "--cask", "vibits")
+          ProcessBuilder(brew, "upgrade", "--cask", "vibits")
             .redirectErrorStream(true)
             .start()
         upgrade.waitFor() == 0


### PR DESCRIPTION
## Summary
- Resolve brew by checking `/opt/homebrew/bin/brew` and `/usr/local/bin/brew` instead of relying on PATH
- macOS apps launched from `/Applications/` have minimal PATH that doesn't include Homebrew

## Test plan
- [ ] Verify upgrade works from packaged app

🤖 Generated with [Claude Code](https://claude.com/claude-code)