### PR TITLE
Use PAT for hero workflow to trigger CI on PRs

### DIFF
--- a/.github/workflows/update-hero.yml
+++ b/.github/workflows/update-hero.yml
@@ -21,6 +21,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           sparse-checkout: .github/hero
+          token: ${{ secrets.HERO_PAT }}
 
       - name: Find CI run
         env:
@@ -67,7 +68,7 @@ jobs:
 
       - name: Create PR if changed
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.HERO_PAT }}
         run: |
           cp .github/hero/hero.webp .github/hero.webp
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
## Summary
- Use `HERO_PAT` for checkout and PR creation in `update-hero` workflow
- `GITHUB_TOKEN`-created PRs don't trigger CI, so status checks never run and auto-merge is blocked

## Test plan
- [ ] Run `Update Hero Image` workflow and verify CI triggers on the created PR
- [ ] Verify auto-merge works after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)