### PR TITLE
Automate hero image generation from UI screenshots

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,46 @@ jobs:
           tag_name: ${{ needs.resolve-version.outputs.version }}
           files: build/Vibits-*-screenshots.zip
 
+  generate-hero:
+    runs-on: ubuntu-latest
+    needs: [check-jvm, resolve-version]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          sparse-checkout: hero
+
+      - name: Download screenshots from release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: |
+          gh release download "$APP_VERSION" \
+            --repo "${{ github.repository }}" \
+            --pattern "*-screenshots.zip" \
+            --dir hero
+
+      - name: Extract screenshots
+        run: unzip -o hero/*-screenshots.zip -d hero
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install dependencies and render
+        working-directory: hero
+        run: |
+          npm install
+          node render.mjs
+
+      - name: Upload hero image to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.resolve-version.outputs.version }}
+          files: hero/hero.webp
+
   check-ios:
     runs-on: macos-latest
     needs: [resolve-version]

--- a/.github/workflows/update-hero.yml
+++ b/.github/workflows/update-hero.yml
@@ -1,0 +1,36 @@
+name: Update Hero Image
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  update-hero:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Download hero.webp from latest release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release download --repo "${{ github.repository }}" \
+            --pattern "hero.webp" \
+            --output .github/hero.webp \
+            --clobber
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add .github/hero.webp
+          if git diff --staged --quiet; then
+            echo "Hero image unchanged, skipping commit"
+          else
+            git commit -m "Update hero image from latest release"
+            git push
+          fi

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ xcuserdata/
 /.ralph/
 /fix_plan.md
 /fix_results.md
+hero/node_modules/
+hero/_hero.html
+hero/hero.webp

--- a/hero/config.json
+++ b/hero/config.json
@@ -1,0 +1,115 @@
+{
+  "canvas": { "width": 1400, "height": 700 },
+  "devices": [
+    {
+      "id": "desktop-1",
+      "type": "macbook",
+      "theme": "light",
+      "screenshot": "wide_light_app_habits_week.png",
+      "screenWidth": 380,
+      "position": { "top": -20, "left": 30 },
+      "rotate": -4,
+      "zIndex": 1
+    },
+    {
+      "id": "desktop-2",
+      "type": "macbook",
+      "theme": "dark",
+      "screenshot": "wide_dark_app_stats_week.png",
+      "screenWidth": 400,
+      "position": { "top": -10, "right": 60 },
+      "rotate": 5,
+      "zIndex": 1
+    },
+    {
+      "id": "desktop-3",
+      "type": "macbook",
+      "theme": "dark",
+      "screenshot": "wide_dark_app_habits_week.png",
+      "screenWidth": 460,
+      "position": { "top": 30, "left": 420 },
+      "rotate": 2,
+      "zIndex": 2
+    },
+    {
+      "id": "desktop-5",
+      "type": "macbook",
+      "theme": "light",
+      "screenshot": "wide_light_app_stats_month.png",
+      "screenWidth": 420,
+      "position": { "bottom": -40, "left": 140 },
+      "rotate": 6,
+      "zIndex": 3
+    },
+    {
+      "id": "desktop-4",
+      "type": "macbook",
+      "theme": "dark",
+      "screenshot": "wide_dark_app_habits_quarter.png",
+      "screenWidth": 580,
+      "position": { "top": 140, "left": 280 },
+      "rotate": -2,
+      "zIndex": 4
+    },
+    {
+      "id": "phone-1",
+      "type": "iphone",
+      "theme": "dark",
+      "screenshot": "compact_dark_app_habits_week.png",
+      "bodyWidth": 155,
+      "position": { "top": 50, "left": 15 },
+      "rotate": -12,
+      "zIndex": 6
+    },
+    {
+      "id": "phone-2",
+      "type": "iphone",
+      "theme": "light",
+      "screenshot": "compact_light_app_habits_year.png",
+      "bodyWidth": 148,
+      "position": { "top": 280, "left": 105 },
+      "rotate": 7,
+      "zIndex": 7
+    },
+    {
+      "id": "phone-3",
+      "type": "iphone",
+      "theme": "dark",
+      "screenshot": "compact_dark_app_celebration_confetti.png",
+      "bodyWidth": 140,
+      "position": { "top": 60, "left": 620 },
+      "rotate": -5,
+      "zIndex": 6
+    },
+    {
+      "id": "phone-4",
+      "type": "iphone",
+      "theme": "light",
+      "screenshot": "compact_light_app_habits_month.png",
+      "bodyWidth": 155,
+      "position": { "top": 240, "right": 120 },
+      "rotate": 10,
+      "zIndex": 7
+    },
+    {
+      "id": "phone-5",
+      "type": "iphone",
+      "theme": "dark",
+      "screenshot": "compact_dark_app_habits_quarter.png",
+      "bodyWidth": 150,
+      "position": { "top": 30, "right": 15 },
+      "rotate": 8,
+      "zIndex": 6
+    },
+    {
+      "id": "phone-6",
+      "type": "iphone",
+      "theme": "light",
+      "screenshot": "compact_light_app_stats_week.png",
+      "bodyWidth": 145,
+      "position": { "bottom": -20, "right": 45 },
+      "rotate": -9,
+      "zIndex": 5
+    }
+  ]
+}

--- a/hero/package.json
+++ b/hero/package.json
@@ -1,0 +1,7 @@
+{
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "puppeteer": "^24.0.0"
+  }
+}

--- a/hero/render.mjs
+++ b/hero/render.mjs
@@ -1,0 +1,181 @@
+import puppeteer from 'puppeteer';
+import { readFileSync, writeFileSync, existsSync, unlinkSync } from 'fs';
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const config = JSON.parse(readFileSync(path.join(__dirname, 'config.json'), 'utf8'));
+
+const missing = config.devices
+  .map(d => d.screenshot)
+  .filter(s => !existsSync(path.join(__dirname, 'ui-screenshots', s)));
+
+if (missing.length > 0) {
+  console.error('Missing screenshots:\n  ' + missing.join('\n  '));
+  process.exit(1);
+}
+
+function positionCss(pos) {
+  return Object.entries(pos).map(([k, v]) => `${k}: ${v}px`).join('; ');
+}
+
+function renderMacbook(device) {
+  const frameClass = device.theme === 'light' ? ' light-frame' : '';
+  return `
+  <div id="${device.id}" class="macbook" style="${positionCss(device.position)}; transform: rotate(${device.rotate}deg); z-index: ${device.zIndex};">
+    <div class="macbook-screen${frameClass}" style="width: ${device.screenWidth}px;">
+      <div class="macbook-titlebar">
+        <span class="tb-red"></span><span class="tb-yellow"></span><span class="tb-green"></span>
+      </div>
+      <img src="ui-screenshots/${device.screenshot}">
+    </div>
+    <div class="macbook-base"></div>
+    <div class="macbook-hinge"></div>
+  </div>`;
+}
+
+function renderIphone(device) {
+  return `
+  <div id="${device.id}" class="iphone" style="${positionCss(device.position)}; transform: rotate(${device.rotate}deg); z-index: ${device.zIndex};">
+    <div class="iphone-body ${device.theme}" style="width: ${device.bodyWidth}px;">
+      <img src="ui-screenshots/${device.screenshot}">
+    </div>
+  </div>`;
+}
+
+const dots = [
+  { cls: 'purple', size: 10, top: 25, left: 200 },
+  { cls: 'blue', size: 8, top: 12, left: 520 },
+  { cls: 'purple', size: 11, top: 55, right: 280 },
+  { cls: 'blue', size: 7, top: 660, left: 90 },
+  { cls: 'purple', size: 9, top: 640, left: 550 },
+  { cls: 'blue', size: 11, top: 380, right: 10 },
+  { cls: 'purple', size: 6, top: 685, left: 900 },
+  { cls: 'blue', size: 9, top: 680, right: 130 },
+  { cls: 'purple', size: 8, top: 320, left: 8 },
+  { cls: 'blue', size: 7, top: 18, right: 40 },
+  { cls: 'purple', size: 7, top: 500, left: 700 },
+  { cls: 'blue', size: 8, top: 150, left: 380 },
+];
+
+const dotsHtml = dots.map(d => {
+  const pos = d.left !== undefined ? `left:${d.left}px` : `right:${d.right}px`;
+  return `  <div class="dot dot-${d.cls}" style="width:${d.size}px;height:${d.size}px;top:${d.top}px;${pos};"></div>`;
+}).join('\n');
+
+const devicesHtml = config.devices
+  .map(d => d.type === 'macbook' ? renderMacbook(d) : renderIphone(d))
+  .join('\n');
+
+const html = `<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    width: ${config.canvas.width}px;
+    height: ${config.canvas.height}px;
+    background: #fafafc;
+    position: relative;
+    overflow: hidden;
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+  }
+
+  .dot {
+    position: absolute;
+    border-radius: 50%;
+    pointer-events: none;
+  }
+  .dot-purple { background: rgba(124, 58, 237, 0.45); }
+  .dot-blue { background: rgba(59, 130, 246, 0.5); }
+
+  .macbook {
+    position: absolute;
+    filter: drop-shadow(0 16px 32px rgba(0,0,0,0.14));
+  }
+  .macbook-screen {
+    border-radius: 10px 10px 0 0;
+    overflow: hidden;
+    border: 3px solid #2a2a2e;
+    background: #1a1625;
+  }
+  .macbook-screen.light-frame {
+    border-color: #c0bcc8;
+    background: #f5f5f7;
+  }
+  .macbook-titlebar {
+    height: 26px;
+    background: #1e1e22;
+    display: flex;
+    align-items: center;
+    padding-left: 11px;
+    gap: 7px;
+  }
+  .macbook-screen.light-frame .macbook-titlebar {
+    background: #e8e6ec;
+  }
+  .macbook-titlebar span {
+    width: 9px; height: 9px;
+    border-radius: 50%;
+    display: inline-block;
+  }
+  .tb-red { background: #ff5f57; }
+  .tb-yellow { background: #febc2e; }
+  .tb-green { background: #28c840; }
+  .macbook-screen img { width: 100%; display: block; }
+  .macbook-base {
+    height: 11px;
+    background: linear-gradient(to bottom, #c8c8cd, #b0b0b5);
+    border-radius: 0 0 5px 5px;
+    margin: 0 -5px;
+  }
+  .macbook-hinge {
+    height: 4px;
+    background: linear-gradient(to bottom, #d8d8dc, #c0c0c5);
+    margin: 0 20px;
+    border-radius: 0 0 2px 2px;
+  }
+
+  .iphone {
+    position: absolute;
+    filter: drop-shadow(0 12px 28px rgba(0,0,0,0.18));
+  }
+  .iphone-body {
+    border-radius: 24px;
+    overflow: hidden;
+    padding: 5px;
+  }
+  .iphone-body.dark { background: #2a2a2e; }
+  .iphone-body.light { background: #d0ccd8; }
+  .iphone-body img {
+    width: 100%;
+    display: block;
+    border-radius: 19px;
+  }
+</style>
+</head>
+<body>
+${dotsHtml}
+${devicesHtml}
+</body>
+</html>`;
+
+const { width, height } = config.canvas;
+const tmpHtml = path.join(__dirname, '_hero.html');
+writeFileSync(tmpHtml, html);
+
+const browser = await puppeteer.launch();
+const page = await browser.newPage();
+await page.setViewport({ width, height, deviceScaleFactor: 2 });
+await page.goto(`file://${tmpHtml}`, { waitUntil: 'networkidle0' });
+await page.screenshot({
+  path: path.join(__dirname, 'hero.webp'),
+  type: 'webp',
+  quality: 90,
+  clip: { x: 0, y: 0, width, height }
+});
+await browser.close();
+unlinkSync(tmpHtml);
+console.log('Done: hero.webp');


### PR DESCRIPTION
## Summary

- Add `hero/` directory with config-driven hero image renderer (Puppeteer)
- `config.json` defines which screenshots go into which device slots — single place to update
- `render.mjs` generates HTML from config, validates screenshots exist, renders to WebP
- Add `generate-hero` job to release workflow (runs after `check-jvm`, attaches `hero.webp` to release)
- Add manual `update-hero` workflow to commit latest hero image to `.github/hero.webp`

## Test plan

- [x] Local render produces correct hero.webp from `build/ui-screenshots/`
- [ ] Verify `generate-hero` job runs successfully on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)