### PR TITLE
Enable allWarningsAsErrors for compiler hardening

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
@@ -44,6 +44,7 @@ kotlin {
 
 tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask<*>>().configureEach {
   compilerOptions {
+    allWarningsAsErrors.set(true)
     freeCompilerArgs.add("-Xexpect-actual-classes")
   }
 }


### PR DESCRIPTION
## Summary

- Enable `allWarningsAsErrors` in the KMP library convention plugin to prevent new compiler warnings from being introduced
- `LocalClipboardManager` deprecation kept as-is — the new `Clipboard` API (`ClipEntry`) is platform-specific with no common-code text setter available in Compose Multiplatform 1.10.2
- Gradle deprecation warnings (16, 2 unique) are upstream issues in detekt and KMP plugins — no fix available

## Test plan

- [x] `./gradlew checkJvm` passes with zero warnings
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)