### PR TITLE
Fix Gradle 9 deprecation warnings

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -13,7 +13,7 @@ kotlin {
     val desktopMain by getting {
       dependencies {
         implementation(compose.desktop.currentOs)
-        implementation(compose.components.resources)
+        implementation(libs.compose.resources)
         implementation(libs.kotlinx.coroutines.swing)
         implementation(project(":core:strings"))
         implementation(project(":feature:homescreen"))

--- a/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.library.gradle.kts
@@ -8,7 +8,7 @@ val buildConfig = the<org.gradle.accessors.dm.LibrariesForBuildConfig>()
 val libs = the<org.gradle.accessors.dm.LibrariesForLibs>()
 
 kotlin {
-  androidLibrary {
+  android {
     namespace = project.androidNamespace()
     compileSdk = buildConfig.versions.compileSdk.get().toInt()
     minSdk = buildConfig.versions.minSdk.get().toInt()

--- a/build-logic/convention/src/main/kotlin/vibits.kmp.metro.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.metro.gradle.kts
@@ -1,4 +1,4 @@
 plugins {
-  id("org.jetbrains.kotlin.multiplatform") apply false
+  id("org.jetbrains.kotlin.multiplatform")
   id("dev.zacsweers.metro")
 }

--- a/build-logic/convention/src/main/kotlin/vibits.kmp.room.gradle.kts
+++ b/build-logic/convention/src/main/kotlin/vibits.kmp.room.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-  id("org.jetbrains.kotlin.multiplatform") apply false
+  id("org.jetbrains.kotlin.multiplatform")
   id("com.google.devtools.ksp")
   id("androidx.room")
 }

--- a/feature/homescreen/build.gradle.kts
+++ b/feature/homescreen/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
 }
 
 kotlin {
-  androidLibrary {
+  android {
     androidResources {
       enable = true
     }


### PR DESCRIPTION
Fix deprecation warnings from the full clean build.

## Changes
- Replace `androidLibrary {}` with `android {}` in `vibits.kmp.library.gradle.kts` and `feature/homescreen/build.gradle.kts`
- Remove `apply false` from precompiled script plugins (`vibits.kmp.metro`, `vibits.kmp.room`) — deprecated in Gradle 9, fails in Gradle 10
- Replace deprecated `compose.components.resources` accessor with `libs.compose.resources` in `app/desktop`

One remaining warning (`ReportingExtension.file`) comes from Firebase App Distribution plugin — not our code.