### PR TITLE
Add diagnostic logging to desktop app upgrade process

### DIFF
--- a/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/androidMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -3,5 +3,7 @@ package space.be1ski.vibits.core.platform.app
 actual class AppUpdater {
   actual suspend fun upgrade(): Boolean = false
 
+  actual fun lastUpgradeLogs(): List<String> = emptyList()
+
   actual fun restart() = Unit
 }

--- a/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/commonMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -3,5 +3,7 @@ package space.be1ski.vibits.core.platform.app
 expect class AppUpdater() {
   suspend fun upgrade(): Boolean
 
+  fun lastUpgradeLogs(): List<String>
+
   fun restart()
 }

--- a/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/desktopMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -2,33 +2,119 @@ package space.be1ski.vibits.core.platform.app
 
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import space.be1ski.vibits.core.platform.logging.LogLevel
+import space.be1ski.vibits.core.platform.logging.platformLog
+import java.io.IOException
 import java.nio.file.Files
 import java.nio.file.Path
 import kotlin.system.exitProcess
 
 private val BREW_PATHS = listOf("/opt/homebrew/bin/brew", "/usr/local/bin/brew")
+private const val TAG = "AppUpdater"
+private const val MAX_OUTPUT_LINES = 80
 
-private fun findBrew(): String? = BREW_PATHS.firstOrNull { Files.exists(Path.of(it)) }
+private fun brewCandidates(): List<String> {
+  val fromEnv =
+    System
+      .getenv("HOMEBREW_PREFIX")
+      ?.trim()
+      ?.takeIf { it.isNotBlank() }
+      ?.let { "$it/bin/brew" }
+  return (listOfNotNull(fromEnv) + BREW_PATHS).distinct()
+}
+
+private fun findBrew(): String? = brewCandidates().firstOrNull { Files.isExecutable(Path.of(it)) }
+
+private data class CommandResult(
+  val exitCode: Int,
+  val output: String,
+)
+
+private fun runCommand(vararg args: String): CommandResult {
+  val process = ProcessBuilder(*args).redirectErrorStream(true).start()
+  val output = process.inputStream.bufferedReader().use { it.readText() }
+  return CommandResult(exitCode = process.waitFor(), output = output)
+}
+
+private fun log(
+  level: LogLevel,
+  message: String,
+) {
+  platformLog(level, TAG, message)
+}
+
+private fun logCommandResult(
+  command: String,
+  result: CommandResult,
+  emit: (LogLevel, String) -> Unit,
+) {
+  val level = if (result.exitCode == 0) LogLevel.INFO else LogLevel.ERROR
+  emit(level, "$command exited with code ${result.exitCode}")
+
+  val lines =
+    result.output
+      .lineSequence()
+      .map(String::trimEnd)
+      .filter { it.isNotBlank() }
+      .toList()
+
+  if (lines.isEmpty()) {
+    emit(level, "$command output: <empty>")
+    return
+  }
+
+  lines.take(MAX_OUTPUT_LINES).forEach { line ->
+    emit(level, "$command | $line")
+  }
+  if (lines.size > MAX_OUTPUT_LINES) {
+    emit(level, "$command | ... ${lines.size - MAX_OUTPUT_LINES} more lines truncated")
+  }
+}
 
 actual class AppUpdater {
+  @Volatile
+  private var lastLogs: List<String> = emptyList()
+
   actual suspend fun upgrade(): Boolean =
     withContext(Dispatchers.IO) {
+      val collectedLogs = mutableListOf<String>()
+
+      fun emit(
+        level: LogLevel,
+        message: String,
+      ) {
+        collectedLogs += "${level.name}: $message"
+        log(level, message)
+      }
+
       try {
-        val brew = findBrew() ?: return@withContext false
-        val update =
-          ProcessBuilder(brew, "update")
-            .redirectErrorStream(true)
-            .start()
-        update.waitFor()
-        val upgrade =
-          ProcessBuilder(brew, "upgrade", "--cask", "vibits")
-            .redirectErrorStream(true)
-            .start()
-        upgrade.waitFor() == 0
-      } catch (_: Exception) {
+        val brew = findBrew()
+        if (brew == null) {
+          emit(LogLevel.ERROR, "brew binary not found. Checked: ${brewCandidates().joinToString()}")
+          return@withContext false
+        }
+
+        emit(LogLevel.INFO, "Using brew at: $brew")
+
+        val update = runCommand(brew, "update")
+        logCommandResult("brew update", update, ::emit)
+        if (update.exitCode != 0) {
+          emit(LogLevel.ERROR, "Skipping upgrade because brew update failed")
+          return@withContext false
+        }
+
+        val upgrade = runCommand(brew, "upgrade", "--cask", "vibits")
+        logCommandResult("brew upgrade --cask vibits", upgrade, ::emit)
+        upgrade.exitCode == 0
+      } catch (e: IOException) {
+        emit(LogLevel.ERROR, "Upgrade failed with exception: ${e::class.simpleName}: ${e.message}")
         false
+      } finally {
+        lastLogs = collectedLogs.toList()
       }
     }
+
+  actual fun lastUpgradeLogs(): List<String> = lastLogs
 
   actual fun restart() {
     try {

--- a/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/iosMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -3,5 +3,7 @@ package space.be1ski.vibits.core.platform.app
 actual class AppUpdater {
   actual suspend fun upgrade(): Boolean = false
 
+  actual fun lastUpgradeLogs(): List<String> = emptyList()
+
   actual fun restart() = Unit
 }

--- a/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
+++ b/core/platform/src/wasmJsMain/kotlin/space/be1ski/vibits/core/platform/app/AppUpdater.kt
@@ -3,5 +3,7 @@ package space.be1ski.vibits.core.platform.app
 actual class AppUpdater {
   actual suspend fun upgrade(): Boolean = false
 
+  actual fun lastUpgradeLogs(): List<String> = emptyList()
+
   actual fun restart() = Unit
 }

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/VibitsApp.kt
@@ -16,6 +16,7 @@ import space.be1ski.vibits.core.ui.celebration.CelebrationAnimation
 import space.be1ski.vibits.core.ui.celebration.CelebrationOverlay
 import space.be1ski.vibits.core.ui.date.rememberDateFormatter
 import space.be1ski.vibits.core.ui.theme.LocalWideLayout
+import space.be1ski.vibits.core.utils.logging.Log
 import space.be1ski.vibits.core.utils.logging.LogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.ChangelogEntry
 import space.be1ski.vibits.feature.changelog.domain.model.UpdateAvailability
@@ -162,6 +163,8 @@ private class AppUpdateState(
   val onRestart: () -> Unit,
 )
 
+private const val APP_UPDATER_TAG = "AppUpdater"
+
 @Composable
 private fun rememberUpdateState(config: AppContentConfig): AppUpdateState {
   var updateAvailability by remember { mutableStateOf<UpdateAvailability?>(null) }
@@ -183,7 +186,16 @@ private fun rememberUpdateState(config: AppContentConfig): AppUpdateState {
       if (appUpdater != null) {
         upgradeState = UpgradeState.UPGRADING
         coroutineScope.launch {
-          upgradeState = if (appUpdater.upgrade()) UpgradeState.DONE else UpgradeState.FAILED
+          val success = appUpdater.upgrade()
+          if (!success) {
+            val logs = appUpdater.lastUpgradeLogs()
+            if (logs.isEmpty()) {
+              Log.e(APP_UPDATER_TAG, "Upgrade failed with no diagnostic logs")
+            } else {
+              logs.forEach { line -> Log.e(APP_UPDATER_TAG, line) }
+            }
+          }
+          upgradeState = if (success) UpgradeState.DONE else UpgradeState.FAILED
         }
       }
     },


### PR DESCRIPTION
## Summary

- Add structured diagnostic logging to desktop `AppUpdater.upgrade()` with brew command output capture
- Add `lastUpgradeLogs()` API to retrieve logs from the last upgrade attempt across all platforms
- Log upgrade failure diagnostics in `VibitsApp` via `Log.e` for in-app observability
- Resolve brew path from `HOMEBREW_PREFIX` env var in addition to hardcoded paths
- Use `Files.isExecutable` instead of `Files.exists` for brew binary detection

## Test plan

- [ ] Run desktop app, trigger upgrade — verify logs appear in system log
- [ ] Simulate upgrade failure (e.g. rename cask) — verify diagnostic logs are captured
- [ ] Verify Android/iOS/Web builds compile (stub `lastUpgradeLogs` returns empty list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)