### PR TITLE
Widen shadow blur and reduce opacity for softer hero shadows

### DIFF
--- a/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
+++ b/core/ui/testing/src/desktopMain/kotlin/space/be1ski/vibits/core/ui/test/hero/HeroCanvas.kt
@@ -26,9 +26,9 @@ private val PURPLE_DOT = Color(124, 58, 237, (0.45f * 255).toInt())
 private val BLUE_DOT = Color(59, 130, 246, (0.5f * 255).toInt())
 
 private const val FOREGROUND_Z_THRESHOLD = 4
-private const val SHADOW_BLUR_RADIUS = 20f
-private const val SHADOW_OFFSET_Y = 6f
-private const val SHADOW_ALPHA = 0.55f
+private const val SHADOW_BLUR_RADIUS = 32f
+private const val SHADOW_OFFSET_Y = 8f
+private const val SHADOW_ALPHA = 0.3f
 
 private data class DeviceLayout(
   val device: HeroDevice,


### PR DESCRIPTION
## Summary

- Increase blur radius 20→32 for wider, more diffuse shadows
- Reduce alpha 0.55→0.3 for less contrasty look
- Increase offset 6→8 to match wider spread

## Test plan

- [x] `./gradlew generateHeroImage` — verified visually

🤖 Generated with [Claude Code](https://claude.com/claude-code)