### PR TITLE
Use reg-viz ui-screenshots artifact directly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,14 +54,6 @@ jobs:
           mkdir -p build/ui-screenshots
           find . -path "*/build/ui-screenshots/*.png" -not -path "./build/*" -exec cp {} build/ui-screenshots/ \;
 
-      - name: Upload screenshots for release
-        if: always()
-        uses: actions/upload-artifact@v7
-        with:
-          name: release-screenshots
-          path: build/ui-screenshots/
-          retention-days: 7
-
       - name: Visual regression test
         if: always()
         uses: reg-viz/reg-actions@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,8 +128,10 @@ jobs:
         run: |
           gh run download "$CI_RUN_ID" \
             --repo "${{ github.repository }}" \
-            --name release-screenshots \
-            --dir ui-screenshots
+            --name ui-screenshots \
+            --dir ci-artifacts
+          mkdir -p ui-screenshots
+          find ci-artifacts -name "*.png" -not -path "*/__reg__/*" -not -path "*/1_diff/*" -not -path "*/1_expected/*" -exec cp {} ui-screenshots/ \;
           zip -r "Vibits-${APP_VERSION#v}-screenshots.zip" ui-screenshots/
 
       - name: Upload screenshots to Release


### PR DESCRIPTION
## Summary
- Remove redundant `release-screenshots` artifact from CI
- Download `ui-screenshots` from reg-viz and extract PNGs from `1_actual/` subdirectory

## Test plan
- [ ] Verify release `generate-hero` succeeds with screenshots from `1_actual/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)