### PR TITLE
Skip update banner for Homebrew until DMG asset is published

### DIFF
--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImpl.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImpl.kt
@@ -15,6 +15,7 @@ class ChangelogRepositoryImpl(
         title = dto.name.ifBlank { dto.tagName },
         body = dto.body,
         date = dto.publishedAt.substringBefore("T"),
+        hasDmgAsset = dto.assets.any { asset -> asset.name.endsWith(".dmg") },
       )
     }
 }

--- a/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleaseDto.kt
+++ b/feature/changelog/data/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleaseDto.kt
@@ -4,9 +4,15 @@ import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
 @Serializable
+data class GitHubAssetDto(
+  val name: String = "",
+)
+
+@Serializable
 data class GitHubReleaseDto(
   @SerialName("tag_name") val tagName: String = "",
   val name: String = "",
   val body: String = "",
   @SerialName("published_at") val publishedAt: String = "",
+  val assets: List<GitHubAssetDto> = emptyList(),
 )

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImplTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/ChangelogRepositoryImplTest.kt
@@ -42,6 +42,7 @@ class ChangelogRepositoryImplTest {
       assertEquals("Release 1.2.0", result[0].title)
       assertEquals("## Changes\n* Feature X", result[0].body)
       assertEquals("2026-02-15", result[0].date)
+      assertEquals(false, result[0].hasDmgAsset)
     }
 
   @Test
@@ -68,6 +69,32 @@ class ChangelogRepositoryImplTest {
       val result = repository.getReleases()
 
       assertEquals("v1.0.0", result[0].title)
+    }
+
+  @Test
+  fun `when release has dmg asset then hasDmgAsset is true`() =
+    runTest {
+      val json = """
+        [
+          {
+            "tag_name": "v1.2.0",
+            "name": "Release 1.2.0",
+            "body": "body",
+            "published_at": "2026-02-15T12:00:00Z",
+            "assets": [
+              {"name": "Vibits-1.2.0.dmg"},
+              {"name": "Vibits-1.2.0.zip"}
+            ]
+          }
+        ]
+      """.trimIndent()
+      val client =
+        HttpClient(MockEngine { respond(json, headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString())) }) {
+          install(ContentNegotiation) { json(Json { ignoreUnknownKeys = true }) }
+        }
+      val repository = ChangelogRepositoryImpl(GitHubReleasesApi(client, "https://api.github.com/repos/test/repo/releases"))
+      val result = repository.getReleases()
+      assertEquals(true, result[0].hasDmgAsset)
     }
 
   @Test

--- a/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApiTest.kt
+++ b/feature/changelog/data/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/data/GitHubReleasesApiTest.kt
@@ -53,7 +53,8 @@ class GitHubReleasesApiTest {
             "tag_name": "v1.2.0",
             "name": "Release 1.2.0",
             "body": "## Changes\n* Added feature X",
-            "published_at": "2026-02-15T12:00:00Z"
+            "published_at": "2026-02-15T12:00:00Z",
+            "assets": [{"name": "app.dmg"}]
           },
           {
             "tag_name": "v1.1.0",
@@ -81,6 +82,32 @@ class GitHubReleasesApiTest {
       assertEquals("## Changes\n* Added feature X", result[0].body)
       assertEquals("2026-02-15T12:00:00Z", result[0].publishedAt)
       assertEquals("v1.1.0", result[1].tagName)
+      assertEquals(1, result[0].assets.size)
+      assertEquals("app.dmg", result[0].assets[0].name)
+    }
+
+  @Test
+  fun `when release has no assets field then assets is empty`() =
+    runTest {
+      val json = """
+        [
+          {
+            "tag_name": "v1.0.0",
+            "name": "Release",
+            "body": "body",
+            "published_at": "2026-01-01T00:00:00Z"
+          }
+        ]
+      """.trimIndent()
+      val client = clientWithHandler {
+        respond(
+          content = json,
+          headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+        )
+      }
+      val api = GitHubReleasesApi(client, TEST_RELEASES_URL)
+      val result = api.getReleases()
+      assertTrue(result[0].assets.isEmpty())
     }
 
   @Test

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/ChangelogEntry.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/model/ChangelogEntry.kt
@@ -5,4 +5,5 @@ data class ChangelogEntry(
   val title: String,
   val body: String,
   val date: String,
+  val hasDmgAsset: Boolean = false,
 )

--- a/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCase.kt
+++ b/feature/changelog/domain/src/commonMain/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCase.kt
@@ -48,7 +48,10 @@ class CheckForUpdateUseCase(
         .onFailure { Log.e(TAG, "Failed to fetch releases", it) }
         .getOrNull() ?: return null
 
-    return releases
+    val isHomebrew = installationSource.isHomebrew()
+    val candidateReleases = if (isHomebrew) releases.filter { entry -> entry.hasDmgAsset } else releases
+
+    return candidateReleases
       .mapNotNull { entry ->
         parseVersion(entry.version)?.let { parsed -> entry.version to parsed }
       }.maxByOrNull { (_, parsed) ->

--- a/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
+++ b/feature/changelog/domain/src/commonTest/kotlin/space/be1ski/vibits/feature/changelog/domain/usecase/CheckForUpdateUseCaseTest.kt
@@ -108,13 +108,91 @@ class CheckForUpdateUseCaseTest {
       val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
       repository.releasesResult =
         Result.success(
-          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01")),
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01", hasDmgAsset = true)),
         )
 
       val result = homebrewUseCase("1.0.0")
 
       assertNotNull(result)
       assertTrue(result.isHomebrewInstallation)
+    }
+
+  @Test
+  fun `when homebrew and latest release has no dmg asset then returns null`() =
+    runTest {
+      val homebrewSource = FakeInstallationSource(homebrew = true)
+      val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01", hasDmgAsset = false)),
+        )
+
+      assertNull(homebrewUseCase("1.0.0"))
+    }
+
+  @Test
+  fun `when homebrew and latest release has dmg asset then returns update`() =
+    runTest {
+      val homebrewSource = FakeInstallationSource(homebrew = true)
+      val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01", hasDmgAsset = true)),
+        )
+
+      val result = homebrewUseCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("2.0.0", result.latestVersion)
+    }
+
+  @Test
+  fun `when homebrew and latest overall release has no dmg asset then falls back to latest release with dmg`() =
+    runTest {
+      val homebrewSource = FakeInstallationSource(homebrew = true)
+      val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("2.0.0", "Newest without DMG", "body", "2026-02-01", hasDmgAsset = false),
+            ChangelogEntry("1.5.0", "Latest with DMG", "body", "2026-01-15", hasDmgAsset = true),
+          ),
+        )
+
+      val result = homebrewUseCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("1.5.0", result.latestVersion)
+    }
+
+  @Test
+  fun `when homebrew and no dmg-backed release is newer than current then returns null`() =
+    runTest {
+      val homebrewSource = FakeInstallationSource(homebrew = true)
+      val homebrewUseCase = CheckForUpdateUseCase(repository, homebrewSource)
+      repository.releasesResult =
+        Result.success(
+          listOf(
+            ChangelogEntry("2.0.0", "Newest without DMG", "body", "2026-02-01", hasDmgAsset = false),
+            ChangelogEntry("1.5.0", "Latest with DMG", "body", "2026-01-15", hasDmgAsset = true),
+          ),
+        )
+
+      assertNull(homebrewUseCase("1.5.0"))
+    }
+
+  @Test
+  fun `when not homebrew and latest release has no dmg asset then still returns update`() =
+    runTest {
+      repository.releasesResult =
+        Result.success(
+          listOf(ChangelogEntry("2.0.0", "Release", "body", "2026-01-01", hasDmgAsset = false)),
+        )
+
+      val result = useCase("1.0.0")
+
+      assertNotNull(result)
+      assertEquals("2.0.0", result.latestVersion)
     }
 
   @Test

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -869,7 +869,7 @@ class AppScreenshotTest {
         FakeChangelogRepository().apply {
           releasesResult =
             Result.success(
-              listOf(ChangelogEntry("2.0.0", "Major Update", "New features", "2026-03-01")),
+              listOf(ChangelogEntry("2.0.0", "Major Update", "New features", "2026-03-01", hasDmgAsset = true)),
             )
         },
         FakeInstallationSource(homebrew = true),


### PR DESCRIPTION
## Summary
- add GitHub release asset parsing and map DMG availability into `ChangelogEntry`
- filter Homebrew update candidates to releases that already have a DMG attached
- keep non-Homebrew update behavior unchanged

## Why
GitHub releases appear before the DMG upload finishes. Homebrew users were seeing an update banner for versions that were not installable yet.

## Verification
- `./gradlew :feature:changelog:data:desktopTest --no-daemon`
- `./gradlew :feature:changelog:domain:desktopTest :feature:homescreen:compileTestKotlinDesktop --no-daemon`
- `./gradlew checkJvm --no-daemon`