### PR TITLE
Fix Dock icon in packaged app

### DIFF
--- a/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
+++ b/app/desktop/src/desktopMain/kotlin/space/be1ski/vibits/desktop/DesktopMain.kt
@@ -70,6 +70,7 @@ fun main() {
 }
 
 private fun setDockIcon() {
+  if (System.getProperty("vibits.env") != "dev") return
   if (!Taskbar.isTaskbarSupported()) return
   val taskbar = Taskbar.getTaskbar()
   if (taskbar.isSupported(Taskbar.Feature.ICON_IMAGE)) {


### PR DESCRIPTION
When running as a packaged `.app` (e.g. from Homebrew), macOS applies the squircle mask to `icon.icns` automatically. Our `Taskbar.setIconImage()` call was overriding that with a pre-padded PNG meant only for dev mode, causing the icon to look different when running vs not running.

Guard the override with `vibits.env == "dev"` so it only applies when launched via `./gradlew run`.