### PR TITLE
Fix release workflow picking wrong version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,8 @@ jobs:
       - name: Get latest tag and calculate next version
         id: version
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
+          LATEST_TAG=$(git tag --sort=-v:refname | head -1)
+          LATEST_TAG=${LATEST_TAG:-v1.0.0}
           echo "Latest tag: $LATEST_TAG"
 
           VERSION=${LATEST_TAG#v}


### PR DESCRIPTION
## Summary
- Replace `git describe --tags --abbrev=0` with `git tag --sort=-v:refname | head -1` to find the latest version tag by semver instead of commit graph proximity
- This caused releases to try creating v1.0.6 instead of v1.4.2

## Test plan
- [ ] Trigger a release workflow_dispatch and verify it picks the correct latest tag (v1.4.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)