### PR TITLE
Add release-screenshots artifact for hero generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,14 @@ jobs:
           mkdir -p build/ui-screenshots
           find . -path "*/build/ui-screenshots/*.png" -not -path "./build/*" -exec cp {} build/ui-screenshots/ \;
 
+      - name: Upload screenshots for release
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: release-screenshots
+          path: build/ui-screenshots/
+          retention-days: 7
+
       - name: Visual regression test
         if: always()
         uses: reg-viz/reg-actions@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,7 @@ jobs:
         run: |
           gh run download "$CI_RUN_ID" \
             --repo "${{ github.repository }}" \
-            --name ui-screenshots \
+            --name release-screenshots \
             --dir ui-screenshots
           zip -r "Vibits-${APP_VERSION#v}-screenshots.zip" ui-screenshots/
 


### PR DESCRIPTION
## Summary
- Add `release-screenshots` artifact upload to CI before `reg-viz` processes screenshots
- Update release workflow to download `release-screenshots` instead of `ui-screenshots`

The `ui-screenshots` artifact from `reg-viz` has nested structure (`__reg__/`, `1_actual/`) that `render.mjs` can't use. This uploads flat screenshots as a separate artifact.

Fixes `generate-hero` failure in release workflow.

## Test plan
- [ ] Verify CI uploads both `release-screenshots` and `ui-screenshots` artifacts
- [ ] Trigger release and verify `generate-hero` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)