### PR TITLE
Install cwebp in hero CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,6 +112,9 @@ jobs:
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v5
 
+      - name: Install cwebp
+        run: sudo apt-get install -y webp
+
       - name: Generate hero image
         run: xvfb-run ./gradlew generateHeroImage
 


### PR DESCRIPTION
## Summary
- Install `webp` package in the hero CI job so `cwebp` is available for generating `hero.webp`
- Fixes the `Missing generated file: build/hero/hero.webp` error on main

## Test plan
- [ ] CI `update-hero` job passes and produces `hero.webp`

🤖 Generated with [Claude Code](https://claude.com/claude-code)