### PR TITLE
Fix Dock icon two-state flicker on macOS

### DIFF
--- a/app/desktop/build.gradle.kts
+++ b/app/desktop/build.gradle.kts
@@ -55,7 +55,7 @@ tasks.matching { it.name == "run" || it.name == "desktopRun" }.configureEach {
         .current()
         .isMacOsX
     ) {
-      (this as? JavaExec)?.jvmArgs("-Xdock:icon=${project.file("src/desktopMain/resources/icon.icns").absolutePath}")
+      (this as? JavaExec)?.jvmArgs("-Xdock:icon=${project.file("src/desktopMain/resources/icon_dock.png").absolutePath}")
     }
   }
 }


### PR DESCRIPTION
`-Xdock:icon` was pointing to `icon.icns` (full-bleed, no padding), which showed the icon without squircle padding until `main()` ran and `Taskbar.setIconImage()` replaced it with `icon_dock.png`.

Point `-Xdock:icon` to `icon_dock.png` (pre-baked squircle with padding) so the icon looks consistent from the moment the process appears in the Dock.