### PR TITLE
Add version to hero image filename in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -172,11 +172,16 @@ jobs:
           npm install
           node render.mjs
 
+      - name: Rename hero image
+        env:
+          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
+        run: mv .github/hero/hero.webp ".github/hero/Vibits-${APP_VERSION#v}-hero.webp"
+
       - name: Upload hero image to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.resolve-version.outputs.version }}
-          files: .github/hero/hero.webp
+          files: .github/hero/Vibits-*-hero.webp
 
   build-apk:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-hero.yml
+++ b/.github/workflows/update-hero.yml
@@ -15,14 +15,15 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Download hero.webp from latest release
+      - name: Download hero image from latest release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release download --repo "${{ github.repository }}" \
-            --pattern "hero.webp" \
-            --output .github/hero.webp \
+            --pattern "*-hero.webp" \
+            --dir /tmp/hero \
             --clobber
+          mv /tmp/hero/*-hero.webp .github/hero.webp
 
       - name: Create PR if changed
         env:


### PR DESCRIPTION
## Summary
- Rename `hero.webp` → `Vibits-{version}-hero.webp` in release assets
- Update `update-hero` workflow to download by `*-hero.webp` pattern

Consistent with other release artifacts (`Vibits-1.3.12.apk`, `Vibits-1.3.12.dmg`, etc).

## Test plan
- [ ] Verify hero image uploads with versioned name in release
- [ ] Verify `update-hero` workflow downloads the renamed file

🤖 Generated with [Claude Code](https://claude.com/claude-code)