### PR TITLE
Add theme-aware hero image variants with content adaptation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,31 +124,34 @@ jobs:
         run: |
           set -euo pipefail
 
-          NEW_FILE="build/hero/hero.webp"
-          if [ ! -f "$NEW_FILE" ]; then
-            echo "Missing generated file: $NEW_FILE"
-            exit 1
-          fi
+          for variant in dark light; do
+            NEW_FILE="build/hero/hero-${variant}.webp"
+            if [ ! -f "$NEW_FILE" ]; then
+              echo "Missing generated file: $NEW_FILE"
+              exit 1
+            fi
+          done
+
+          NEW_HASH="$(cat build/hero/hero-dark.webp build/hero/hero-light.webp | sha256sum | cut -d' ' -f1)"
 
           OLD_HASH="none"
           if git fetch --depth=1 origin hero:refs/remotes/origin/hero 2>/dev/null; then
-            if git cat-file -e origin/hero:hero.webp 2>/dev/null; then
-              git show origin/hero:hero.webp > /tmp/old-hero.webp
-              OLD_HASH="$(sha256sum /tmp/old-hero.webp | cut -d' ' -f1)"
+            if git cat-file -e origin/hero:hero-dark.webp 2>/dev/null && git cat-file -e origin/hero:hero-light.webp 2>/dev/null; then
+              git show origin/hero:hero-dark.webp > /tmp/old-hero-dark.webp
+              git show origin/hero:hero-light.webp > /tmp/old-hero-light.webp
+              OLD_HASH="$(cat /tmp/old-hero-dark.webp /tmp/old-hero-light.webp | sha256sum | cut -d' ' -f1)"
             fi
           fi
-
-          NEW_HASH="$(sha256sum "$NEW_FILE" | cut -d' ' -f1)"
 
           echo "new_hash=$NEW_HASH" >> "$GITHUB_OUTPUT"
           echo "old_hash=$OLD_HASH" >> "$GITHUB_OUTPUT"
 
           if [ "$NEW_HASH" = "$OLD_HASH" ]; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
-            echo "Hero image unchanged, skip publish"
+            echo "Hero images unchanged, skip publish"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
-            echo "Hero image changed, publish required"
+            echo "Hero images changed, publish required"
           fi
 
       - name: Publish hero branch
@@ -157,7 +160,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          cp build/hero/hero.webp /tmp/hero.webp
+          cp build/hero/hero-dark.webp /tmp/hero-dark.webp
+          cp build/hero/hero-light.webp /tmp/hero-light.webp
           git config user.name "automatedcolleague"
           git config user.email "automatedcolleague@users.noreply.github.com"
 
@@ -165,7 +169,8 @@ jobs:
           git reset --hard
           git clean -fdx
 
-          mv /tmp/hero.webp hero.webp
-          git add hero.webp
-          git commit -m "chore(hero): update hero.webp (${GITHUB_SHA::7})"
+          mv /tmp/hero-dark.webp hero-dark.webp
+          mv /tmp/hero-light.webp hero-light.webp
+          git add hero-dark.webp hero-light.webp
+          git commit -m "chore(hero): update hero images (${GITHUB_SHA::7})"
           git push -f origin hero

--- a/README.md
+++ b/README.md
@@ -5,7 +5,11 @@
 [![Release](https://img.shields.io/github/v/release/be1ski/vibits)](https://github.com/be1ski/vibits/releases/latest)
 [![Live Demo](https://img.shields.io/badge/demo-live-brightgreen)](https://be1ski.github.io/vibits/)
 
-![Vibits](https://raw.githubusercontent.com/be1ski/vibits/hero/hero.webp)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="https://raw.githubusercontent.com/be1ski/vibits/hero/hero-dark.webp">
+  <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/be1ski/vibits/hero/hero-light.webp">
+  <img alt="Vibits" src="https://raw.githubusercontent.com/be1ski/vibits/hero/hero-dark.webp">
+</picture>
 
 Habit tracker powered by [Memos](https://github.com/usememos/memos)
 

--- a/build-logic/convention/src/main/kotlin/vibits.checks.hero.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.hero.gradle.kts
@@ -2,7 +2,7 @@ val buildHeroDir = rootProject.layout.buildDirectory.dir("hero")
 
 tasks.register("generateHeroImage") {
   group = "hero"
-  description = "Generate hero.webp from screenshot tests"
+  description = "Generate hero.webp variants from screenshot tests"
   dependsOn("screenshotTests")
 
   subprojects {
@@ -12,30 +12,37 @@ tasks.register("generateHeroImage") {
   notCompatibleWithConfigurationCache("reads files at execution time")
 
   doLast {
-    val heroPng = subprojects
-      .map { File(it.layout.buildDirectory.get().asFile, "hero/hero.png") }
-      .firstOrNull { it.exists() }
-    requireNotNull(heroPng) { "hero.png not found in any subproject build directory" }
+    val heroPngs = subprojects
+      .flatMap { sub ->
+        val heroDir = File(sub.layout.buildDirectory.get().asFile, "hero")
+        heroDir.listFiles()?.filter { it.name.startsWith("hero-") && it.extension == "png" }
+          ?: emptyList()
+      }
+    require(heroPngs.isNotEmpty()) { "No hero-*.png files found in any subproject build directory" }
 
     val outputDir = buildHeroDir.get().asFile
     outputDir.mkdirs()
-    val heroWebp = File(outputDir, "hero.webp")
 
-    val cwebpSuccess = try {
-      val process = ProcessBuilder(
-        "cwebp", "-q", "90", "-alpha_q", "100",
-        heroPng.absolutePath, "-o", heroWebp.absolutePath,
-      ).redirectErrorStream(true).start()
-      process.waitFor() == 0
-    } catch (_: Exception) {
-      false
-    }
+    for (heroPng in heroPngs) {
+      val baseName = heroPng.nameWithoutExtension
+      val heroWebp = File(outputDir, "$baseName.webp")
 
-    if (cwebpSuccess) {
-      println("Done: ${heroWebp.name}")
-    } else {
-      heroPng.copyTo(File(outputDir, "hero.png"), overwrite = true)
-      println("Warning: cwebp not found, saved as hero.png")
+      val cwebpSuccess = try {
+        val process = ProcessBuilder(
+          "cwebp", "-q", "90", "-alpha_q", "100",
+          heroPng.absolutePath, "-o", heroWebp.absolutePath,
+        ).redirectErrorStream(true).start()
+        process.waitFor() == 0
+      } catch (_: Exception) {
+        false
+      }
+
+      if (cwebpSuccess) {
+        println("Done: ${heroWebp.name}")
+      } else {
+        heroPng.copyTo(File(outputDir, heroPng.name), overwrite = true)
+        println("Warning: cwebp not found, saved as ${heroPng.name}")
+      }
     }
   }
 }

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/ScreenshotCapture.kt
@@ -34,7 +34,7 @@ fun runHeroUiTest(block: suspend DesktopComposeUiTest.() -> Unit) =
   runDesktopComposeUiTest(width = HERO_WIDTH, height = HERO_HEIGHT, block = block)
 
 @OptIn(ExperimentalTestApi::class)
-fun ComposeUiTest.saveHeroImage() {
+fun ComposeUiTest.saveHeroImage(suffix: String = "") {
   waitForIdle()
   val roots = onAllNodes(isRoot())
   val firstImage = roots[0].captureToImage().toAwtImage()
@@ -58,8 +58,9 @@ fun ComposeUiTest.saveHeroImage() {
   dg.drawImage(composite, 0, 0, targetW, targetH, null)
   dg.dispose()
 
+  val filename = if (suffix.isEmpty()) "hero.png" else "hero-$suffix.png"
   val dir = File("build/hero").also { it.mkdirs() }
-  ImageIO.write(downscaled, "png", File(dir, "hero.png"))
+  ImageIO.write(downscaled, "png", File(dir, filename))
 }
 
 @OptIn(ExperimentalTestApi::class)

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
@@ -27,8 +27,11 @@ private val MACBOOK_SHADOW_SHAPE = RoundedCornerShape(10.dp)
 private val IPHONE_SHADOW_ELEVATION = 20.dp
 private val IPHONE_SHADOW_SHAPE = RoundedCornerShape(24.dp)
 
+private const val FOREGROUND_Z_THRESHOLD = 4
+
 private data class DeviceLayout(
   val device: HeroDevice,
+  val theme: String,
   val screenshot: ImageBitmap,
   val offsetX: Dp,
   val offsetY: Dp,
@@ -42,6 +45,7 @@ private data class HeroLayout(
 
 private fun assignScreenshots(
   config: HeroConfig,
+  variant: HeroVariant,
   heroDir: File,
 ): Map<String, String> {
   val manifest = File(heroDir, "hero-candidates.txt")
@@ -50,9 +54,17 @@ private fun assignScreenshots(
   val candidates = manifest.readLines().filter { it.isNotBlank() }.toSet()
   require(candidates.isNotEmpty()) { "No hero candidates listed in $manifest" }
 
+  val oppositeTheme =
+    when (variant) {
+      HeroVariant.DARK -> HeroVariant.LIGHT.theme
+      HeroVariant.LIGHT -> HeroVariant.DARK.theme
+    }
+
   return config.devices.associate { device ->
     val layout = if (device.type == "macbook") "wide" else "compact"
-    val filename = "${layout}_${device.theme}_${device.scenario}.png"
+    val theme =
+      if (device.zIndex >= FOREGROUND_Z_THRESHOLD) variant.theme else oppositeTheme
+    val filename = "${layout}_${theme}_${device.scenario}.png"
     require(filename in candidates) {
       "Missing screenshot for ${device.id}: $filename"
     }
@@ -60,12 +72,25 @@ private fun assignScreenshots(
   }
 }
 
+private fun deviceTheme(
+  device: HeroDevice,
+  variant: HeroVariant,
+): String {
+  val oppositeTheme =
+    when (variant) {
+      HeroVariant.DARK -> HeroVariant.LIGHT.theme
+      HeroVariant.LIGHT -> HeroVariant.DARK.theme
+    }
+  return if (device.zIndex >= FOREGROUND_Z_THRESHOLD) variant.theme else oppositeTheme
+}
+
 private fun computeLayout(
   config: HeroConfig,
+  variant: HeroVariant,
   screenshotsDir: File,
   heroDir: File,
 ): HeroLayout {
-  val assignments = assignScreenshots(config, heroDir)
+  val assignments = assignScreenshots(config, variant, heroDir)
 
   val deviceLayouts =
     config.devices.sortedBy { it.zIndex }.map { device ->
@@ -99,6 +124,7 @@ private fun computeLayout(
 
       DeviceLayout(
         device = device,
+        theme = deviceTheme(device, variant),
         screenshot = screenshot,
         offsetX = offsetX,
         offsetY = offsetY,
@@ -111,54 +137,63 @@ private fun computeLayout(
 }
 
 @Composable
+private fun HeroDots(config: HeroConfig) {
+  for (dot in config.dots) {
+    val dotColor = if (dot.color == "purple") PURPLE_DOT else BLUE_DOT
+    val x =
+      dot.left?.dp
+        ?: (config.canvas.width.dp - dot.right!!.dp - dot.size.dp)
+    Box(
+      Modifier
+        .offset(x, dot.top.dp)
+        .size(dot.size.dp)
+        .clip(CircleShape)
+        .background(dotColor),
+    )
+  }
+}
+
+@Composable
+private fun HeroDevices(layout: HeroLayout) {
+  for (dl in layout.deviceLayouts) {
+    Box(
+      modifier =
+        Modifier
+          .offset(dl.offsetX, dl.offsetY)
+          .graphicsLayer {
+            rotationZ = dl.device.rotate.toFloat()
+          }.shadow(dl.shadowElevation, dl.shadowShape),
+    ) {
+      when (dl.device.type) {
+        "macbook" ->
+          MacbookFrame(
+            screenshot = dl.screenshot,
+            screenWidth = dl.device.screenWidth!!.dp,
+            theme = dl.theme,
+          )
+        "iphone" ->
+          IphoneFrame(
+            screenshot = dl.screenshot,
+            bodyWidth = dl.device.bodyWidth!!.dp,
+            theme = dl.theme,
+          )
+      }
+    }
+  }
+}
+
+@Composable
 fun HeroCanvas(
   screenshotsDir: File,
   heroDir: File,
+  variant: HeroVariant,
 ) {
   val config = heroConfig
-  val layout = remember { computeLayout(config, screenshotsDir, heroDir) }
+  val layout =
+    remember(variant) { computeLayout(config, variant, screenshotsDir, heroDir) }
 
   Box(Modifier.size(config.canvas.width.dp, config.canvas.height.dp)) {
-    // Decorative dots
-    for (dot in config.dots) {
-      val dotColor = if (dot.color == "purple") PURPLE_DOT else BLUE_DOT
-      val x =
-        dot.left?.dp
-          ?: (config.canvas.width.dp - dot.right!!.dp - dot.size.dp)
-      Box(
-        Modifier
-          .offset(x, dot.top.dp)
-          .size(dot.size.dp)
-          .clip(CircleShape)
-          .background(dotColor),
-      )
-    }
-
-    // Devices sorted by zIndex
-    for (dl in layout.deviceLayouts) {
-      Box(
-        modifier =
-          Modifier
-            .offset(dl.offsetX, dl.offsetY)
-            .graphicsLayer {
-              rotationZ = dl.device.rotate.toFloat()
-            }.shadow(dl.shadowElevation, dl.shadowShape),
-      ) {
-        when (dl.device.type) {
-          "macbook" ->
-            MacbookFrame(
-              screenshot = dl.screenshot,
-              screenWidth = dl.device.screenWidth!!.dp,
-              theme = dl.device.theme,
-            )
-          "iphone" ->
-            IphoneFrame(
-              screenshot = dl.screenshot,
-              bodyWidth = dl.device.bodyWidth!!.dp,
-              theme = dl.device.theme,
-            )
-        }
-      }
-    }
+    HeroDots(config)
+    HeroDevices(layout)
   }
 }

--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroConfig.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroConfig.kt
@@ -1,5 +1,13 @@
 package space.be1ski.vibits.core.ui.test.hero
 
+enum class HeroVariant {
+  LIGHT,
+  DARK,
+  ;
+
+  val theme: String get() = name.lowercase()
+}
+
 data class HeroCanvasSize(
   val width: Int,
   val height: Int,
@@ -15,7 +23,6 @@ data class HeroPosition(
 data class HeroDevice(
   val id: String,
   val type: String,
-  val theme: String,
   val scenario: String,
   val screenWidth: Int? = null,
   val bodyWidth: Int? = null,
@@ -46,7 +53,6 @@ val heroConfig =
         HeroDevice(
           id = "desktop-4",
           type = "macbook",
-          theme = "dark",
           scenario = "app_habits_week",
           screenWidth = 580,
           position = HeroPosition(top = 190, left = 280),
@@ -56,7 +62,6 @@ val heroConfig =
         HeroDevice(
           id = "desktop-3",
           type = "macbook",
-          theme = "dark",
           scenario = "app_habits_month",
           screenWidth = 460,
           position = HeroPosition(top = 80, left = 420),
@@ -66,7 +71,6 @@ val heroConfig =
         HeroDevice(
           id = "desktop-1",
           type = "macbook",
-          theme = "light",
           scenario = "app_feed",
           screenWidth = 380,
           position = HeroPosition(top = 30, left = 60),
@@ -76,7 +80,6 @@ val heroConfig =
         HeroDevice(
           id = "desktop-2",
           type = "macbook",
-          theme = "dark",
           scenario = "app_stats_week",
           screenWidth = 400,
           position = HeroPosition(top = 40, right = 90),
@@ -86,7 +89,6 @@ val heroConfig =
         HeroDevice(
           id = "phone-1",
           type = "iphone",
-          theme = "dark",
           scenario = "app_habits_year",
           bodyWidth = 155,
           position = HeroPosition(top = 100, left = 50),
@@ -96,7 +98,6 @@ val heroConfig =
         HeroDevice(
           id = "phone-2",
           type = "iphone",
-          theme = "light",
           scenario = "app_feed",
           bodyWidth = 148,
           position = HeroPosition(top = 330, left = 130),
@@ -106,7 +107,6 @@ val heroConfig =
         HeroDevice(
           id = "phone-3",
           type = "iphone",
-          theme = "dark",
           scenario = "app_habit_editor",
           bodyWidth = 140,
           position = HeroPosition(top = 110, left = 620),
@@ -116,7 +116,6 @@ val heroConfig =
         HeroDevice(
           id = "phone-4",
           type = "iphone",
-          theme = "light",
           scenario = "app_habits_quarter",
           bodyWidth = 155,
           position = HeroPosition(top = 290, right = 150),

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HeroImageTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/HeroImageTest.kt
@@ -5,6 +5,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.unit.Density
 import space.be1ski.vibits.core.ui.test.hero.HeroCanvas
+import space.be1ski.vibits.core.ui.test.hero.HeroVariant
 import space.be1ski.vibits.core.ui.test.runHeroUiTest
 import space.be1ski.vibits.core.ui.test.saveHeroImage
 import java.io.File
@@ -16,16 +17,22 @@ class HeroImageTest {
   fun `generate hero image`() {
     val buildDir = System.getProperty("hero.buildDir") ?: return
     val root = File(buildDir)
-    runHeroUiTest {
-      setContent {
-        CompositionLocalProvider(LocalDensity provides Density(4f)) {
-          HeroCanvas(
-            screenshotsDir = File(root, "ui-screenshots"),
-            heroDir = File(root, "hero"),
-          )
+    val screenshotsDir = File(root, "ui-screenshots")
+    val heroDir = File(root, "hero")
+
+    for (variant in HeroVariant.entries) {
+      runHeroUiTest {
+        setContent {
+          CompositionLocalProvider(LocalDensity provides Density(4f)) {
+            HeroCanvas(
+              screenshotsDir = screenshotsDir,
+              heroDir = heroDir,
+              variant = variant,
+            )
+          }
         }
+        saveHeroImage(variant.name.lowercase())
       }
-      saveHeroImage()
     }
   }
 }


### PR DESCRIPTION
## Summary

Depends on #400.

- Add `HeroVariant` enum — foreground devices (zIndex >= 4) show the variant's theme, background devices show the opposite theme
- Both themes visible in each variant, with accent on the matching one
- Generate `hero-dark.webp` and `hero-light.webp` with distinct screenshot content
- Update Gradle task to convert both PNGs to WebP
- Update CI to hash-compare and publish both variants to hero branch
- Update README with `<picture>` tag for automatic GitHub theme adaptation

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] `./gradlew generateHeroImage` produces both `hero-dark.webp` and `hero-light.webp`
- [x] Visual: dark variant foregrounds dark screenshots, light variant foregrounds light screenshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)