### PR TITLE
Fix flaky celebration screenshot test

### DIFF
--- a/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/celebration/CelebrationOverlay.kt
+++ b/core/ui/src/commonMain/kotlin/space/be1ski/vibits/core/ui/celebration/CelebrationOverlay.kt
@@ -9,6 +9,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.platform.testTag
 import io.github.alexzhirkevich.compottie.DotLottie
 import io.github.alexzhirkevich.compottie.LottieCompositionSpec
 import io.github.alexzhirkevich.compottie.animateLottieCompositionAsState
@@ -56,7 +57,7 @@ fun CelebrationOverlay(
       else -> OVERLAY_ALPHA
     }
 
-  Box(Modifier.fillMaxSize()) {
+  Box(Modifier.fillMaxSize().then(if (composition != null) Modifier.testTag(CELEBRATION_OVERLAY_TEST_TAG) else Modifier)) {
     Image(
       painter =
         rememberLottiePainter(
@@ -69,3 +70,5 @@ fun CelebrationOverlay(
     )
   }
 }
+
+const val CELEBRATION_OVERLAY_TEST_TAG = "celebration_overlay"

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -5,6 +5,7 @@ package space.be1ski.vibits.feature.homescreen.presentation.view
 import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
+import androidx.compose.ui.test.onAllNodesWithTag
 import androidx.compose.ui.test.onNodeWithTag
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
@@ -14,6 +15,7 @@ import space.be1ski.vibits.core.elm.test.RecordingFeature
 import space.be1ski.vibits.core.platform.locale.AppLanguage
 import space.be1ski.vibits.core.platform.logging.LogLevel
 import space.be1ski.vibits.core.platform.mode.AppMode
+import space.be1ski.vibits.core.ui.celebration.CELEBRATION_OVERLAY_TEST_TAG
 import space.be1ski.vibits.core.ui.celebration.CelebrationAnimation
 import space.be1ski.vibits.core.ui.celebration.CelebrationOverlay
 import space.be1ski.vibits.core.ui.test.captureAllVariants
@@ -65,7 +67,7 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 
 private const val CELEBRATION_SCREENSHOT_PROGRESS = 0.25f
-private const val LOTTIE_LOAD_DELAY_MS = 2000L
+private const val LOTTIE_LOAD_TIMEOUT_MS = 5000L
 
 @OptIn(ExperimentalTestApi::class)
 class AppScreenshotTest {
@@ -798,7 +800,9 @@ class AppScreenshotTest {
           )
         }
       }
-      Thread.sleep(LOTTIE_LOAD_DELAY_MS)
+      waitUntil(timeoutMillis = LOTTIE_LOAD_TIMEOUT_MS) {
+        onAllNodesWithTag(CELEBRATION_OVERLAY_TEST_TAG).fetchSemanticsNodes().isNotEmpty()
+      }
       waitForIdle()
       saveScreenshot("${platform}_${theme}_app_celebration_confetti")
     }


### PR DESCRIPTION
## Summary
- Replace `Thread.sleep(2000)` with `waitUntil` on a testTag that appears only when the Lottie composition has finished loading
- Add `testTag("celebration_overlay")` to `CelebrationOverlay` when composition is non-null
- Fixes flaky `wide_light_app_celebration_confetti.png` screenshot diffs caused by race between Lottie async load and screenshot capture

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] `./gradlew screenshotTests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)