### PR TITLE
Group LongParameterList callbacks into container classes

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/HabitRowDimensions.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/HabitRowDimensions.kt
@@ -1,0 +1,10 @@
+package space.be1ski.vibits.feature.habits.presentation.view
+
+import androidx.compose.ui.unit.Dp
+
+internal class HabitRowDimensions(
+  val cellWidth: Dp,
+  val cellHeight: Dp,
+  val labelWidth: Dp,
+  val spacing: Dp,
+)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -804,7 +804,13 @@ private fun SingleHabitWeekStrip(
           }
         }
       }
-      SingleHabitRow(days, habit, demoMode, cellWidth, cellHeight, labelWidth, spacing, onHabitClick)
+      SingleHabitRow(
+        days = days,
+        habit = habit,
+        demoMode = demoMode,
+        dimensions = HabitRowDimensions(cellWidth, cellHeight, labelWidth, spacing),
+        onHabitClick = onHabitClick,
+      )
       Row(horizontalArrangement = Arrangement.spacedBy(spacing)) {
         Spacer(modifier = Modifier.width(labelWidth))
         days.forEach { day ->
@@ -820,27 +826,23 @@ private fun SingleHabitWeekStrip(
   }
 }
 
-@Suppress("LongParameterList")
 @Composable
 private fun SingleHabitRow(
   days: List<ContributionDay>,
   habit: HabitConfig,
   demoMode: Boolean,
-  cellWidth: androidx.compose.ui.unit.Dp,
-  cellHeight: androidx.compose.ui.unit.Dp,
-  labelWidth: androidx.compose.ui.unit.Dp,
-  spacing: androidx.compose.ui.unit.Dp,
+  dimensions: HabitRowDimensions,
   onHabitClick: (day: ContributionDay, habitTag: String, habitLabel: String) -> Unit,
 ) {
   val pendingColor = AppColors.inactiveCell.resolve()
   Row(
-    horizontalArrangement = Arrangement.spacedBy(spacing),
+    horizontalArrangement = Arrangement.spacedBy(dimensions.spacing),
     verticalAlignment = Alignment.CenterVertically,
   ) {
     Text(
       text = habit.localizedLabel(demoMode),
       style = MaterialTheme.typography.bodySmall,
-      modifier = Modifier.width(labelWidth),
+      modifier = Modifier.width(dimensions.labelWidth),
     )
     days.forEach { day ->
       val done = day.habitStatuses.firstOrNull { status -> status.tag == habit.tag }?.done == true
@@ -859,7 +861,7 @@ private fun SingleHabitRow(
       Box(
         modifier =
           Modifier
-            .size(width = cellWidth, height = cellHeight)
+            .size(width = dimensions.cellWidth, height = dimensions.cellHeight)
             .background(cellColor, shape = MaterialTheme.shapes.extraSmall)
             .then(
               if (day.isClickable) {

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContent.kt
@@ -14,22 +14,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import org.jetbrains.compose.resources.stringResource
-import space.be1ski.vibits.core.platform.app.AppUpdater
-import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.mode.AppMode
 import space.be1ski.vibits.core.strings.generated.Res
 import space.be1ski.vibits.core.strings.generated.msg_state_loading
 import space.be1ski.vibits.core.strings.generated.title_state_loading
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.core.ui.StatePanel
-import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
-import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.homescreen.di.AppDependencies
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
-import space.be1ski.vibits.feature.memos.domain.repository.ExportService
 import space.be1ski.vibits.feature.mode.presentation.view.ModeSelectionScreen
 import space.be1ski.vibits.feature.onboarding.presentation.view.OnboardingScreen
-import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 @Composable
 internal fun SyncAppMode(
@@ -61,23 +55,14 @@ internal fun ObserveOnboardingCheck(
   }
 }
 
-@Suppress("LongParameterList")
 @Composable
 internal fun AppContent(
   appMode: AppMode,
   showOnboarding: Boolean,
   justFinishedOnboarding: Boolean,
   featuresState: FeaturesState,
-  appTheme: AppTheme,
-  appLanguage: AppLanguage,
-  exportService: ExportService,
-  currentVersion: String,
-  getChangelog: GetChangelogUseCase,
-  checkForUpdate: CheckForUpdateUseCase? = null,
-  appUpdater: AppUpdater? = null,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
+  config: AppContentConfig,
+  callbacks: AppContentCallbacks,
 ) {
   when (appMode) {
     AppMode.NOT_SELECTED -> ModeSelectionScreen(feature = featuresState.modeSelection)
@@ -92,52 +77,27 @@ internal fun AppContent(
         AppWithLoadingScreen(
           features = featuresState.app,
           justFinishedOnboarding = justFinishedOnboarding,
-          appTheme = appTheme,
-          appLanguage = appLanguage,
-          exportService = exportService,
-          currentVersion = currentVersion,
-          getChangelog = getChangelog,
-          checkForUpdate = checkForUpdate,
-          appUpdater = appUpdater,
-          onResetApp = onResetApp,
-          onThemeChanged = onThemeChanged,
-          onLanguageChanged = onLanguageChanged,
+          config = config,
+          callbacks = callbacks,
         )
       }
     AppMode.ONLINE, AppMode.DEMO -> {
       AppWithLoadingScreen(
         features = featuresState.app,
         justFinishedOnboarding = justFinishedOnboarding,
-        appTheme = appTheme,
-        appLanguage = appLanguage,
-        exportService = exportService,
-        currentVersion = currentVersion,
-        getChangelog = getChangelog,
-        checkForUpdate = checkForUpdate,
-        appUpdater = appUpdater,
-        onResetApp = onResetApp,
-        onThemeChanged = onThemeChanged,
-        onLanguageChanged = onLanguageChanged,
+        config = config,
+        callbacks = callbacks,
       )
     }
   }
 }
 
-@Suppress("LongParameterList")
 @Composable
 private fun AppWithLoadingScreen(
   features: AppFeatures,
   justFinishedOnboarding: Boolean,
-  appTheme: AppTheme,
-  appLanguage: AppLanguage,
-  exportService: ExportService,
-  currentVersion: String,
-  getChangelog: GetChangelogUseCase,
-  checkForUpdate: CheckForUpdateUseCase?,
-  appUpdater: AppUpdater?,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
+  config: AppContentConfig,
+  callbacks: AppContentCallbacks,
 ) {
   val memosState by features.memos.state.collectAsState()
 
@@ -147,16 +107,8 @@ private fun AppWithLoadingScreen(
     VibitsApp(
       features = features,
       justFinishedOnboarding = justFinishedOnboarding,
-      currentTheme = appTheme,
-      currentLanguage = appLanguage,
-      exportService = exportService,
-      currentVersion = currentVersion,
-      getChangelog = getChangelog,
-      checkForUpdate = checkForUpdate,
-      appUpdater = appUpdater,
-      onResetApp = onResetApp,
-      onThemeChanged = onThemeChanged,
-      onLanguageChanged = onLanguageChanged,
+      config = config,
+      callbacks = callbacks,
     )
   }
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContentCallbacks.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContentCallbacks.kt
@@ -1,0 +1,10 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+
+internal class AppContentCallbacks(
+  val onResetApp: () -> Unit,
+  val onThemeChanged: (AppTheme) -> Unit,
+  val onLanguageChanged: (AppLanguage) -> Unit,
+)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContentConfig.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppContentConfig.kt
@@ -1,0 +1,19 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import space.be1ski.vibits.core.platform.app.AppUpdater
+import space.be1ski.vibits.core.platform.locale.AppLanguage
+import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
+import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
+import space.be1ski.vibits.feature.memos.domain.repository.ExportService
+import space.be1ski.vibits.feature.settings.domain.model.AppTheme
+
+@Suppress("LongParameterList")
+internal class AppContentConfig(
+  val appTheme: AppTheme,
+  val appLanguage: AppLanguage,
+  val exportService: ExportService,
+  val currentVersion: String,
+  val getChangelog: GetChangelogUseCase,
+  val checkForUpdate: CheckForUpdateUseCase?,
+  val appUpdater: AppUpdater?,
+)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -71,28 +71,34 @@ fun AppRoot(
           showOnboarding = showOnboarding,
           justFinishedOnboarding = justFinishedOnboarding,
           featuresState = featuresState,
-          appTheme = appTheme,
-          appLanguage = appLanguage,
-          exportService = dependencies.settingsDependencies.exportService,
-          currentVersion = currentVersion,
-          getChangelog = dependencies.getChangelog,
-          checkForUpdate = dependencies.checkForUpdate,
-          appUpdater = dependencies.appUpdater,
-          onResetApp = {
-            resetApp(
-              dependencies = dependencies,
-              onThemeReset = { appTheme = AppTheme.SYSTEM },
-              onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
-              onVersionIncrement = { featuresVersion++ },
-              onModeReset = { appMode = AppMode.NOT_SELECTED },
-              onOnboardingReset = { showOnboarding = false },
-            )
-          },
-          onThemeChanged = { appTheme = it },
-          onLanguageChanged = {
-            dependencies.localeProvider.configureLocale(it)
-            appLanguage = it
-          },
+          config =
+            AppContentConfig(
+              appTheme = appTheme,
+              appLanguage = appLanguage,
+              exportService = dependencies.settingsDependencies.exportService,
+              currentVersion = currentVersion,
+              getChangelog = dependencies.getChangelog,
+              checkForUpdate = dependencies.checkForUpdate,
+              appUpdater = dependencies.appUpdater,
+            ),
+          callbacks =
+            AppContentCallbacks(
+              onResetApp = {
+                resetApp(
+                  dependencies = dependencies,
+                  onThemeReset = { appTheme = AppTheme.SYSTEM },
+                  onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
+                  onVersionIncrement = { featuresVersion++ },
+                  onModeReset = { appMode = AppMode.NOT_SELECTED },
+                  onOnboardingReset = { showOnboarding = false },
+                )
+              },
+              onThemeChanged = { appTheme = it },
+              onLanguageChanged = {
+                dependencies.localeProvider.configureLocale(it)
+                appLanguage = it
+              },
+            ),
         )
       }
     }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/DesktopSidebar.kt
@@ -79,24 +79,16 @@ import space.be1ski.vibits.feature.memos.presentation.view.SyncDot
 
 private val SIDEBAR_WIDTH = 256.dp
 
-@Suppress("LongParameterList")
 @Composable
 internal fun DesktopSidebar(
   appState: AppState,
   todayHabits: TodayHabits,
   memosState: MemosState,
   onAppAction: (AppAction) -> Unit,
-  onClearSelection: () -> Unit,
-  onFeedScrollToTop: () -> Unit,
-  onOpenTodayEditor: () -> Unit,
-  onOpenConfigDialog: () -> Unit,
-  onShowCreateMemoDialog: () -> Unit,
-  onSettingsClick: () -> Unit,
   dispatchMemos: (MemosAction) -> Unit,
+  callbacks: SidebarCallbacks,
   updateAvailability: UpdateAvailability? = null,
   upgradeState: UpgradeState = UpgradeState.IDLE,
-  onUpgrade: () -> Unit = {},
-  onRestart: () -> Unit = {},
 ) {
   Surface(
     modifier = Modifier.width(SIDEBAR_WIDTH).fillMaxHeight(),
@@ -104,23 +96,23 @@ internal fun DesktopSidebar(
   ) {
     Column(modifier = Modifier.padding(Indent.s)) {
       SidebarHeader(memosState, dispatchMemos)
-      SidebarNavigation(appState, onAppAction, onClearSelection, onFeedScrollToTop)
+      SidebarNavigation(appState, onAppAction, callbacks.onClearSelection, callbacks.onFeedScrollToTop)
       Spacer(modifier = Modifier.weight(1f))
       if (updateAvailability != null) {
         UpdatePill(
           updateAvailability = updateAvailability,
           upgradeState = upgradeState,
-          onUpgrade = onUpgrade,
-          onRestart = onRestart,
+          onUpgrade = callbacks.onUpgrade,
+          onRestart = callbacks.onRestart,
         )
       }
       SidebarActions(
         selectedScreen = appState.selectedScreen,
         todayHabits = todayHabits,
-        onOpenTodayEditor = onOpenTodayEditor,
-        onOpenConfigDialog = onOpenConfigDialog,
-        onShowCreateMemoDialog = onShowCreateMemoDialog,
-        onSettingsClick = onSettingsClick,
+        onOpenTodayEditor = callbacks.onOpenTodayEditor,
+        onOpenConfigDialog = callbacks.onOpenConfigDialog,
+        onShowCreateMemoDialog = callbacks.onShowCreateMemoDialog,
+        onSettingsClick = callbacks.onSettingsClick,
       )
     }
   }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureCoordinator.kt
@@ -24,13 +24,14 @@ internal fun FeatureCoordinator(
   settingsState: SettingsState,
   currentLanguage: AppLanguage,
   currentTheme: AppTheme,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
+  callbacks: AppContentCallbacks,
 ) {
-  val dispatchApp = features.app::send
-  val dispatchMemos = features.memos::send
-  val dispatchHabits = features.habits::send
+  val dispatchers =
+    FeatureDispatchers(
+      dispatchApp = features.app::send,
+      dispatchMemos = features.memos::send,
+      dispatchHabits = features.habits::send,
+    )
 
   // Cross-feature coordination via Settings notifications
   LaunchedEffect(features.settings) {
@@ -40,12 +41,8 @@ internal fun FeatureCoordinator(
         notification,
         currentMemosState.baseUrl,
         currentMemosState.token,
-        dispatchApp,
-        dispatchMemos,
-        dispatchHabits,
-        onResetApp,
-        onThemeChanged,
-        onLanguageChanged,
+        dispatchers,
+        callbacks,
       )
     }
   }
@@ -80,42 +77,37 @@ internal fun FeatureCoordinator(
         !memosState.isLoading &&
         (skipCredentialsCheck || memosState.hasCredentials)
     if (shouldAutoLoad) {
-      dispatchApp(AppAction.UI.MarkAutoLoaded)
-      dispatchMemos(MemosAction.Loading.LoadMemos)
+      dispatchers.dispatchApp(AppAction.UI.MarkAutoLoaded)
+      dispatchers.dispatchMemos(MemosAction.Loading.LoadMemos)
     }
   }
 }
 
-@Suppress("LongParameterList")
 private fun handleNotification(
   effect: SettingsEffect.Notification,
   currentMemosBaseUrl: String,
   currentMemosToken: String,
-  dispatchApp: (AppAction) -> Unit,
-  dispatchMemos: (MemosAction) -> Unit,
-  dispatchHabits: (HabitsAction) -> Unit,
-  onResetApp: () -> Unit,
-  onThemeChanged: (AppTheme) -> Unit,
-  onLanguageChanged: (AppLanguage) -> Unit,
+  dispatchers: FeatureDispatchers,
+  callbacks: AppContentCallbacks,
 ) {
   when (effect) {
     is SettingsEffect.Notification.ModeChanged -> {
-      dispatchApp(AppAction.Mode.SetAppMode(effect.newMode))
-      dispatchMemos(MemosAction.Loading.ResetForModeChange(effect.newMode))
-      dispatchMemos(MemosAction.Loading.LoadMemos)
-      dispatchHabits(HabitsAction.Cache.InvalidateAllCache)
+      dispatchers.dispatchApp(AppAction.Mode.SetAppMode(effect.newMode))
+      dispatchers.dispatchMemos(MemosAction.Loading.ResetForModeChange(effect.newMode))
+      dispatchers.dispatchMemos(MemosAction.Loading.LoadMemos)
+      dispatchers.dispatchHabits(HabitsAction.Cache.InvalidateAllCache)
     }
-    is SettingsEffect.Notification.ResetCompleted -> onResetApp()
+    is SettingsEffect.Notification.ResetCompleted -> callbacks.onResetApp()
     is SettingsEffect.Notification.CredentialsSaved -> {
       val credentialsChanged = effect.baseUrl != currentMemosBaseUrl || effect.token != currentMemosToken
-      dispatchMemos(MemosAction.Credentials.UpdateBaseUrl(effect.baseUrl))
-      dispatchMemos(MemosAction.Credentials.UpdateToken(effect.token))
+      dispatchers.dispatchMemos(MemosAction.Credentials.UpdateBaseUrl(effect.baseUrl))
+      dispatchers.dispatchMemos(MemosAction.Credentials.UpdateToken(effect.token))
       if (credentialsChanged) {
-        dispatchMemos(MemosAction.Loading.LoadMemos)
+        dispatchers.dispatchMemos(MemosAction.Loading.LoadMemos)
       }
     }
-    is SettingsEffect.Notification.ThemeChanged -> onThemeChanged(effect.theme)
-    is SettingsEffect.Notification.LanguageChanged -> onLanguageChanged(effect.language)
+    is SettingsEffect.Notification.ThemeChanged -> callbacks.onThemeChanged(effect.theme)
+    is SettingsEffect.Notification.LanguageChanged -> callbacks.onLanguageChanged(effect.language)
     is SettingsEffect.Notification.DialogClosed -> Unit
   }
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureDispatchers.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/FeatureDispatchers.kt
@@ -1,0 +1,11 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
+import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction
+import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
+
+internal class FeatureDispatchers(
+  val dispatchApp: (AppAction) -> Unit,
+  val dispatchMemos: (MemosAction) -> Unit,
+  val dispatchHabits: (HabitsAction) -> Unit,
+)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SidebarCallbacks.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SidebarCallbacks.kt
@@ -1,0 +1,13 @@
+package space.be1ski.vibits.feature.homescreen.presentation.view
+
+@Suppress("LongParameterList")
+internal class SidebarCallbacks(
+  val onClearSelection: () -> Unit,
+  val onFeedScrollToTop: () -> Unit,
+  val onOpenTodayEditor: () -> Unit,
+  val onOpenConfigDialog: () -> Unit,
+  val onShowCreateMemoDialog: () -> Unit,
+  val onSettingsClick: () -> Unit,
+  val onUpgrade: () -> Unit,
+  val onRestart: () -> Unit,
+)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -37,6 +37,7 @@ import space.be1ski.vibits.feature.memos.domain.model.PostFilter
 import space.be1ski.vibits.feature.memos.domain.usecase.ClassifyPostTypeUseCase
 import space.be1ski.vibits.feature.memos.presentation.action.MemosAction
 import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+import space.be1ski.vibits.feature.memos.presentation.view.FeedCallbacks
 import space.be1ski.vibits.feature.memos.presentation.view.FeedScreen
 import space.be1ski.vibits.feature.settings.domain.model.TimeRangeTab
 
@@ -61,20 +62,22 @@ internal fun SwipeableTabContent(
       memos = memosState.memos,
       dateFormatter = dateFormatter,
       activeFilter = memosState.activePostFilter,
-      onFilterChange = { filter -> dispatchMemos(MemosAction.Loading.ChangePostFilter(filter)) },
       isRefreshing = memosState.isLoading,
-      onRefresh = {},
       enablePullRefresh = !wideLayout,
       demoMode = appState.isDemoMode,
-      onMemoClick = { memo ->
-        handleMemoClick(
-          memo = memo,
-          memos = memosState.memos,
-          onMemosAction = dispatchMemos,
-          onHabitsAction = onHabitsAction,
-        )
-      },
-      onDeleteMemo = { memo -> dispatchMemos(MemosAction.Crud.DeleteMemo(memo.name)) },
+      callbacks =
+        FeedCallbacks(
+          onFilterChange = { filter -> dispatchMemos(MemosAction.Loading.ChangePostFilter(filter)) },
+          onMemoClick = { memo ->
+            handleMemoClick(
+              memo = memo,
+              memos = memosState.memos,
+              onMemosAction = dispatchMemos,
+              onHabitsAction = onHabitsAction,
+            )
+          },
+          onDeleteMemo = { memo -> dispatchMemos(MemosAction.Crud.DeleteMemo(memo.name)) },
+        ),
       listState = feedListState,
     )
     return

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -10,9 +10,7 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import kotlinx.coroutines.launch
 import kotlinx.datetime.TimeZone
-import space.be1ski.vibits.core.platform.app.AppUpdater
 import space.be1ski.vibits.core.platform.date.currentLocalDate
-import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.ui.celebration.CelebrationAnimation
 import space.be1ski.vibits.core.ui.celebration.CelebrationOverlay
 import space.be1ski.vibits.core.ui.date.rememberDateFormatter
@@ -20,30 +18,18 @@ import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
-import space.be1ski.vibits.feature.changelog.domain.usecase.CheckForUpdateUseCase
-import space.be1ski.vibits.feature.changelog.domain.usecase.GetChangelogUseCase
 import space.be1ski.vibits.feature.habits.presentation.view.components.rememberHabitsConfigTimeline
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
-import space.be1ski.vibits.feature.memos.domain.repository.ExportService
-import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 import space.be1ski.vibits.feature.settings.presentation.view.SettingsDialog
 
-@Suppress("LongParameterList", "LongMethod")
+@Suppress("LongMethod")
 @Composable
 internal fun VibitsApp(
   features: AppFeatures,
   justFinishedOnboarding: Boolean = false,
-  currentTheme: AppTheme,
-  currentLanguage: AppLanguage,
-  exportService: ExportService,
-  currentVersion: String,
-  getChangelog: GetChangelogUseCase,
-  checkForUpdate: CheckForUpdateUseCase? = null,
-  appUpdater: AppUpdater? = null,
+  config: AppContentConfig,
+  callbacks: AppContentCallbacks = AppContentCallbacks({}, {}, {}),
   testLogs: List<LogEntry>? = null,
-  onResetApp: () -> Unit = {},
-  onThemeChanged: (AppTheme) -> Unit = {},
-  onLanguageChanged: (AppLanguage) -> Unit = {},
 ) {
   val appState by features.app.state.collectAsState()
   val memosState by features.memos.state.collectAsState()
@@ -67,15 +53,16 @@ internal fun VibitsApp(
   var upgradeState by remember { mutableStateOf(UpgradeState.IDLE) }
 
   LaunchedEffect(Unit) {
-    val entries = getChangelog(currentVersion)
+    val entries = config.getChangelog(config.currentVersion)
     if (entries.isNotEmpty()) {
       changelogEntries = entries
     }
   }
 
   LaunchedEffect(Unit) {
+    val checkForUpdate = config.checkForUpdate
     if (checkForUpdate != null) {
-      updateAvailability = checkForUpdate(currentVersion)
+      updateAvailability = checkForUpdate(config.currentVersion)
     }
   }
 
@@ -84,11 +71,9 @@ internal fun VibitsApp(
     appState = appState,
     memosState = memosState,
     settingsState = settingsState,
-    currentLanguage = currentLanguage,
-    currentTheme = currentTheme,
-    onResetApp = onResetApp,
-    onThemeChanged = onThemeChanged,
-    onLanguageChanged = onLanguageChanged,
+    currentLanguage = config.appLanguage,
+    currentTheme = config.appTheme,
+    callbacks = callbacks,
   )
 
   val wideLayout = LocalWideLayout.current
@@ -99,14 +84,15 @@ internal fun VibitsApp(
       memosState = memosState,
       habitsState = habitsState,
       settingsState = settingsState,
-      currentLanguage = currentLanguage,
-      currentTheme = currentTheme,
+      currentLanguage = config.appLanguage,
+      currentTheme = config.appTheme,
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
-      exportService = exportService,
+      exportService = config.exportService,
       testLogs = testLogs,
       updateAvailability = updateAvailability,
       upgradeState = upgradeState,
       onUpgrade = {
+        val appUpdater = config.appUpdater
         if (appUpdater != null) {
           upgradeState = UpgradeState.UPGRADING
           coroutineScope.launch {
@@ -114,7 +100,7 @@ internal fun VibitsApp(
           }
         }
       },
-      onRestart = { appUpdater?.restart() },
+      onRestart = { config.appUpdater?.restart() },
     )
   } else {
     VibitsAppScaffold(
@@ -122,8 +108,8 @@ internal fun VibitsApp(
       appState = appState,
       memosState = memosState,
       habitsState = habitsState,
-      currentLanguage = currentLanguage,
-      currentTheme = currentTheme,
+      currentLanguage = config.appLanguage,
+      currentTheme = config.appTheme,
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
     )
   }
@@ -131,7 +117,7 @@ internal fun VibitsApp(
   val dateFormatter = rememberDateFormatter()
 
   if (!wideLayout) {
-    SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = exportService, testLogs = testLogs)
+    SettingsDialog(state = settingsState, dispatch = features.settings::send, exportService = config.exportService, testLogs = testLogs)
   }
   MemoCreateDialog(state = memosState, dispatch = features.memos::send)
   MemoEditDialog(state = memosState, dispatch = features.memos::send)

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
@@ -80,35 +80,38 @@ internal fun VibitsDesktopShell(
         todayHabits = shell.todayHabits,
         memosState = memosState,
         onAppAction = features.app::send,
-        onClearSelection = shell.callbacks.onClearSelection,
-        onFeedScrollToTop = shell.callbacks.onFeedScrollToTop,
-        onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
-        onOpenConfigDialog = {
-          features.habits.send(
-            space.be1ski.vibits.feature.habits.presentation.action.HabitsAction.Config.OpenConfigDialog(
-              shell.todayHabits.config,
-            ),
-          )
-        },
-        onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
-        onSettingsClick = {
-          features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
-          features.settings.send(
-            SettingsAction.Dialog.Open(
-              baseUrl = memosState.baseUrl,
-              token = memosState.token,
-              appMode = appState.appMode,
-              language = currentLanguage,
-              theme = currentTheme,
-              syncDebounceSeconds = syncDebounceSeconds,
-            ),
-          )
-        },
         dispatchMemos = features.memos::send,
+        callbacks =
+          SidebarCallbacks(
+            onClearSelection = shell.callbacks.onClearSelection,
+            onFeedScrollToTop = shell.callbacks.onFeedScrollToTop,
+            onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
+            onOpenConfigDialog = {
+              features.habits.send(
+                space.be1ski.vibits.feature.habits.presentation.action.HabitsAction.Config.OpenConfigDialog(
+                  shell.todayHabits.config,
+                ),
+              )
+            },
+            onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
+            onSettingsClick = {
+              features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
+              features.settings.send(
+                SettingsAction.Dialog.Open(
+                  baseUrl = memosState.baseUrl,
+                  token = memosState.token,
+                  appMode = appState.appMode,
+                  language = currentLanguage,
+                  theme = currentTheme,
+                  syncDebounceSeconds = syncDebounceSeconds,
+                ),
+              )
+            },
+            onUpgrade = onUpgrade,
+            onRestart = onRestart,
+          ),
         updateAvailability = updateAvailability,
         upgradeState = upgradeState,
-        onUpgrade = onUpgrade,
-        onRestart = onRestart,
       )
       VerticalDivider()
       Box(

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -210,12 +210,16 @@ class AppScreenshotTest {
       VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
         VibitsApp(
           features = features,
-          currentTheme = AppTheme.SYSTEM,
-          currentLanguage = AppLanguage.ENGLISH,
-          exportService = fakeExportService,
-          currentVersion = currentVersion,
-          getChangelog = getChangelog,
-          checkForUpdate = checkForUpdate,
+          config =
+            AppContentConfig(
+              appTheme = AppTheme.SYSTEM,
+              appLanguage = AppLanguage.ENGLISH,
+              exportService = fakeExportService,
+              currentVersion = currentVersion,
+              getChangelog = getChangelog,
+              checkForUpdate = checkForUpdate,
+              appUpdater = null,
+            ),
           testLogs = testLogs,
         )
       }
@@ -374,14 +378,22 @@ class AppScreenshotTest {
             onboarding = RecordingFeature(OnboardingState()),
             app = features,
           ),
-        appTheme = AppTheme.SYSTEM,
-        appLanguage = AppLanguage.ENGLISH,
-        exportService = fakeExportService,
-        currentVersion = "dev",
-        getChangelog = fakeGetChangelog,
-        onResetApp = {},
-        onThemeChanged = {},
-        onLanguageChanged = {},
+        config =
+          AppContentConfig(
+            appTheme = AppTheme.SYSTEM,
+            appLanguage = AppLanguage.ENGLISH,
+            exportService = fakeExportService,
+            currentVersion = "dev",
+            getChangelog = fakeGetChangelog,
+            checkForUpdate = null,
+            appUpdater = null,
+          ),
+        callbacks =
+          AppContentCallbacks(
+            onResetApp = {},
+            onThemeChanged = {},
+            onLanguageChanged = {},
+          ),
       )
     }
   }
@@ -768,11 +780,16 @@ class AppScreenshotTest {
         VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
           VibitsApp(
             features = features,
-            currentTheme = AppTheme.SYSTEM,
-            currentLanguage = AppLanguage.ENGLISH,
-            exportService = fakeExportService,
-            currentVersion = "dev",
-            getChangelog = fakeGetChangelog,
+            config =
+              AppContentConfig(
+                appTheme = AppTheme.SYSTEM,
+                appLanguage = AppLanguage.ENGLISH,
+                exportService = fakeExportService,
+                currentVersion = "dev",
+                getChangelog = fakeGetChangelog,
+                checkForUpdate = null,
+                appUpdater = null,
+              ),
           )
           CelebrationOverlay(
             animation = CelebrationAnimation.Confetti,

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedCallbacks.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedCallbacks.kt
@@ -1,0 +1,11 @@
+package space.be1ski.vibits.feature.memos.presentation.view
+
+import space.be1ski.vibits.feature.memos.domain.model.Memo
+import space.be1ski.vibits.feature.memos.domain.model.PostFilter
+
+class FeedCallbacks(
+  val onFilterChange: (PostFilter) -> Unit = {},
+  val onRefresh: () -> Unit = {},
+  val onMemoClick: (Memo) -> Unit = {},
+  val onDeleteMemo: ((Memo) -> Unit)? = null,
+)

--- a/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
+++ b/feature/memos/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/memos/presentation/view/FeedScreen.kt
@@ -65,25 +65,22 @@ import space.be1ski.vibits.feature.memos.domain.usecase.FilterMemosByTypeUseCase
 /**
  * Feed tab showing the raw memos list.
  */
-@Suppress("LongParameterList", "LongMethod", "CyclomaticComplexMethod")
+@Suppress("LongMethod", "CyclomaticComplexMethod")
 @OptIn(androidx.compose.material.ExperimentalMaterialApi::class)
 @Composable
 fun FeedScreen(
   memos: List<Memo>,
   dateFormatter: DateFormatter,
   activeFilter: PostFilter = PostFilter.ALL,
-  onFilterChange: (PostFilter) -> Unit = {},
   isRefreshing: Boolean = false,
-  onRefresh: () -> Unit = {},
   enablePullRefresh: Boolean = true,
-  onMemoClick: (Memo) -> Unit = {},
-  onDeleteMemo: ((Memo) -> Unit)? = null,
   demoMode: Boolean = false,
+  callbacks: FeedCallbacks = FeedCallbacks(),
   listState: LazyListState = rememberLazyListState(),
 ) {
   var memoToDelete by remember { mutableStateOf<Memo?>(null) }
   val timeZone = TimeZone.currentSystemDefault()
-  val pullRefreshState = rememberPullRefreshState(isRefreshing, onRefresh)
+  val pullRefreshState = rememberPullRefreshState(isRefreshing, callbacks.onRefresh)
   val containerModifier =
     if (enablePullRefresh) {
       Modifier.pullRefresh(pullRefreshState)
@@ -99,7 +96,7 @@ fun FeedScreen(
         label = stringResource(Res.string.label_post_filter),
         options = listOf(PostFilter.ALL, PostFilter.CONFIG, PostFilter.HABIT_TRACKING, PostFilter.REGULAR),
         selected = activeFilter,
-        onSelect = onFilterChange,
+        onSelect = callbacks.onFilterChange,
         optionLabel = { filter ->
           when (filter) {
             PostFilter.ALL -> stringResource(Res.string.filter_all)
@@ -129,7 +126,7 @@ fun FeedScreen(
               modifier =
                 Modifier
                   .fillMaxWidth()
-                  .clickable { onMemoClick(memo) },
+                  .clickable { callbacks.onMemoClick(memo) },
             ) {
               Row(
                 modifier = Modifier.padding(start = 0.dp, top = Indent.s, bottom = Indent.s, end = Indent.xs),
@@ -148,7 +145,7 @@ fun FeedScreen(
                     demoMode = demoMode,
                   )
                 }
-                if (onDeleteMemo != null && memo.canDeleteFromFeed) {
+                if (callbacks.onDeleteMemo != null && memo.canDeleteFromFeed) {
                   IconButton(
                     onClick = { memoToDelete = memo },
                     modifier = Modifier.size(36.dp),
@@ -183,7 +180,7 @@ fun FeedScreen(
       confirmButton = {
         Button(
           onClick = {
-            onDeleteMemo?.invoke(memo)
+            callbacks.onDeleteMemo?.invoke(memo)
             memoToDelete = null
           },
           colors =


### PR DESCRIPTION
## Summary

- Extract `SidebarCallbacks`, `AppContentConfig`, `AppContentCallbacks`, `FeatureDispatchers`, `FeedCallbacks`, and `HabitRowDimensions` container classes
- Remove `@Suppress("LongParameterList")` from `DesktopSidebar`, `AppContent`, `AppWithLoadingScreen`, `VibitsApp`, `FeatureCoordinator.handleNotification`, `FeedScreen`, and `SingleHabitRow`
- Follows existing `ScaffoldCallbacks` pattern for grouping by responsibility

## Test plan

- [x] `./gradlew checkJvm` passes (ktlint, detekt, compile, tests)
- [x] Screenshot tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)