### PR TITLE
Move hero generation out of release into standalone workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,51 +140,6 @@ jobs:
           tag_name: ${{ needs.resolve-version.outputs.version }}
           files: Vibits-*-screenshots.zip
 
-  generate-hero:
-    runs-on: ubuntu-latest
-    needs: [await-ci, resolve-version]
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-        with:
-          sparse-checkout: .github/hero
-
-      - name: Download screenshots from release
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
-        run: |
-          gh release download "$APP_VERSION" \
-            --repo "${{ github.repository }}" \
-            --pattern "*-screenshots.zip" \
-            --dir .github/hero
-
-      - name: Extract screenshots
-        run: unzip -o .github/hero/*-screenshots.zip -d .github/hero
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
-        with:
-          node-version: '24'
-
-      - name: Install dependencies and render
-        working-directory: .github/hero
-        run: |
-          npm install
-          node render.mjs
-
-      - name: Rename hero image
-        env:
-          APP_VERSION: ${{ needs.resolve-version.outputs.version }}
-        run: mv .github/hero/hero.webp ".github/hero/Vibits-${APP_VERSION#v}-hero.webp"
-
-      - name: Upload hero image to release
-        uses: softprops/action-gh-release@v2
-        with:
-          tag_name: ${{ needs.resolve-version.outputs.version }}
-          files: .github/hero/Vibits-*-hero.webp
-
   build-apk:
     runs-on: ubuntu-latest
     needs: [await-ci, resolve-version]

--- a/.github/workflows/update-hero.yml
+++ b/.github/workflows/update-hero.yml
@@ -2,6 +2,10 @@ name: Update Hero Image
 
 on:
   workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+    branches: [main]
 
 permissions:
   contents: write
@@ -10,25 +14,62 @@ permissions:
 jobs:
   update-hero:
     runs-on: ubuntu-latest
+    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
 
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          sparse-checkout: .github/hero
 
-      - name: Download hero image from latest release
+      - name: Find CI run
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release download --repo "${{ github.repository }}" \
-            --pattern "*-hero.webp" \
-            --dir /tmp/hero \
-            --clobber
-          mv /tmp/hero/*-hero.webp .github/hero.webp
+          if [ "${{ github.event_name }}" = "workflow_run" ]; then
+            echo "CI_RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
+          else
+            RUN_ID=$(gh run list \
+              --repo "${{ github.repository }}" \
+              --workflow CI \
+              --branch main \
+              --status success \
+              --limit 1 \
+              --json databaseId --jq '.[0].databaseId')
+            echo "CI_RUN_ID=$RUN_ID" >> $GITHUB_ENV
+          fi
+
+      - name: Download screenshots from CI
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh run download "$CI_RUN_ID" \
+            --repo "${{ github.repository }}" \
+            --name ui-screenshots \
+            --dir ci-artifacts
+          mkdir -p .github/hero/ui-screenshots
+          find ci-artifacts -name "*.png" \
+            -not -path "*/__reg__/*" \
+            -not -path "*/1_diff/*" \
+            -not -path "*/1_expected/*" \
+            -exec cp {} .github/hero/ui-screenshots/ \;
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '24'
+
+      - name: Render hero image
+        working-directory: .github/hero
+        run: |
+          npm install
+          node render.mjs
 
       - name: Create PR if changed
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
+          cp .github/hero/hero.webp .github/hero.webp
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add .github/hero.webp
@@ -37,12 +78,12 @@ jobs:
           else
             BRANCH="update-hero-image"
             git checkout -b "$BRANCH"
-            git commit -m "Update hero image from latest release"
+            git commit -m "Update hero image"
             git push -f origin "$BRANCH"
             if ! gh pr list --head "$BRANCH" --state open --json number --jq '.[0].number' | grep -q .; then
               gh pr create \
                 --title "Update hero image" \
-                --body "Auto-generated from latest release hero.webp" \
+                --body "Auto-generated from latest CI screenshots." \
                 --head "$BRANCH"
               gh pr merge --auto --squash --delete-branch
             fi


### PR DESCRIPTION
## Summary
- Remove `generate-hero` job from release workflow
- Rewrite `update-hero` workflow to generate hero image directly from CI screenshots
- Triggers automatically on CI success on main, or manually via `workflow_dispatch`

Hero image is for the README, not a release artifact. No reason to tie it to the release pipeline.

## Test plan
- [ ] Verify release workflow no longer has `generate-hero` job
- [ ] Trigger `Update Hero Image` manually and verify it renders + creates PR
- [ ] Verify it auto-triggers after CI on main succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)