### PR TITLE
Move hero candidates to manifest file

### DIFF
--- a/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.screenshots.gradle.kts
@@ -1,4 +1,5 @@
 val outputDir: File = rootProject.layout.buildDirectory.dir("ui-screenshots").get().asFile
+val heroDir: File = rootProject.layout.buildDirectory.dir("hero").get().asFile
 
 // Screenshot PNGs are side-effects of desktopTest not declared as task outputs,
 // so Gradle's build cache doesn't restore them. Disable caching unconditionally
@@ -25,20 +26,22 @@ tasks.register("screenshotTests") {
   doLast {
     outputDir.deleteRecursively()
     outputDir.mkdirs()
-    val heroDir = File(outputDir, "hero").also { it.mkdirs() }
+    heroDir.mkdirs()
+    val heroCandidates = mutableSetOf<String>()
     subprojects.forEach { subproject ->
       val dir = subproject.layout.buildDirectory.dir("ui-screenshots").get().asFile
       if (dir.exists()) {
         dir.listFiles().orEmpty().filter { it.isFile && it.extension == "png" }.forEach { file ->
           file.copyTo(File(outputDir, file.name), overwrite = true)
         }
-        val subHeroDir = File(dir, "hero")
-        if (subHeroDir.exists()) {
-          subHeroDir.listFiles().orEmpty().filter { it.isFile && it.extension == "png" }.forEach { file ->
-            file.copyTo(File(heroDir, file.name), overwrite = true)
-          }
-        }
       }
+      val manifest = File(subproject.layout.buildDirectory.dir("hero").get().asFile, "hero-candidates.txt")
+      if (manifest.exists()) {
+        heroCandidates += manifest.readLines().filter { it.isNotBlank() }
+      }
+    }
+    if (heroCandidates.isNotEmpty()) {
+      File(heroDir, "hero-candidates.txt").writeText(heroCandidates.sorted().joinToString("\n") + "\n")
     }
   }
 }

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -65,19 +65,6 @@ fun ComposeUiTest.setThemedContent(
 }
 
 @OptIn(ExperimentalTestApi::class)
-fun ComposeUiTest.captureInBothThemes(
-  name: String,
-  wideLayout: Boolean = true,
-  hero: Boolean = false,
-  content: @Composable () -> Unit,
-) {
-  setThemedContent(darkTheme = false, wideLayout = wideLayout, content = content)
-  saveScreenshot("${name}_light", hero = hero)
-  setThemedContent(darkTheme = true, wideLayout = wideLayout, content = content)
-  saveScreenshot("${name}_dark", hero = hero)
-}
-
-@OptIn(ExperimentalTestApi::class)
 fun captureAllVariants(
   name: String,
   hero: Boolean = false,
@@ -121,7 +108,7 @@ fun ComposeUiTest.saveScreenshot(
   val file = File(dir, "$scenario.png")
   ImageIO.write(composite, "png", file)
   if (hero) {
-    val heroDir = File(dir, "hero").also { it.mkdirs() }
-    file.copyTo(File(heroDir, file.name), overwrite = true)
+    val heroDir = File("build/hero").also { it.mkdirs() }
+    File(heroDir, "hero-candidates.txt").appendText("${file.name}\n")
   }
 }

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
@@ -42,18 +42,13 @@ private data class HeroLayout(
 
 private fun assignScreenshots(
   config: HeroConfig,
-  screenshotsDir: File,
+  heroDir: File,
 ): Map<String, String> {
-  val heroDir = File(screenshotsDir, "hero")
-  require(heroDir.exists()) { "Missing hero screenshots directory: $heroDir" }
+  val manifest = File(heroDir, "hero-candidates.txt")
+  require(manifest.exists()) { "Missing hero-candidates.txt in $heroDir" }
 
-  val candidates =
-    heroDir
-      .listFiles()
-      .orEmpty()
-      .filter { it.isFile && it.extension == "png" }
-      .map { it.name }
-  require(candidates.isNotEmpty()) { "No hero candidate screenshots in $heroDir" }
+  val candidates = manifest.readLines().filter { it.isNotBlank() }
+  require(candidates.isNotEmpty()) { "No hero candidates listed in $manifest" }
 
   val sorted = candidates.sorted()
   val typeToLayout = mapOf("macbook" to "wide", "iphone" to "compact")
@@ -90,16 +85,16 @@ private fun assignScreenshots(
 private fun computeLayout(
   config: HeroConfig,
   screenshotsDir: File,
+  heroDir: File,
 ): HeroLayout {
-  val assignments = assignScreenshots(config, screenshotsDir)
-  val heroDir = File(screenshotsDir, "hero")
+  val assignments = assignScreenshots(config, heroDir)
 
   val deviceLayouts =
     config.devices.sortedBy { it.zIndex }.map { device ->
       val fileName = requireNotNull(assignments[device.id])
       val screenshot =
         org.jetbrains.skia.Image
-          .makeFromEncoded(File(heroDir, fileName).readBytes())
+          .makeFromEncoded(File(screenshotsDir, fileName).readBytes())
           .toComposeImageBitmap()
       val aspectRatio = screenshot.width.toFloat() / screenshot.height.toFloat()
 
@@ -138,9 +133,12 @@ private fun computeLayout(
 }
 
 @Composable
-fun HeroCanvas(screenshotsDir: File) {
+fun HeroCanvas(
+  screenshotsDir: File,
+  heroDir: File,
+) {
   val config = heroConfig
-  val layout = remember { computeLayout(config, screenshotsDir) }
+  val layout = remember { computeLayout(config, screenshotsDir, heroDir) }
 
   Box(Modifier.size(config.canvas.width.dp, config.canvas.height.dp)) {
     // Decorative dots

--- a/feature/homescreen/build.gradle.kts
+++ b/feature/homescreen/build.gradle.kts
@@ -106,9 +106,8 @@ tasks.register<Test>("heroDesktopTest") {
   classpath = files(dt.map { it.classpath.files })
   filter.includeTestsMatching("*.HeroImageTest")
   systemProperty(
-    "hero.screenshotsDir",
+    "hero.buildDir",
     rootProject.layout.buildDirectory
-      .dir("ui-screenshots")
       .get()
       .asFile
       .absolutePath,

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HeroImageTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HeroImageTest.kt
@@ -14,11 +14,15 @@ import kotlin.test.Test
 class HeroImageTest {
   @Test
   fun `generate hero image`() {
-    val screenshotsDir = System.getProperty("hero.screenshotsDir") ?: return
+    val buildDir = System.getProperty("hero.buildDir") ?: return
+    val root = File(buildDir)
     runHeroUiTest {
       setContent {
         CompositionLocalProvider(LocalDensity provides Density(2f)) {
-          HeroCanvas(screenshotsDir = File(screenshotsDir))
+          HeroCanvas(
+            screenshotsDir = File(root, "ui-screenshots"),
+            heroDir = File(root, "hero"),
+          )
         }
       }
       saveHeroImage()


### PR DESCRIPTION
## Summary
- Replace hero screenshot copies (`ui-screenshots/hero/`) with a manifest file (`build/hero/hero-candidates.txt`)
- All hero artifacts now live in `build/hero/` — no hero files mixed into `ui-screenshots/`

## Changes
- `saveScreenshot(hero=true)` writes filename to `build/hero/hero-candidates.txt` instead of copying PNG
- `screenshotTests` collects manifests from subprojects into root `build/hero/`
- `HeroCanvas` reads candidate list from manifest, loads PNGs from `ui-screenshots/`
- `HeroImageTest` receives root build dir, derives both paths

## Test plan
- [x] `./gradlew generateHeroImage` produces `build/hero/hero.webp`
- [x] No hero artifacts in `build/ui-screenshots/`
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)