### PR TITLE
Put waterConfig first in allHabits screenshot list

### DIFF
--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -85,8 +85,8 @@ class AppScreenshotTest {
   private val earlySleepConfig = HabitConfig(tag = "#habits/early_sleep", label = "Early Sleep", color = HabitColor(0xFF607D8B))
   private val allHabits =
     listOf(
-      meditationConfig,
       waterConfig,
+      meditationConfig,
       exerciseConfig,
       readingConfig,
       walkingConfig,


### PR DESCRIPTION
## Summary
- Reorder `allHabits` in `AppScreenshotTest` so `waterConfig` is first and `meditationConfig` second

## Test plan
- [x] `checkJvm` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)