### PR TITLE
Optimize check-ios CI with path filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,7 +89,7 @@ jobs:
 
   check-ios:
     needs: detect-changes
-    if: github.event_name == 'push' || needs.detect-changes.outputs.ios-relevant == 'true'
+    if: needs.detect-changes.outputs.ios-relevant == 'true'
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,24 @@ permissions:
   pull-requests: write
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      ios-relevant: ${{ steps.filter.outputs.ios }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Check for iOS-relevant changes
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            ios:
+              - '**/platform/**'
+              - '**/iosMain/**'
+              - 'app/ios/**'
+
   check-jvm:
     runs-on: ubuntu-latest
 
@@ -70,6 +88,8 @@ jobs:
           retention-days: "7"
 
   check-ios:
+    needs: detect-changes
+    if: github.event_name == 'push' || needs.detect-changes.outputs.ios-relevant == 'true'
     runs-on: macos-latest
 
     steps:
@@ -92,7 +112,12 @@ jobs:
     name: Update hero image
     runs-on: ubuntu-latest
     needs: [check-jvm, check-ios]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: |
+      always()
+      && github.event_name == 'push'
+      && github.ref == 'refs/heads/main'
+      && needs.check-jvm.result == 'success'
+      && (needs.check-ios.result == 'success' || needs.check-ios.result == 'skipped')
     concurrency:
       group: hero-update-${{ github.ref }}
       cancel-in-progress: true

--- a/build-logic/convention/src/main/kotlin/vibits.checks.verification.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.checks.verification.gradle.kts
@@ -15,11 +15,10 @@ tasks.register("checkJvm") {
 
 tasks.register("checkIos") {
   group = "verification"
-  description = "Runs iOS checks: compile, ktlint (requires macOS)"
+  description = "Runs iOS checks: compile (requires macOS)"
   subprojects {
     plugins.withId("org.jetbrains.kotlin.multiplatform") {
       tasks.findByName("compileKotlinIosArm64")?.let { dependsOn(it) }
-      tasks.findByName("ktlintCheck")?.let { dependsOn(it) }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Skip `check-ios` (macOS runner) when PR/push doesn't touch iOS-relevant paths (`**/platform/**`, `**/iosMain/**`, `app/ios/**`)
- Remove duplicate `ktlintCheck` from `checkIos` — already covered by `checkJvm`
- `update-hero` tolerates skipped `check-ios`

## Test plan
- [ ] Push a PR that only changes domain logic — `check-ios` should be skipped
- [ ] Push a PR that changes `**/platform/**` — `check-ios` should run
- [ ] Push to main without iOS changes — `update-hero` runs with `check-ios` skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)