### PR TITLE
Fix Android adaptive icon: full 4x4 grid with diagonal gradient

### DIFF
--- a/app/android/src/main/res/drawable/ic_launcher_foreground.xml
+++ b/app/android/src/main/res/drawable/ic_launcher_foreground.xml
@@ -1,8 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
   Adaptive icon foreground: 108×108dp canvas, 66dp safe-zone circle.
-  Grid: cell=12dp, gap=3dp, offset=25.5dp.
-  All tile centres ≤ 31.82dp from canvas centre (safe-zone radius = 33dp).
+  Grid: 4×4 tiles, cell=12dp, gap=3dp, offset=25.5dp.
+  All tile centres at 31.82dp from canvas centre (safe-zone radius = 33dp).
+  Diagonal gradient: bottom-left darkest (#5B21B6) → top-right lightest (#C084FC).
 -->
 <vector xmlns:android="http://schemas.android.com/apk/res/android"
     android:width="108dp"
@@ -10,50 +11,59 @@
     android:viewportWidth="108"
     android:viewportHeight="108">
 
-    <!-- Row 0: cols 2, 3 -->
+    <!-- Row 0 (top): cols 0–3 -->
     <path
-        android:fillColor="#EDE9FE"
+        android:fillColor="#9333EA"
+        android:pathData="M28.5,25.5 H34.5 A3,3,0,0,1,37.5,28.5 V34.5 A3,3,0,0,1,34.5,37.5 H28.5 A3,3,0,0,1,25.5,34.5 V28.5 A3,3,0,0,1,28.5,25.5 Z"/>
+    <path
+        android:fillColor="#A855F7"
+        android:pathData="M43.5,25.5 H49.5 A3,3,0,0,1,52.5,28.5 V34.5 A3,3,0,0,1,49.5,37.5 H43.5 A3,3,0,0,1,40.5,34.5 V28.5 A3,3,0,0,1,43.5,25.5 Z"/>
+    <path
+        android:fillColor="#C084FC"
         android:pathData="M58.5,25.5 H64.5 A3,3,0,0,1,67.5,28.5 V34.5 A3,3,0,0,1,64.5,37.5 H58.5 A3,3,0,0,1,55.5,34.5 V28.5 A3,3,0,0,1,58.5,25.5 Z"/>
     <path
-        android:fillColor="#F5F3FF"
+        android:fillColor="#C084FC"
         android:pathData="M73.5,25.5 H79.5 A3,3,0,0,1,82.5,28.5 V34.5 A3,3,0,0,1,79.5,37.5 H73.5 A3,3,0,0,1,70.5,34.5 V28.5 A3,3,0,0,1,73.5,25.5 Z"/>
 
-    <!-- Row 1: cols 1, 2, 3 -->
-    <path
-        android:fillColor="#C084FC"
-        android:pathData="M43.5,40.5 H49.5 A3,3,0,0,1,52.5,43.5 V49.5 A3,3,0,0,1,49.5,52.5 H43.5 A3,3,0,0,1,40.5,49.5 V43.5 A3,3,0,0,1,43.5,40.5 Z"/>
-    <path
-        android:fillColor="#DDD6FE"
-        android:pathData="M58.5,40.5 H64.5 A3,3,0,0,1,67.5,43.5 V49.5 A3,3,0,0,1,64.5,52.5 H58.5 A3,3,0,0,1,55.5,49.5 V43.5 A3,3,0,0,1,58.5,40.5 Z"/>
-    <path
-        android:fillColor="#EDE9FE"
-        android:pathData="M73.5,40.5 H79.5 A3,3,0,0,1,82.5,43.5 V49.5 A3,3,0,0,1,79.5,52.5 H73.5 A3,3,0,0,1,70.5,49.5 V43.5 A3,3,0,0,1,73.5,40.5 Z"/>
-
-    <!-- Row 2: cols 0, 1, 2, 3 -->
-    <path
-        android:fillColor="#9333EA"
-        android:pathData="M28.5,55.5 H34.5 A3,3,0,0,1,37.5,58.5 V64.5 A3,3,0,0,1,34.5,67.5 H28.5 A3,3,0,0,1,25.5,64.5 V58.5 A3,3,0,0,1,28.5,55.5 Z"/>
-    <path
-        android:fillColor="#A855F7"
-        android:pathData="M43.5,55.5 H49.5 A3,3,0,0,1,52.5,58.5 V64.5 A3,3,0,0,1,49.5,67.5 H43.5 A3,3,0,0,1,40.5,64.5 V58.5 A3,3,0,0,1,43.5,55.5 Z"/>
-    <path
-        android:fillColor="#C084FC"
-        android:pathData="M58.5,55.5 H64.5 A3,3,0,0,1,67.5,58.5 V64.5 A3,3,0,0,1,64.5,67.5 H58.5 A3,3,0,0,1,55.5,64.5 V58.5 A3,3,0,0,1,58.5,55.5 Z"/>
-    <path
-        android:fillColor="#DDD6FE"
-        android:pathData="M73.5,55.5 H79.5 A3,3,0,0,1,82.5,58.5 V64.5 A3,3,0,0,1,79.5,67.5 H73.5 A3,3,0,0,1,70.5,64.5 V58.5 A3,3,0,0,1,73.5,55.5 Z"/>
-
-    <!-- Row 3: cols 0, 1, 2, 3 -->
-    <path
-        android:fillColor="#6D28D9"
-        android:pathData="M28.5,70.5 H34.5 A3,3,0,0,1,37.5,73.5 V79.5 A3,3,0,0,1,34.5,82.5 H28.5 A3,3,0,0,1,25.5,79.5 V73.5 A3,3,0,0,1,28.5,70.5 Z"/>
+    <!-- Row 1: cols 0–3 -->
     <path
         android:fillColor="#7C3AED"
-        android:pathData="M43.5,70.5 H49.5 A3,3,0,0,1,52.5,73.5 V79.5 A3,3,0,0,1,49.5,82.5 H43.5 A3,3,0,0,1,40.5,79.5 V73.5 A3,3,0,0,1,43.5,70.5 Z"/>
+        android:pathData="M28.5,40.5 H34.5 A3,3,0,0,1,37.5,43.5 V49.5 A3,3,0,0,1,34.5,52.5 H28.5 A3,3,0,0,1,25.5,49.5 V43.5 A3,3,0,0,1,28.5,40.5 Z"/>
     <path
         android:fillColor="#9333EA"
-        android:pathData="M58.5,70.5 H64.5 A3,3,0,0,1,67.5,73.5 V79.5 A3,3,0,0,1,64.5,82.5 H58.5 A3,3,0,0,1,55.5,79.5 V73.5 A3,3,0,0,1,58.5,70.5 Z"/>
+        android:pathData="M43.5,40.5 H49.5 A3,3,0,0,1,52.5,43.5 V49.5 A3,3,0,0,1,49.5,52.5 H43.5 A3,3,0,0,1,40.5,49.5 V43.5 A3,3,0,0,1,43.5,40.5 Z"/>
     <path
         android:fillColor="#A855F7"
+        android:pathData="M58.5,40.5 H64.5 A3,3,0,0,1,67.5,43.5 V49.5 A3,3,0,0,1,64.5,52.5 H58.5 A3,3,0,0,1,55.5,49.5 V43.5 A3,3,0,0,1,58.5,40.5 Z"/>
+    <path
+        android:fillColor="#C084FC"
+        android:pathData="M73.5,40.5 H79.5 A3,3,0,0,1,82.5,43.5 V49.5 A3,3,0,0,1,79.5,52.5 H73.5 A3,3,0,0,1,70.5,49.5 V43.5 A3,3,0,0,1,73.5,40.5 Z"/>
+
+    <!-- Row 2: cols 0–3 -->
+    <path
+        android:fillColor="#6D28D9"
+        android:pathData="M28.5,55.5 H34.5 A3,3,0,0,1,37.5,58.5 V64.5 A3,3,0,0,1,34.5,67.5 H28.5 A3,3,0,0,1,25.5,64.5 V58.5 A3,3,0,0,1,28.5,55.5 Z"/>
+    <path
+        android:fillColor="#7C3AED"
+        android:pathData="M43.5,55.5 H49.5 A3,3,0,0,1,52.5,58.5 V64.5 A3,3,0,0,1,49.5,67.5 H43.5 A3,3,0,0,1,40.5,64.5 V58.5 A3,3,0,0,1,43.5,55.5 Z"/>
+    <path
+        android:fillColor="#9333EA"
+        android:pathData="M58.5,55.5 H64.5 A3,3,0,0,1,67.5,58.5 V64.5 A3,3,0,0,1,64.5,67.5 H58.5 A3,3,0,0,1,55.5,64.5 V58.5 A3,3,0,0,1,58.5,55.5 Z"/>
+    <path
+        android:fillColor="#A855F7"
+        android:pathData="M73.5,55.5 H79.5 A3,3,0,0,1,82.5,58.5 V64.5 A3,3,0,0,1,79.5,67.5 H73.5 A3,3,0,0,1,70.5,64.5 V58.5 A3,3,0,0,1,73.5,55.5 Z"/>
+
+    <!-- Row 3 (bottom): cols 0–3 -->
+    <path
+        android:fillColor="#5B21B6"
+        android:pathData="M28.5,70.5 H34.5 A3,3,0,0,1,37.5,73.5 V79.5 A3,3,0,0,1,34.5,82.5 H28.5 A3,3,0,0,1,25.5,79.5 V73.5 A3,3,0,0,1,28.5,70.5 Z"/>
+    <path
+        android:fillColor="#6D28D9"
+        android:pathData="M43.5,70.5 H49.5 A3,3,0,0,1,52.5,73.5 V79.5 A3,3,0,0,1,49.5,82.5 H43.5 A3,3,0,0,1,40.5,79.5 V73.5 A3,3,0,0,1,43.5,70.5 Z"/>
+    <path
+        android:fillColor="#7C3AED"
+        android:pathData="M58.5,70.5 H64.5 A3,3,0,0,1,67.5,73.5 V79.5 A3,3,0,0,1,64.5,82.5 H58.5 A3,3,0,0,1,55.5,79.5 V73.5 A3,3,0,0,1,58.5,70.5 Z"/>
+    <path
+        android:fillColor="#9333EA"
         android:pathData="M73.5,70.5 H79.5 A3,3,0,0,1,82.5,73.5 V79.5 A3,3,0,0,1,79.5,82.5 H73.5 A3,3,0,0,1,70.5,79.5 V73.5 A3,3,0,0,1,73.5,70.5 Z"/>
 </vector>


### PR DESCRIPTION
Replace the 10-tile staircase with a balanced 4×4 grid (16 tiles) that fills the safe zone uniformly in any launcher mask shape (circle, squircle, etc.).

- Full 4×4 grid, same geometry (cell=12dp, gap=3dp, offset=25.5dp)
- All tile centres at 31.82dp from canvas centre (within 33dp safe-zone radius)
- Diagonal gradient: `#5B21B6` (bottom-left) → `#C084FC` (top-right)
- Background remains `#EDE9FE`