### PR TITLE
Decompose long composable methods

### DIFF
--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -20,6 +20,10 @@ import space.be1ski.vibits.core.ui.date.DateFormatter
 import space.be1ski.vibits.feature.habits.domain.model.ActivityMode
 import space.be1ski.vibits.feature.habits.domain.model.ActivityRange
 import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
+import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
+import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
+import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
 import space.be1ski.vibits.feature.habits.domain.model.findDayByDate
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractDailyMemosUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
@@ -30,6 +34,7 @@ import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
 import space.be1ski.vibits.feature.habits.presentation.state.isDataLoading
 import space.be1ski.vibits.feature.habits.presentation.view.components.HabitPicker
+import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 /**
  * Stats tab with activity charts.
@@ -49,7 +54,6 @@ fun StatsScreen(
   StatsScreenDialogs(derived, onHabitsAction)
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun rememberStatsScreenDerived(
   state: StatsScreenState,
@@ -57,37 +61,95 @@ private fun rememberStatsScreenDerived(
   habitsState: HabitsState,
   dateFormatter: DateFormatter,
 ): StatsScreenDerivedState {
-  val memos = state.memos
   val range = state.range
   val activityMode = state.activityMode
 
-  // Read from TEA cache (new system)
+  val cached = rememberCachedActivityData(habitsState, range, activityMode, appMode)
+  val currentHabitsConfig =
+    remember(cached.habitsConfigTimeline) {
+      cached.habitsConfigTimeline.lastOrNull()?.habits ?: emptyList()
+    }
+  val timeZone = remember { TimeZone.currentSystemDefault() }
+  val today = remember { currentLocalDate() }
+  val todayData = rememberTodayData(state.memos, cached.habitsConfigTimeline, timeZone, today)
+
+  val showLast7DaysMatrix =
+    activityMode == ActivityMode.HABITS &&
+      range is ActivityRange.Week &&
+      currentHabitsConfig.isNotEmpty()
+
+  return StatsScreenDerivedState(
+    state = state,
+    habitsState = habitsState,
+    habitsConfigTimeline = cached.habitsConfigTimeline,
+    currentHabitsConfig = currentHabitsConfig,
+    weekData = cached.weekData,
+    isLoadingWeekData = cached.isLoadingWeekData,
+    showWeekdayLegend = range is ActivityRange.Week || range is ActivityRange.Month || range is ActivityRange.Quarter,
+    useCompactHeight = range !is ActivityRange.Week,
+    collapseHabits = activityMode == ActivityMode.HABITS && range is ActivityRange.Year,
+    showLast7DaysMatrix = showLast7DaysMatrix,
+    showHabitSections = !showLast7DaysMatrix && activityMode == ActivityMode.HABITS && currentHabitsConfig.isNotEmpty(),
+    useHabitPicker = state.wideLayout && activityMode == ActivityMode.HABITS && currentHabitsConfig.isNotEmpty(),
+    selectedDay =
+      remember(cached.weekData.weeks, habitsState.selectedDate) {
+        habitsState.selectedDate?.let { date -> cached.weekData.findDayByDate(date) }
+      },
+    todayConfig = todayData.todayConfig,
+    todayDay = todayData.todayDay,
+    today = today,
+    timeZone = timeZone,
+    successRate = cached.successRate,
+    periodPosts = remember(state.memos, range, timeZone) { GetPeriodPostsUseCase(state.memos, range, timeZone) },
+    dateFormatter = dateFormatter,
+    configStartDate = remember(cached.habitsConfigTimeline) { cached.habitsConfigTimeline.firstOrNull()?.date },
+  )
+}
+
+private class CachedActivityResult(
+  val weekData: ActivitySummary,
+  val habitsConfigTimeline: List<HabitsConfigEntry>,
+  val isLoadingWeekData: Boolean,
+  val successRate: SuccessRate?,
+)
+
+@Composable
+private fun rememberCachedActivityData(
+  habitsState: HabitsState,
+  range: ActivityRange,
+  activityMode: ActivityMode,
+  appMode: AppMode,
+): CachedActivityResult {
   val cacheKey =
     remember(range, activityMode, appMode) {
       ActivityCacheKey(range, activityMode, appMode)
     }
   val cachedData = habitsState.getActivityData(range, activityMode, appMode)
   val isLoadingWeekData = habitsState.isDataLoading(cacheKey)
-
-  // Read from TEA cache
   val emptyWeekData =
     remember {
-      ActivitySummary(
-        weeks = emptyList(),
-        maxDaily = 0,
-        maxWeekly = 0,
-      )
+      ActivitySummary(weeks = emptyList(), maxDaily = 0, maxWeekly = 0)
     }
-  val weekData = cachedData?.weekData ?: emptyWeekData
-  val habitsConfigTimeline = cachedData?.configTimeline.orEmpty()
-  val successRate = cachedData?.successRate
+  return CachedActivityResult(
+    weekData = cachedData?.weekData ?: emptyWeekData,
+    habitsConfigTimeline = cachedData?.configTimeline.orEmpty(),
+    isLoadingWeekData = isLoadingWeekData,
+    successRate = cachedData?.successRate,
+  )
+}
 
-  val currentHabitsConfig =
-    remember(habitsConfigTimeline) {
-      habitsConfigTimeline.lastOrNull()?.habits ?: emptyList()
-    }
-  val timeZone = remember { TimeZone.currentSystemDefault() }
-  val today = remember { currentLocalDate() }
+private class TodayData(
+  val todayConfig: List<HabitConfig>,
+  val todayDay: ContributionDay?,
+)
+
+@Composable
+private fun rememberTodayData(
+  memos: List<Memo>,
+  habitsConfigTimeline: List<HabitsConfigEntry>,
+  timeZone: TimeZone,
+  today: kotlinx.datetime.LocalDate,
+): TodayData {
   val todayMemo =
     remember(memos, timeZone, today) {
       ExtractDailyMemosUseCase.forDate(memos, timeZone, today)
@@ -98,65 +160,9 @@ private fun rememberStatsScreenDerived(
     }
   val todayDay =
     remember(todayConfig, todayMemo, today) {
-      buildHabitDay(
-        date = today,
-        habitsConfig = todayConfig,
-        dailyMemo = todayMemo,
-      )
+      buildHabitDay(date = today, habitsConfig = todayConfig, dailyMemo = todayMemo)
     }
-  val showWeekdayLegend =
-    range is ActivityRange.Week ||
-      range is ActivityRange.Month ||
-      range is ActivityRange.Quarter
-  val useCompactHeight = range !is ActivityRange.Week
-  val collapseHabits = activityMode == ActivityMode.HABITS && range is ActivityRange.Year
-  val showLast7DaysMatrix =
-    activityMode == ActivityMode.HABITS &&
-      range is ActivityRange.Week &&
-      currentHabitsConfig.isNotEmpty()
-  val showHabitSections =
-    !showLast7DaysMatrix &&
-      activityMode == ActivityMode.HABITS &&
-      currentHabitsConfig.isNotEmpty()
-  val useHabitPicker =
-    state.wideLayout &&
-      activityMode == ActivityMode.HABITS &&
-      currentHabitsConfig.isNotEmpty()
-  val selectedDay =
-    remember(weekData.weeks, habitsState.selectedDate) {
-      habitsState.selectedDate?.let { date -> weekData.findDayByDate(date) }
-    }
-  val configStartDate =
-    remember(habitsConfigTimeline) {
-      habitsConfigTimeline.firstOrNull()?.date
-    }
-  val periodPosts =
-    remember(memos, range, timeZone) {
-      GetPeriodPostsUseCase(memos, range, timeZone)
-    }
-  return StatsScreenDerivedState(
-    state = state,
-    habitsState = habitsState,
-    habitsConfigTimeline = habitsConfigTimeline,
-    currentHabitsConfig = currentHabitsConfig,
-    weekData = weekData,
-    isLoadingWeekData = isLoadingWeekData,
-    showWeekdayLegend = showWeekdayLegend,
-    useCompactHeight = useCompactHeight,
-    collapseHabits = collapseHabits,
-    showLast7DaysMatrix = showLast7DaysMatrix,
-    showHabitSections = showHabitSections,
-    useHabitPicker = useHabitPicker,
-    selectedDay = selectedDay,
-    todayConfig = todayConfig,
-    todayDay = todayDay,
-    today = today,
-    timeZone = timeZone,
-    successRate = successRate,
-    periodPosts = periodPosts,
-    dateFormatter = dateFormatter,
-    configStartDate = configStartDate,
-  )
+  return TodayData(todayConfig = todayConfig, todayDay = todayDay)
 }
 
 @Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -468,7 +468,6 @@ private const val COMPACT_POST_MAX_LENGTH = 50
 private const val MATRIX_CELL_FILL_MS = 220
 private const val MAX_MATRIX_CELL_HEIGHT_DP = 36
 
-@Suppress("LongMethod")
 @Composable
 internal fun StatsMainChart(
   derived: StatsScreenDerivedState,
@@ -488,24 +487,7 @@ internal fun StatsMainChart(
     return
   }
 
-  val habitsState = derived.habitsState
-  val chartScrollState = rememberScrollState()
-
-  val onDaySelected =
-    remember(dispatch, state.activityMode, derived.weekData.weeks) {
-      { day: ContributionDay ->
-        dispatch(HabitsAction.Selection.SelectDay(day, "main"))
-        if (state.activityMode == ActivityMode.POSTS) {
-          val week =
-            derived.weekData.weeks.firstOrNull { week ->
-              week.days.any { it.date == day.date }
-            }
-          if (week != null) {
-            dispatch(HabitsAction.Selection.SelectWeek(week))
-          }
-        }
-      }
-    }
+  val onDaySelected = rememberOnDaySelected(dispatch, state, derived)
   val onClearSelection = remember(dispatch) { { dispatch(HabitsAction.Selection.ClearSelection) } }
   val onEditRequested =
     remember(dispatch, derived.habitsConfigTimeline) {
@@ -516,48 +498,90 @@ internal fun StatsMainChart(
     }
 
   if (derived.showLast7DaysMatrix) {
-    val onSingleHabitToggle =
-      remember(dispatch, derived.currentHabitsConfig) {
-        { day: ContributionDay, habitTag: String, habitLabel: String ->
-          dispatch(HabitsAction.SingleToggle.RequestSingleHabitToggle(day, habitTag, habitLabel, derived.currentHabitsConfig))
+    StatsMainChartMatrix(derived, dispatch)
+  } else {
+    StatsMainChartGrid(derived, onDaySelected, onClearSelection, onEditRequested)
+  }
+}
+
+@Composable
+private fun rememberOnDaySelected(
+  dispatch: (HabitsAction) -> Unit,
+  state: StatsScreenState,
+  derived: StatsScreenDerivedState,
+): (ContributionDay) -> Unit =
+  remember(dispatch, state.activityMode, derived.weekData.weeks) {
+    { day: ContributionDay ->
+      dispatch(HabitsAction.Selection.SelectDay(day, "main"))
+      if (state.activityMode == ActivityMode.POSTS) {
+        val week =
+          derived.weekData.weeks.firstOrNull { week ->
+            week.days.any { it.date == day.date }
+          }
+        if (week != null) {
+          dispatch(HabitsAction.Selection.SelectWeek(week))
         }
       }
-    LastSevenDaysMatrix(
-      days = derived.weekData.lastSevenDays(),
-      habits = derived.currentHabitsConfig,
-      compactHeight = derived.useCompactHeight,
-      demoMode = state.demoMode,
-      formatter = derived.dateFormatter,
-      onHabitClick = onSingleHabitToggle,
-    )
-  } else {
-    val showTimeline = state.range is ActivityRange.Quarter || state.range is ActivityRange.Year
-    val useCalendarLayout = state.range is ActivityRange.Month
-    ContributionGrid(
-      state =
-        ContributionGridState(
-          weekData = derived.weekData,
-          range = state.range,
-          selectedDay = if (habitsState.activeSelectionId == "main") derived.selectedDay else null,
-          selectedWeekStart =
-            if (state.activityMode == ActivityMode.POSTS) habitsState.selectedWeek?.startDate else null,
-          isActiveSelection = habitsState.activeSelectionId == "main",
-          scrollState = chartScrollState,
-          showWeekdayLegend = derived.showWeekdayLegend && !useCalendarLayout,
-          showAllWeekdayLabels = true,
-          compactHeight = derived.useCompactHeight,
-          showTimeline = showTimeline,
-          calendarLayout = useCalendarLayout,
-          today = derived.today,
-          demoMode = state.demoMode,
-        ),
-      dateFormatter = derived.dateFormatter,
-      onDaySelected = onDaySelected,
-      onClearSelection = onClearSelection,
-      onEditRequested = onEditRequested,
-      onCreateRequested = onEditRequested,
-    )
+    }
   }
+
+@Composable
+private fun StatsMainChartMatrix(
+  derived: StatsScreenDerivedState,
+  dispatch: (HabitsAction) -> Unit,
+) {
+  val onSingleHabitToggle =
+    remember(dispatch, derived.currentHabitsConfig) {
+      { day: ContributionDay, habitTag: String, habitLabel: String ->
+        dispatch(HabitsAction.SingleToggle.RequestSingleHabitToggle(day, habitTag, habitLabel, derived.currentHabitsConfig))
+      }
+    }
+  LastSevenDaysMatrix(
+    days = derived.weekData.lastSevenDays(),
+    habits = derived.currentHabitsConfig,
+    compactHeight = derived.useCompactHeight,
+    demoMode = derived.state.demoMode,
+    formatter = derived.dateFormatter,
+    onHabitClick = onSingleHabitToggle,
+  )
+}
+
+@Composable
+private fun StatsMainChartGrid(
+  derived: StatsScreenDerivedState,
+  onDaySelected: (ContributionDay) -> Unit,
+  onClearSelection: () -> Unit,
+  onEditRequested: (ContributionDay) -> Unit,
+) {
+  val state = derived.state
+  val habitsState = derived.habitsState
+  val chartScrollState = rememberScrollState()
+  val showTimeline = state.range is ActivityRange.Quarter || state.range is ActivityRange.Year
+  val useCalendarLayout = state.range is ActivityRange.Month
+  ContributionGrid(
+    state =
+      ContributionGridState(
+        weekData = derived.weekData,
+        range = state.range,
+        selectedDay = if (habitsState.activeSelectionId == "main") derived.selectedDay else null,
+        selectedWeekStart =
+          if (state.activityMode == ActivityMode.POSTS) habitsState.selectedWeek?.startDate else null,
+        isActiveSelection = habitsState.activeSelectionId == "main",
+        scrollState = chartScrollState,
+        showWeekdayLegend = derived.showWeekdayLegend && !useCalendarLayout,
+        showAllWeekdayLabels = true,
+        compactHeight = derived.useCompactHeight,
+        showTimeline = showTimeline,
+        calendarLayout = useCalendarLayout,
+        today = derived.today,
+        demoMode = state.demoMode,
+      ),
+    dateFormatter = derived.dateFormatter,
+    onDaySelected = onDaySelected,
+    onClearSelection = onClearSelection,
+    onEditRequested = onEditRequested,
+    onCreateRequested = onEditRequested,
+  )
 }
 
 @Composable

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppRoot.kt
@@ -23,35 +23,24 @@ import space.be1ski.vibits.feature.settings.domain.model.AppTheme
 
 private val DESKTOP_BREAKPOINT = 900.dp
 
-@Suppress("LongMethod")
 @Composable
 fun AppRoot(
   dependencies: AppDependencies,
   onFeaturesReady: ((AppFeatures) -> Unit)? = null,
 ) {
-  val initialPrefs = remember { dependencies.loadPreferences() }
-  val currentVersion = remember { dependencies.loadAppDetails().version }
-  remember { dependencies.localeProvider.configureLocale(initialPrefs.language) }
-
-  var appMode by remember { mutableStateOf(dependencies.fixInvalidOnlineMode()) }
-  var appTheme by remember { mutableStateOf(initialPrefs.theme) }
-  var appLanguage by remember { mutableStateOf(initialPrefs.language) }
-  var featuresVersion by remember { mutableIntStateOf(0) }
-  var showOnboarding by remember { mutableStateOf(false) }
-  var justFinishedOnboarding by remember { mutableStateOf(false) }
-
-  val darkTheme = resolveDarkTheme(appTheme)
+  val rootState = rememberAppRootState(dependencies)
+  val darkTheme = resolveDarkTheme(rootState.appTheme)
   val featuresState =
     rememberFeaturesState(
       dependencies = dependencies,
-      featuresVersion = featuresVersion,
+      featuresVersion = rootState.featuresVersion,
       onModeSelected = {
-        featuresVersion++
-        appMode = it
+        rootState.featuresVersion++
+        rootState.appMode = it
       },
       onOnboardingCompleted = {
-        showOnboarding = false
-        justFinishedOnboarding = true
+        rootState.showOnboarding = false
+        rootState.justFinishedOnboarding = true
       },
     )
 
@@ -59,49 +48,82 @@ fun AppRoot(
     onFeaturesReady?.invoke(featuresState.app)
   }
 
-  SyncAppMode(featuresState, appMode) { appMode = it }
-  ObserveOnboardingCheck(appMode, dependencies) { showOnboarding = it }
+  SyncAppMode(featuresState, rootState.appMode) { rootState.appMode = it }
+  ObserveOnboardingCheck(rootState.appMode, dependencies) { rootState.showOnboarding = it }
 
   BoxWithConstraints(modifier = Modifier.fillMaxSize()) {
     val wideLayout = maxWidth >= DESKTOP_BREAKPOINT
-    key(appLanguage) {
+    key(rootState.appLanguage) {
       VibitsTheme(darkTheme = darkTheme, wideLayout = wideLayout) {
         AppContent(
-          appMode = appMode,
-          showOnboarding = showOnboarding,
-          justFinishedOnboarding = justFinishedOnboarding,
+          appMode = rootState.appMode,
+          showOnboarding = rootState.showOnboarding,
+          justFinishedOnboarding = rootState.justFinishedOnboarding,
           featuresState = featuresState,
-          config =
-            AppContentConfig(
-              appTheme = appTheme,
-              appLanguage = appLanguage,
-              exportService = dependencies.settingsDependencies.exportService,
-              currentVersion = currentVersion,
-              getChangelog = dependencies.getChangelog,
-              checkForUpdate = dependencies.checkForUpdate,
-              appUpdater = dependencies.appUpdater,
-            ),
-          callbacks =
-            AppContentCallbacks(
-              onResetApp = {
-                resetApp(
-                  dependencies = dependencies,
-                  onThemeReset = { appTheme = AppTheme.SYSTEM },
-                  onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
-                  onVersionIncrement = { featuresVersion++ },
-                  onModeReset = { appMode = AppMode.NOT_SELECTED },
-                  onOnboardingReset = { showOnboarding = false },
-                )
-              },
-              onThemeChanged = { appTheme = it },
-              onLanguageChanged = {
-                dependencies.localeProvider.configureLocale(it)
-                appLanguage = it
-              },
-            ),
+          config = rootState.buildConfig(dependencies),
+          callbacks = rootState.buildCallbacks(dependencies),
         )
       }
     }
+  }
+}
+
+private class AppRootState(
+  initialMode: AppMode,
+  initialTheme: AppTheme,
+  initialLanguage: AppLanguage,
+  val currentVersion: String,
+) {
+  var appMode by mutableStateOf(initialMode)
+  var appTheme by mutableStateOf(initialTheme)
+  var appLanguage by mutableStateOf(initialLanguage)
+  var featuresVersion by mutableIntStateOf(0)
+  var showOnboarding by mutableStateOf(false)
+  var justFinishedOnboarding by mutableStateOf(false)
+
+  fun buildConfig(dependencies: AppDependencies) =
+    AppContentConfig(
+      appTheme = appTheme,
+      appLanguage = appLanguage,
+      exportService = dependencies.settingsDependencies.exportService,
+      currentVersion = currentVersion,
+      getChangelog = dependencies.getChangelog,
+      checkForUpdate = dependencies.checkForUpdate,
+      appUpdater = dependencies.appUpdater,
+    )
+
+  fun buildCallbacks(dependencies: AppDependencies) =
+    AppContentCallbacks(
+      onResetApp = {
+        resetApp(
+          dependencies = dependencies,
+          onThemeReset = { appTheme = AppTheme.SYSTEM },
+          onLanguageReset = { appLanguage = AppLanguage.SYSTEM },
+          onVersionIncrement = { featuresVersion++ },
+          onModeReset = { appMode = AppMode.NOT_SELECTED },
+          onOnboardingReset = { showOnboarding = false },
+        )
+      },
+      onThemeChanged = { appTheme = it },
+      onLanguageChanged = {
+        dependencies.localeProvider.configureLocale(it)
+        appLanguage = it
+      },
+    )
+}
+
+@Composable
+private fun rememberAppRootState(dependencies: AppDependencies): AppRootState {
+  val initialPrefs = remember { dependencies.loadPreferences() }
+  val currentVersion = remember { dependencies.loadAppDetails().version }
+  remember { dependencies.localeProvider.configureLocale(initialPrefs.language) }
+  return remember {
+    AppRootState(
+      initialMode = dependencies.fixInvalidOnlineMode(),
+      initialTheme = initialPrefs.theme,
+      initialLanguage = initialPrefs.language,
+      currentVersion = currentVersion,
+    )
   }
 }
 

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -107,7 +107,6 @@ internal fun SwipeableTabContent(
   }
 }
 
-@Suppress("LongMethod")
 @Composable
 private fun SwipeablePagerContent(
   memosState: MemosState,

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -2,6 +2,7 @@ package space.be1ski.vibits.feature.homescreen.presentation.view
 
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -18,11 +19,14 @@ import space.be1ski.vibits.core.ui.theme.LocalWideLayout
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
+import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.habits.presentation.view.components.rememberHabitsConfigTimeline
+import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
+import space.be1ski.vibits.feature.memos.presentation.state.MemosState
+import space.be1ski.vibits.feature.settings.presentation.state.SettingsState
 import space.be1ski.vibits.feature.settings.presentation.view.SettingsDialog
 
-@Suppress("LongMethod")
 @Composable
 internal fun VibitsApp(
   features: AppFeatures,
@@ -41,30 +45,9 @@ internal fun VibitsApp(
   val habitsTimeline = rememberHabitsConfigTimeline(memosState.memos)
   val todayHabits = rememberTodayHabits(habitsTimeline, memosState.memos, timeZone, today)
 
-  val coroutineScope = rememberCoroutineScope()
-  var celebrationAnimation by remember { mutableStateOf<CelebrationAnimation?>(null) }
-  val allJustCompleted = rememberAllHabitsJustCompleted(todayHabits, justFinishedOnboarding)
-  LaunchedEffect(allJustCompleted) {
-    if (allJustCompleted) celebrationAnimation = CelebrationAnimation.Confetti
-  }
-
-  var changelogEntries by remember { mutableStateOf<List<ChangelogEntry>?>(null) }
-  var updateAvailability by remember { mutableStateOf<UpdateAvailability?>(null) }
-  var upgradeState by remember { mutableStateOf(UpgradeState.IDLE) }
-
-  LaunchedEffect(Unit) {
-    val entries = config.getChangelog(config.currentVersion)
-    if (entries.isNotEmpty()) {
-      changelogEntries = entries
-    }
-  }
-
-  LaunchedEffect(Unit) {
-    val checkForUpdate = config.checkForUpdate
-    if (checkForUpdate != null) {
-      updateAvailability = checkForUpdate(config.currentVersion)
-    }
-  }
+  val celebrationAnimation = rememberCelebrationState(todayHabits, justFinishedOnboarding)
+  val changelogEntries = rememberChangelogEntries(config)
+  val updateState = rememberUpdateState(config)
 
   FeatureCoordinator(
     features = features,
@@ -77,6 +60,46 @@ internal fun VibitsApp(
   )
 
   val wideLayout = LocalWideLayout.current
+  VibitsAppShell(
+    wideLayout = wideLayout,
+    features = features,
+    appState = appState,
+    memosState = memosState,
+    habitsState = habitsState,
+    settingsState = settingsState,
+    config = config,
+    testLogs = testLogs,
+    updateState = updateState,
+  )
+
+  VibitsAppDialogs(
+    features = features,
+    appState = appState,
+    memosState = memosState,
+    habitsState = habitsState,
+    settingsState = settingsState,
+    config = config,
+    testLogs = testLogs,
+    wideLayout = wideLayout,
+    changelogEntries = changelogEntries.value,
+    onDismissChangelog = { changelogEntries.value = null },
+    celebrationAnimation = celebrationAnimation.value,
+    onCelebrationFinished = { celebrationAnimation.value = null },
+  )
+}
+
+@Composable
+private fun VibitsAppShell(
+  wideLayout: Boolean,
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  settingsState: SettingsState,
+  config: AppContentConfig,
+  testLogs: List<LogEntry>?,
+  updateState: AppUpdateState,
+) {
   if (wideLayout) {
     VibitsDesktopShell(
       features = features,
@@ -89,18 +112,10 @@ internal fun VibitsApp(
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
       exportService = config.exportService,
       testLogs = testLogs,
-      updateAvailability = updateAvailability,
-      upgradeState = upgradeState,
-      onUpgrade = {
-        val appUpdater = config.appUpdater
-        if (appUpdater != null) {
-          upgradeState = UpgradeState.UPGRADING
-          coroutineScope.launch {
-            upgradeState = if (appUpdater.upgrade()) UpgradeState.DONE else UpgradeState.FAILED
-          }
-        }
-      },
-      onRestart = { config.appUpdater?.restart() },
+      updateAvailability = updateState.availability,
+      upgradeState = updateState.upgradeState,
+      onUpgrade = updateState.onUpgrade,
+      onRestart = updateState.onRestart,
     )
   } else {
     VibitsAppScaffold(
@@ -113,7 +128,84 @@ internal fun VibitsApp(
       syncDebounceSeconds = settingsState.selectedSyncDebounceSeconds,
     )
   }
+}
 
+@Composable
+private fun rememberCelebrationState(
+  todayHabits: TodayHabits,
+  justFinishedOnboarding: Boolean,
+): MutableState<CelebrationAnimation?> {
+  val state = remember { mutableStateOf<CelebrationAnimation?>(null) }
+  val allJustCompleted = rememberAllHabitsJustCompleted(todayHabits, justFinishedOnboarding)
+  LaunchedEffect(allJustCompleted) {
+    if (allJustCompleted) state.value = CelebrationAnimation.Confetti
+  }
+  return state
+}
+
+@Composable
+private fun rememberChangelogEntries(config: AppContentConfig): MutableState<List<ChangelogEntry>?> {
+  val state = remember { mutableStateOf<List<ChangelogEntry>?>(null) }
+  LaunchedEffect(Unit) {
+    val entries = config.getChangelog(config.currentVersion)
+    if (entries.isNotEmpty()) {
+      state.value = entries
+    }
+  }
+  return state
+}
+
+private class AppUpdateState(
+  val availability: UpdateAvailability?,
+  val upgradeState: UpgradeState,
+  val onUpgrade: () -> Unit,
+  val onRestart: () -> Unit,
+)
+
+@Composable
+private fun rememberUpdateState(config: AppContentConfig): AppUpdateState {
+  var updateAvailability by remember { mutableStateOf<UpdateAvailability?>(null) }
+  var upgradeState by remember { mutableStateOf(UpgradeState.IDLE) }
+  val coroutineScope = rememberCoroutineScope()
+
+  LaunchedEffect(Unit) {
+    val checkForUpdate = config.checkForUpdate
+    if (checkForUpdate != null) {
+      updateAvailability = checkForUpdate(config.currentVersion)
+    }
+  }
+
+  return AppUpdateState(
+    availability = updateAvailability,
+    upgradeState = upgradeState,
+    onUpgrade = {
+      val appUpdater = config.appUpdater
+      if (appUpdater != null) {
+        upgradeState = UpgradeState.UPGRADING
+        coroutineScope.launch {
+          upgradeState = if (appUpdater.upgrade()) UpgradeState.DONE else UpgradeState.FAILED
+        }
+      }
+    },
+    onRestart = { config.appUpdater?.restart() },
+  )
+}
+
+@Composable
+private fun VibitsAppDialogs(
+  features: AppFeatures,
+  appState: AppState,
+  memosState: MemosState,
+  habitsState: HabitsState,
+  settingsState: SettingsState,
+  config: AppContentConfig,
+  testLogs: List<LogEntry>?,
+  wideLayout: Boolean,
+  changelogEntries: List<ChangelogEntry>?,
+  onDismissChangelog: () -> Unit,
+  celebrationAnimation: CelebrationAnimation?,
+  onCelebrationFinished: () -> Unit,
+) {
   val dateFormatter = rememberDateFormatter()
 
   if (!wideLayout) {
@@ -126,12 +218,12 @@ internal fun VibitsApp(
   changelogEntries?.let { entries ->
     ChangelogDialog(
       entries = entries,
-      onDismiss = { changelogEntries = null },
+      onDismiss = onDismissChangelog,
     )
   }
 
   CelebrationOverlay(
     animation = celebrationAnimation,
-    onFinished = { celebrationAnimation = null },
+    onFinished = onCelebrationFinished,
   )
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsDesktopShell.kt
@@ -43,7 +43,6 @@ import space.be1ski.vibits.feature.settings.presentation.view.SettingsPage
 
 private val DESKTOP_CONTENT_MAX_WIDTH = 900.dp
 
-@Suppress("LongMethod")
 @Composable
 internal fun VibitsDesktopShell(
   features: AppFeatures,
@@ -63,15 +62,7 @@ internal fun VibitsDesktopShell(
 ) {
   val shell = rememberAppShellState(features, appState, memosState, habitsState)
 
-  // Sync settings screen ↔ dialog state
-  LaunchedEffect(settingsState.isOpen, appState.selectedScreen) {
-    if (!settingsState.isOpen && appState.selectedScreen == Screen.SETTINGS) {
-      features.app.send(AppAction.Navigation.SelectScreen(Screen.HABITS))
-    }
-    if (settingsState.isOpen && appState.selectedScreen != Screen.SETTINGS) {
-      features.settings.send(SettingsAction.Dialog.Dismiss)
-    }
-  }
+  SettingsSyncEffect(features, settingsState, appState)
 
   Surface(modifier = Modifier.fillMaxSize()) {
     Row(modifier = Modifier.fillMaxSize()) {
@@ -82,31 +73,14 @@ internal fun VibitsDesktopShell(
         onAppAction = features.app::send,
         dispatchMemos = features.memos::send,
         callbacks =
-          SidebarCallbacks(
-            onClearSelection = shell.callbacks.onClearSelection,
-            onFeedScrollToTop = shell.callbacks.onFeedScrollToTop,
-            onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
-            onOpenConfigDialog = {
-              features.habits.send(
-                space.be1ski.vibits.feature.habits.presentation.action.HabitsAction.Config.OpenConfigDialog(
-                  shell.todayHabits.config,
-                ),
-              )
-            },
-            onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
-            onSettingsClick = {
-              features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
-              features.settings.send(
-                SettingsAction.Dialog.Open(
-                  baseUrl = memosState.baseUrl,
-                  token = memosState.token,
-                  appMode = appState.appMode,
-                  language = currentLanguage,
-                  theme = currentTheme,
-                  syncDebounceSeconds = syncDebounceSeconds,
-                ),
-              )
-            },
+          rememberDesktopSidebarCallbacks(
+            shell = shell,
+            features = features,
+            memosState = memosState,
+            appState = appState,
+            currentLanguage = currentLanguage,
+            currentTheme = currentTheme,
+            syncDebounceSeconds = syncDebounceSeconds,
             onUpgrade = onUpgrade,
             onRestart = onRestart,
           ),
@@ -137,6 +111,64 @@ internal fun VibitsDesktopShell(
 }
 
 @Composable
+private fun SettingsSyncEffect(
+  features: AppFeatures,
+  settingsState: SettingsState,
+  appState: AppState,
+) {
+  LaunchedEffect(settingsState.isOpen, appState.selectedScreen) {
+    if (!settingsState.isOpen && appState.selectedScreen == Screen.SETTINGS) {
+      features.app.send(AppAction.Navigation.SelectScreen(Screen.HABITS))
+    }
+    if (settingsState.isOpen && appState.selectedScreen != Screen.SETTINGS) {
+      features.settings.send(SettingsAction.Dialog.Dismiss)
+    }
+  }
+}
+
+@Suppress("LongParameterList")
+@Composable
+private fun rememberDesktopSidebarCallbacks(
+  shell: AppShellState,
+  features: AppFeatures,
+  memosState: MemosState,
+  appState: AppState,
+  currentLanguage: AppLanguage,
+  currentTheme: AppTheme,
+  syncDebounceSeconds: Int,
+  onUpgrade: () -> Unit,
+  onRestart: () -> Unit,
+): SidebarCallbacks =
+  SidebarCallbacks(
+    onClearSelection = shell.callbacks.onClearSelection,
+    onFeedScrollToTop = shell.callbacks.onFeedScrollToTop,
+    onOpenTodayEditor = shell.callbacks.onOpenTodayEditor,
+    onOpenConfigDialog = {
+      features.habits.send(
+        space.be1ski.vibits.feature.habits.presentation.action.HabitsAction.Config.OpenConfigDialog(
+          shell.todayHabits.config,
+        ),
+      )
+    },
+    onShowCreateMemoDialog = shell.callbacks.onShowCreateMemoDialog,
+    onSettingsClick = {
+      features.app.send(AppAction.Navigation.SelectScreen(Screen.SETTINGS))
+      features.settings.send(
+        SettingsAction.Dialog.Open(
+          baseUrl = memosState.baseUrl,
+          token = memosState.token,
+          appMode = appState.appMode,
+          language = currentLanguage,
+          theme = currentTheme,
+          syncDebounceSeconds = syncDebounceSeconds,
+        ),
+      )
+    },
+    onUpgrade = onUpgrade,
+    onRestart = onRestart,
+  )
+
+@Composable
 private fun SyncDialogs(
   memosState: MemosState,
   dispatchMemos: (MemosAction) -> Unit,
@@ -154,7 +186,7 @@ private fun SyncDialogs(
   }
 }
 
-@Suppress("LongMethod", "LongParameterList")
+@Suppress("LongParameterList")
 @Composable
 private fun DesktopContent(
   modifier: Modifier = Modifier,


### PR DESCRIPTION
## Summary
- Extract helper composables and state classes to bring long `@Composable` functions under detekt's 60-line `LongMethod` threshold
- Remove `@Suppress("LongMethod")` from `VibitsApp`, `VibitsDesktopShell`, `SwipeableContent`, `StatsScreen`, `StatsScreenContent`, and `AppRoot`
- Extract `rememberCelebrationState()`, `rememberChangelogEntries()`, `rememberUpdateState()`, `VibitsAppShell()`, `VibitsAppDialogs()` from `VibitsApp`
- Extract `SettingsSyncEffect()`, `rememberDesktopSidebarCallbacks()` from `VibitsDesktopShell`
- Extract `rememberCachedActivityData()`, `rememberTodayData()` from `StatsScreen`
- Extract `rememberOnDaySelected()`, `StatsMainChartMatrix()`, `StatsMainChartGrid()` from `StatsScreenContent`
- Extract `AppRootState` class and `rememberAppRootState()` from `AppRoot`

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] `./gradlew screenshotTests` passes — no UI changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)