### PR TITLE
Add phone habits week view to hero composition

### DIFF
--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroConfig.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroConfig.kt
@@ -122,6 +122,15 @@ val heroConfig =
           rotate = 10,
           zIndex = 7,
         ),
+        HeroDevice(
+          id = "phone-5",
+          type = "iphone",
+          scenario = "app_habits_week",
+          bodyWidth = 150,
+          position = HeroPosition(bottom = 20, left = 520),
+          rotate = -6,
+          zIndex = 5,
+        ),
       ),
     dots =
       listOf(


### PR DESCRIPTION
## Summary

Depends on #403.

- Add phone-5 device showing habits week view (bottom-center, zIndex=5)
- Colorful week grid is recognizable at phone size and complements the focal desktop

## Test plan
- [x] `./gradlew checkJvm` passes
- [x] `./gradlew generateHeroImage` produces both variants
- [x] Visual: phone-5 fits naturally below focal desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)