### PR TITLE
Add generateHeroImage Gradle task

### DIFF
--- a/.github/workflows/update-hero.yml
+++ b/.github/workflows/update-hero.yml
@@ -19,131 +19,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
-          sparse-checkout: .github/hero
           token: ${{ secrets.HERO_PAT }}
 
-      - name: Find CI run
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          if [ "${{ github.event_name }}" = "workflow_run" ]; then
-            echo "CI_RUN_ID=${{ github.event.workflow_run.id }}" >> $GITHUB_ENV
-          else
-            RUN_ID=$(gh run list \
-              --repo "${{ github.repository }}" \
-              --workflow CI \
-              --branch main \
-              --status success \
-              --limit 1 \
-              --json databaseId --jq '.[0].databaseId')
-            echo "CI_RUN_ID=$RUN_ID" >> $GITHUB_ENV
-          fi
-
-      - name: Download screenshots from CI
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run download "$CI_RUN_ID" \
-            --repo "${{ github.repository }}" \
-            --name ui-screenshots \
-            --dir ci-artifacts
-          mkdir -p .github/hero/ui-screenshots
-          find ci-artifacts -name "*.png" \
-            -not -path "*/__reg__/*" \
-            -not -path "*/1_diff/*" \
-            -not -path "*/1_expected/*" \
-            -exec cp {} .github/hero/ui-screenshots/ \;
-
-      - name: Download hero candidates manifest
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh run download "$CI_RUN_ID" \
-            --repo "${{ github.repository }}" \
-            --name hero-candidates \
-            --dir ci-hero-manifest || echo "No hero manifest found"
-          if [ -f ci-hero-manifest/hero-candidates.txt ]; then
-            cp ci-hero-manifest/hero-candidates.txt .github/hero/ui-screenshots/hero-candidates.txt
-          fi
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v4
         with:
-          node-version: '24'
+          distribution: 'temurin'
+          java-version: '21'
 
-      - name: Install renderer dependencies
-        working-directory: .github/hero
-        run: npm install
-
-      - name: Check if hero inputs changed
-        id: check
-        run: |
-          MANIFEST=".github/hero/ui-screenshots/hero-candidates.txt"
-          if [ ! -f "$MANIFEST" ]; then
-            HERO_EXISTS=$(git ls-remote --heads origin hero | wc -l | tr -d ' ')
-            if [ "$HERO_EXISTS" = "0" ]; then
-              echo "::error::Hero branch does not exist and no manifest available to render it"
-              exit 1
-            fi
-            echo "skip=true" >> $GITHUB_OUTPUT
-            exit 0
-          fi
-          SCREENSHOTS_DIR=".github/hero/ui-screenshots"
-          # Hash all render inputs: manifest, candidate PNGs, config, renderer, dependencies
-          {
-            sort "$MANIFEST"
-            sort "$MANIFEST" | while read -r f; do
-              if [ -f "$SCREENSHOTS_DIR/$f" ]; then
-                sha256sum "$SCREENSHOTS_DIR/$f"
-              fi
-            done
-            sha256sum .github/hero/config.json
-            sha256sum .github/hero/render.mjs
-            sha256sum .github/hero/package.json
-            sha256sum .github/hero/package-lock.json
-          } | sha256sum | cut -d' ' -f1 > /tmp/hero-hash-new.txt
-          echo "hash=$(cat /tmp/hero-hash-new.txt)" >> $GITHUB_OUTPUT
-          echo "skip=false" >> $GITHUB_OUTPUT
-
-      - name: Restore previous hash
-        if: steps.check.outputs.skip != 'true'
-        id: cache
-        uses: actions/cache/restore@v5
-        with:
-          path: /tmp/hero-hash.txt
-          key: hero-hash-${{ github.run_id }}
-          restore-keys: hero-hash-
-
-      - name: Compare hashes
-        if: steps.check.outputs.skip != 'true'
-        id: compare
-        run: |
-          PREV_HASH=""
-          if [ -f /tmp/hero-hash.txt ]; then
-            PREV_HASH=$(cat /tmp/hero-hash.txt)
-          fi
-          HERO_EXISTS=$(git ls-remote --heads origin hero | wc -l | tr -d ' ')
-          if [ "$HERO_EXISTS" = "0" ]; then
-            echo "Hero branch missing, must publish"
-            echo "skip=false" >> $GITHUB_OUTPUT
-          elif [ -n "$PREV_HASH" ] && [ "$PREV_HASH" = "${{ steps.check.outputs.hash }}" ]; then
-            echo "Hero candidates unchanged, skipping"
-            echo "skip=true" >> $GITHUB_OUTPUT
-          else
-            echo "skip=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Render hero image
-        if: steps.check.outputs.skip != 'true' && steps.compare.outputs.skip != 'true'
-        working-directory: .github/hero
-        run: node render.mjs
+      - name: Generate hero image
+        run: xvfb-run ./gradlew generateHeroImage
 
       - name: Publish to hero branch
-        if: steps.check.outputs.skip != 'true' && steps.compare.outputs.skip != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.HERO_PAT }}
         run: |
-          cp .github/hero/hero.webp /tmp/hero.webp
+          cp build/hero/hero.webp /tmp/hero.webp
           git config user.name "automatedcolleague"
           git config user.email "automatedcolleague@users.noreply.github.com"
           git checkout --orphan hero
@@ -153,14 +42,3 @@ jobs:
           git add hero.webp
           git commit -m "Update hero image"
           git push -f origin hero
-
-      - name: Cache new hash
-        if: steps.check.outputs.skip != 'true' && steps.compare.outputs.skip != 'true'
-        run: cp /tmp/hero-hash-new.txt /tmp/hero-hash.txt
-
-      - name: Save hash cache
-        if: steps.check.outputs.skip != 'true' && steps.compare.outputs.skip != 'true'
-        uses: actions/cache/save@v5
-        with:
-          path: /tmp/hero-hash.txt
-          key: hero-hash-${{ github.run_id }}

--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -28,5 +28,6 @@ dependencies {
   implementation(libs.ksp.plugin)
   implementation(libs.ktlint.plugin)
   implementation(libs.metro.plugin)
+  implementation(libs.node.gradle.plugin)
   implementation(libs.room.plugin)
 }

--- a/build-logic/convention/src/main/kotlin/vibits.checks.hero.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.hero.gradle.kts
@@ -1,0 +1,60 @@
+import com.github.gradle.node.NodeExtension
+import com.github.gradle.node.npm.task.NpmTask
+import com.github.gradle.node.task.NodeTask
+
+plugins {
+  id("com.github.node-gradle.node")
+}
+
+val heroDir = rootProject.file(".github/hero")
+
+configure<NodeExtension> {
+  version = "24.0.0"
+  download = true
+  nodeProjectDir = heroDir
+}
+
+val heroNpmInstall = tasks.register<NpmTask>("heroNpmInstall") {
+  group = "hero"
+  description = "Install Node dependencies for hero image renderer"
+  workingDir = heroDir
+  args = listOf("install")
+  inputs.file(heroDir.resolve("package.json"))
+  outputs.dir(heroDir.resolve("node_modules"))
+}
+
+val screenshotsDir = heroDir.resolve("ui-screenshots")
+
+val copyScreenshotsForHero = tasks.register<Copy>("copyScreenshotsForHero") {
+  group = "hero"
+  description = "Copy screenshot test output into hero renderer directory"
+  dependsOn("screenshotTests")
+  from(rootProject.layout.buildDirectory.dir("ui-screenshots"))
+  into(screenshotsDir)
+}
+
+val renderHeroImage = tasks.register<NodeTask>("renderHeroImage") {
+  group = "hero"
+  description = "Render hero image using Puppeteer"
+  dependsOn(heroNpmInstall, copyScreenshotsForHero)
+  script = heroDir.resolve("render.mjs")
+  inputs.dir(screenshotsDir)
+  inputs.file(heroDir.resolve("config.json"))
+  inputs.file(heroDir.resolve("render.mjs"))
+  outputs.file(heroDir.resolve("hero.webp"))
+}
+
+tasks.register("generateHeroImage") {
+  group = "hero"
+  description = "Generate hero.webp from screenshot tests"
+  notCompatibleWithConfigurationCache("copies files at execution time")
+  dependsOn(renderHeroImage)
+
+  val heroOutput = heroDir.resolve("hero.webp")
+  val buildHeroDir = rootProject.layout.buildDirectory.dir("hero").get().asFile
+
+  doLast {
+    buildHeroDir.mkdirs()
+    heroOutput.copyTo(buildHeroDir.resolve("hero.webp"), overwrite = true)
+  }
+}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -15,5 +15,6 @@ plugins {
   id("vibits.checks.coverage")
   id("vibits.checks.githooks")
   id("vibits.checks.screenshots")
+  id("vibits.checks.hero")
   id("vibits.checks.verification")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -18,3 +18,11 @@ plugins {
   id("vibits.checks.hero")
   id("vibits.checks.verification")
 }
+
+// node-gradle plugin adds a project-level Ivy repository (nodejs.org),
+// which with PREFER_PROJECT causes Gradle to skip settings repositories.
+// Re-declare them here so all dependencies (e.g. kover-jvm-agent) resolve.
+repositories {
+  google()
+  mavenCentral()
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ datetime = "0.7.1"
 detekt = "1.23.8"
 kover = "0.9.7"
 metro = "0.11.2"
+nodeGradle = "7.1.0"
 kotlin = "2.3.10"
 ksp = "2.3.6"
 ktor = "3.4.1"
@@ -79,6 +80,7 @@ ktor-client-okhttp = { group = "io.ktor", name = "ktor-client-okhttp", version.r
 ktor-serialization-kotlinx-json = { group = "io.ktor", name = "ktor-serialization-kotlinx-json", version.ref = "ktor" }
 material-components = { group = "com.google.android.material", name = "material", version.ref = "material" }
 metro-plugin = { group = "dev.zacsweers.metro", name = "gradle-plugin", version.ref = "metro" }
+node-gradle-plugin = { group = "com.github.node-gradle", name = "gradle-node-plugin", version.ref = "nodeGradle" }
 room-plugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "room" }
 slf4j-simple = { group = "org.slf4j", name = "slf4j-simple", version.ref = "slf4j" }
 firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
@@ -94,5 +96,6 @@ kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "ko
 kotlin-multiplatform = { id = "org.jetbrains.kotlin.multiplatform", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
+node-gradle = { id = "com.github.node-gradle.node", version.ref = "nodeGradle" }
 google-services = { id = "com.google.gms.google-services", version.ref = "googleServices" }
 firebase-appdistribution = { id = "com.google.firebase.appdistribution", version.ref = "firebaseAppDistribution" }


### PR DESCRIPTION
## Summary
- New `vibits.checks.hero` convention plugin with `node-gradle` for auto-downloading Node.js
- `./gradlew generateHeroImage` chains: screenshot tests → copy → npm install → Puppeteer render → `build/hero/hero.webp`
- Simplifies `update-hero.yml` CI workflow from ~160 lines to ~40 lines (drops artifact downloads, Node setup, hash caching)
- Gradle up-to-date checks handle caching (second run completes in ~3s)

## Test plan
- [x] `./gradlew generateHeroImage` produces `build/hero/hero.webp` locally
- [x] Second run is up-to-date (~3s)
- [x] `checkJvm` passes
- [ ] CI workflow runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)