### PR TITLE
Add weekday performance chart to per-habit stats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,4 @@ xcuserdata/
 /fix_plan.md
 /fix_results.md
 app/android/google-services.json
+.worktrees/

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">كتابة</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d عادات</string>
     <string name="format_tooltip_memos">%1$s: %2$d مذكرة</string>
+    <string name="format_weekday_avg_rate">متوسط %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">ليل</string>
     <string name="label_today">اليوم</string>
     <string name="label_version">الإصدار</string>
-    <string name="label_weekday_performance">الأداء حسب اليوم</string>
+    <string name="label_weekday_performance">حسب يوم الأسبوع</string>
 
     <!-- Filter options -->
     <string name="filter_all">الكل</string>

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">لم يتم تكوين عادات بعد.</string>
     <string name="msg_no_logs">لا توجد سجلات بعد</string>
     <string name="msg_no_memos_yet">لا توجد مذكرات في هذه الفترة.</string>
-    <string name="msg_not_enough_data_for_trends">بيانات غير كافية لإظهار الاتجاهات</string>
+    <string name="msg_not_enough_data_for_trends">تتبع المزيد من الأسابيع لعرض أنماط أيام الأسبوع</string>
     <string name="msg_reset_confirm">هل أنت متأكد من إعادة تعيين التطبيق؟ سيتم مسح جميع البيانات.</string>
     <string name="msg_reset_choose_option">اختر خيار إعادة التعيين:</string>
     <string name="msg_select_habit">اختر عادة واحدة على الأقل.</string>

--- a/core/strings/src/commonMain/composeResources/values-ar/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ar/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">كتابة</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d عادات</string>
     <string name="format_tooltip_memos">%1$s: %2$d مذكرة</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">أضف مذكرة تكوين العادات للبدء في التتبع.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">ليل</string>
     <string name="label_today">اليوم</string>
     <string name="label_version">الإصدار</string>
+    <string name="label_weekday_performance">الأداء حسب اليوم</string>
 
     <!-- Filter options -->
     <string name="filter_all">الكل</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">لم يتم تكوين عادات بعد.</string>
     <string name="msg_no_logs">لا توجد سجلات بعد</string>
     <string name="msg_no_memos_yet">لا توجد مذكرات في هذه الفترة.</string>
+    <string name="msg_not_enough_data_for_trends">بيانات غير كافية لإظهار الاتجاهات</string>
     <string name="msg_reset_confirm">هل أنت متأكد من إعادة تعيين التطبيق؟ سيتم مسح جميع البيانات.</string>
     <string name="msg_reset_choose_option">اختر خيار إعادة التعيين:</string>
     <string name="msg_select_habit">اختر عادة واحدة على الأقل.</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Yaz</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d vərdiş</string>
     <string name="format_tooltip_memos">%1$s: %2$d qeyd</string>
+    <string name="format_weekday_avg_rate">Ort. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Gecə</string>
     <string name="label_today">Bu gün</string>
     <string name="label_version">Versiya</string>
-    <string name="label_weekday_performance">Günlərə görə fəaliyyət</string>
+    <string name="label_weekday_performance">Həftə günü üzrə</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hamısı</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Yaz</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d vərdiş</string>
     <string name="format_tooltip_memos">%1$s: %2$d qeyd</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">İzləməyə başlamaq üçün vərdiş konfiqurasiyası əlavə edin.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Gecə</string>
     <string name="label_today">Bu gün</string>
     <string name="label_version">Versiya</string>
+    <string name="label_weekday_performance">Günlərə görə fəaliyyət</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hamısı</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Vərdişlər hələ tənzimlənməyib.</string>
     <string name="msg_no_logs">Loglar hələ yoxdur</string>
     <string name="msg_no_memos_yet">Bu dövrdə qeyd yoxdur.</string>
+    <string name="msg_not_enough_data_for_trends">Tendensiyalar üçün kifayət qədər məlumat yoxdur</string>
     <string name="msg_reset_confirm">Tətbiqi sıfırlamaq istədiyinizə əminsiniz? Bütün məlumatlar silinəcək.</string>
     <string name="msg_reset_choose_option">Sıfırlama variantını seçin:</string>
     <string name="msg_select_habit">Ən azı bir vərdiş seçin.</string>

--- a/core/strings/src/commonMain/composeResources/values-az/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-az/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Vərdişlər hələ tənzimlənməyib.</string>
     <string name="msg_no_logs">Loglar hələ yoxdur</string>
     <string name="msg_no_memos_yet">Bu dövrdə qeyd yoxdur.</string>
-    <string name="msg_not_enough_data_for_trends">Tendensiyalar üçün kifayət qədər məlumat yoxdur</string>
+    <string name="msg_not_enough_data_for_trends">Həftə içi nümunələri görmək üçün daha çox həftə izləyin</string>
     <string name="msg_reset_confirm">Tətbiqi sıfırlamaq istədiyinizə əminsiniz? Bütün məlumatlar silinəcək.</string>
     <string name="msg_reset_choose_option">Sıfırlama variantını seçin:</string>
     <string name="msg_select_habit">Ən azı bir vərdiş seçin.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Напісаць</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d звычак</string>
     <string name="format_tooltip_memos">%1$s: %2$d нататак</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Дадайце нататку з канфігурацыяй звычак, каб пачаць адсочванне.</string>
@@ -120,6 +121,7 @@
     <string name="label_time_night">Ноч</string>
     <string name="label_today">Сёння</string>
     <string name="label_version">Версія</string>
+    <string name="label_weekday_performance">Актыўнасць па днях</string>
 
     <!-- Filter options -->
     <string name="filter_all">Усе</string>
@@ -144,6 +146,7 @@
     <string name="msg_no_habits_yet">Звычкі яшчэ не наладжаны.</string>
     <string name="msg_no_logs">Логаў пакуль няма</string>
     <string name="msg_no_memos_yet">Няма нататак за гэты перыяд.</string>
+    <string name="msg_not_enough_data_for_trends">Недастаткова даных для паказу тэндэнцый</string>
     <string name="msg_reset_confirm">Вы ўпэўнены, што хочаце скінуць праграму? Усе даныя будуць выдалены.</string>
     <string name="msg_reset_choose_option">Абярыце варыянт скіду:</string>
     <string name="msg_select_habit">Абярыце хаця б адну звычку.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -146,7 +146,7 @@
     <string name="msg_no_habits_yet">Звычкі яшчэ не наладжаны.</string>
     <string name="msg_no_logs">Логаў пакуль няма</string>
     <string name="msg_no_memos_yet">Няма нататак за гэты перыяд.</string>
-    <string name="msg_not_enough_data_for_trends">Недастаткова даных для паказу тэндэнцый</string>
+    <string name="msg_not_enough_data_for_trends">Сачыце больш тыдняў, каб убачыць заканамернасці па днях тыдня</string>
     <string name="msg_reset_confirm">Вы ўпэўнены, што хочаце скінуць праграму? Усе даныя будуць выдалены.</string>
     <string name="msg_reset_choose_option">Абярыце варыянт скіду:</string>
     <string name="msg_select_habit">Абярыце хаця б адну звычку.</string>

--- a/core/strings/src/commonMain/composeResources/values-be/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-be/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Напісаць</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d звычак</string>
     <string name="format_tooltip_memos">%1$s: %2$d нататак</string>
+    <string name="format_weekday_avg_rate">Сярэд. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -121,7 +122,7 @@
     <string name="label_time_night">Ноч</string>
     <string name="label_today">Сёння</string>
     <string name="label_version">Версія</string>
-    <string name="label_weekday_performance">Актыўнасць па днях</string>
+    <string name="label_weekday_performance">Па днях тыдня</string>
 
     <!-- Filter options -->
     <string name="filter_all">Усе</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Schreiben</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d Gewohnheiten</string>
     <string name="format_tooltip_memos">%1$s: %2$d Notizen</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Fügen Sie eine Gewohnheits-Konfigurationsnotiz hinzu, um mit dem Tracking zu beginnen.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Nacht</string>
     <string name="label_today">Heute</string>
     <string name="label_version">Version</string>
+    <string name="label_weekday_performance">Leistung nach Wochentag</string>
 
     <!-- Filter options -->
     <string name="filter_all">Alle</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Noch keine Gewohnheiten konfiguriert.</string>
     <string name="msg_no_logs">Noch keine Protokolle</string>
     <string name="msg_no_memos_yet">Keine Notizen in diesem Zeitraum.</string>
+    <string name="msg_not_enough_data_for_trends">Nicht genug Daten für Trends</string>
     <string name="msg_reset_confirm">Sind Sie sicher, dass Sie die App zurücksetzen möchten? Alle Daten werden gelöscht.</string>
     <string name="msg_reset_choose_option">Zurücksetzungsoption wählen:</string>
     <string name="msg_select_habit">Wählen Sie mindestens eine Gewohnheit aus.</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Schreiben</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d Gewohnheiten</string>
     <string name="format_tooltip_memos">%1$s: %2$d Notizen</string>
+    <string name="format_weekday_avg_rate">Ø %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Nacht</string>
     <string name="label_today">Heute</string>
     <string name="label_version">Version</string>
-    <string name="label_weekday_performance">Leistung nach Wochentag</string>
+    <string name="label_weekday_performance">Nach Wochentag</string>
 
     <!-- Filter options -->
     <string name="filter_all">Alle</string>

--- a/core/strings/src/commonMain/composeResources/values-de/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-de/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Noch keine Gewohnheiten konfiguriert.</string>
     <string name="msg_no_logs">Noch keine Protokolle</string>
     <string name="msg_no_memos_yet">Keine Notizen in diesem Zeitraum.</string>
-    <string name="msg_not_enough_data_for_trends">Nicht genug Daten für Trends</string>
+    <string name="msg_not_enough_data_for_trends">Verfolge mehr Wochen, um Wochentag-Muster zu sehen</string>
     <string name="msg_reset_confirm">Sind Sie sicher, dass Sie die App zurücksetzen möchten? Alle Daten werden gelöscht.</string>
     <string name="msg_reset_choose_option">Zurücksetzungsoption wählen:</string>
     <string name="msg_select_habit">Wählen Sie mindestens eine Gewohnheit aus.</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Escribir</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
     <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+    <string name="format_weekday_avg_rate">Med. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Noche</string>
     <string name="label_today">Hoy</string>
     <string name="label_version">Versión</string>
-    <string name="label_weekday_performance">Rendimiento por día</string>
+    <string name="label_weekday_performance">Por día de la semana</string>
 
     <!-- Filter options -->
     <string name="filter_all">Todos</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Escribir</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
     <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Añade una nota de configuración para empezar a registrar.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Noche</string>
     <string name="label_today">Hoy</string>
     <string name="label_version">Versión</string>
+    <string name="label_weekday_performance">Rendimiento por día</string>
 
     <!-- Filter options -->
     <string name="filter_all">Todos</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Aún no hay hábitos configurados.</string>
     <string name="msg_no_logs">Aún no hay registros</string>
     <string name="msg_no_memos_yet">No hay notas en este período.</string>
+    <string name="msg_not_enough_data_for_trends">Datos insuficientes para las tendencias</string>
     <string name="msg_reset_confirm">¿Está seguro de que desea restablecer la app? Se eliminarán todos los datos.</string>
     <string name="msg_reset_choose_option">Elige la opción de restablecimiento:</string>
     <string name="msg_select_habit">Seleccione al menos un hábito.</string>

--- a/core/strings/src/commonMain/composeResources/values-es/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-es/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Aún no hay hábitos configurados.</string>
     <string name="msg_no_logs">Aún no hay registros</string>
     <string name="msg_no_memos_yet">No hay notas en este período.</string>
-    <string name="msg_not_enough_data_for_trends">Datos insuficientes para las tendencias</string>
+    <string name="msg_not_enough_data_for_trends">Registra más semanas para ver los patrones por día de la semana</string>
     <string name="msg_reset_confirm">¿Está seguro de que desea restablecer la app? Se eliminarán todos los datos.</string>
     <string name="msg_reset_choose_option">Elige la opción de restablecimiento:</string>
     <string name="msg_select_habit">Seleccione al menos un hábito.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Aucune habitude configurée pour l\'instant.</string>
     <string name="msg_no_logs">Aucun journal pour l\'instant</string>
     <string name="msg_no_memos_yet">Aucune note pour cette période.</string>
-    <string name="msg_not_enough_data_for_trends">Données insuffisantes pour les tendances</string>
+    <string name="msg_not_enough_data_for_trends">Suis plus de semaines pour voir les tendances par jour de la semaine</string>
     <string name="msg_reset_confirm">Êtes-vous sûr de vouloir réinitialiser l\'app ? Toutes les données seront supprimées.</string>
     <string name="msg_reset_choose_option">Choisissez l option de réinitialisation :</string>
     <string name="msg_select_habit">Sélectionnez au moins une habitude.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Écrire</string>
     <string name="format_tooltip_habits">%1$s : %2$d/%3$d habitudes</string>
     <string name="format_tooltip_memos">%1$s : %2$d notes</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Ajoutez une note de configuration d\'habitudes pour commencer le suivi.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Nuit</string>
     <string name="label_today">Aujourd\'hui</string>
     <string name="label_version">Version</string>
+    <string name="label_weekday_performance">Performance par jour</string>
 
     <!-- Filter options -->
     <string name="filter_all">Tous</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Aucune habitude configurée pour l\'instant.</string>
     <string name="msg_no_logs">Aucun journal pour l\'instant</string>
     <string name="msg_no_memos_yet">Aucune note pour cette période.</string>
+    <string name="msg_not_enough_data_for_trends">Données insuffisantes pour les tendances</string>
     <string name="msg_reset_confirm">Êtes-vous sûr de vouloir réinitialiser l\'app ? Toutes les données seront supprimées.</string>
     <string name="msg_reset_choose_option">Choisissez l option de réinitialisation :</string>
     <string name="msg_select_habit">Sélectionnez au moins une habitude.</string>

--- a/core/strings/src/commonMain/composeResources/values-fr/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-fr/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Écrire</string>
     <string name="format_tooltip_habits">%1$s : %2$d/%3$d habitudes</string>
     <string name="format_tooltip_memos">%1$s : %2$d notes</string>
+    <string name="format_weekday_avg_rate">Moy. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Nuit</string>
     <string name="label_today">Aujourd\'hui</string>
     <string name="label_version">Version</string>
-    <string name="label_weekday_performance">Performance par jour</string>
+    <string name="label_weekday_performance">Par jour de la semaine</string>
 
     <!-- Filter options -->
     <string name="filter_all">Tous</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">लिखें</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d आदतें</string>
     <string name="format_tooltip_memos">%1$s: %2$d मेमो</string>
+    <string name="format_weekday_avg_rate">औसत %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">रात</string>
     <string name="label_today">आज</string>
     <string name="label_version">संस्करण</string>
-    <string name="label_weekday_performance">दिन के अनुसार प्रदर्शन</string>
+    <string name="label_weekday_performance">सप्ताह के दिन अनुसार</string>
 
     <!-- Filter options -->
     <string name="filter_all">सभी</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">अभी तक कोई आदत कॉन्फ़िगर नहीं।</string>
     <string name="msg_no_logs">अभी कोई लॉग नहीं</string>
     <string name="msg_no_memos_yet">इस अवधि में कोई मेमो नहीं।</string>
-    <string name="msg_not_enough_data_for_trends">रुझान दिखाने के लिए पर्याप्त डेटा नहीं है</string>
+    <string name="msg_not_enough_data_for_trends">कार्यदिवस के पैटर्न देखने के लिए अधिक सप्ताह ट्रैक करें</string>
     <string name="msg_reset_confirm">क्या आप वाकई ऐप रीसेट करना चाहते हैं? सभी डेटा हटा दिया जाएगा।</string>
     <string name="msg_reset_choose_option">रीसेट विकल्प चुनें:</string>
     <string name="msg_select_habit">कम से कम एक आदत चुनें।</string>

--- a/core/strings/src/commonMain/composeResources/values-hi/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-hi/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">लिखें</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d आदतें</string>
     <string name="format_tooltip_memos">%1$s: %2$d मेमो</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">ट्रैकिंग शुरू करने के लिए आदत कॉन्फ़िगरेशन मेमो जोड़ें।</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">रात</string>
     <string name="label_today">आज</string>
     <string name="label_version">संस्करण</string>
+    <string name="label_weekday_performance">दिन के अनुसार प्रदर्शन</string>
 
     <!-- Filter options -->
     <string name="filter_all">सभी</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">अभी तक कोई आदत कॉन्फ़िगर नहीं।</string>
     <string name="msg_no_logs">अभी कोई लॉग नहीं</string>
     <string name="msg_no_memos_yet">इस अवधि में कोई मेमो नहीं।</string>
+    <string name="msg_not_enough_data_for_trends">रुझान दिखाने के लिए पर्याप्त डेटा नहीं है</string>
     <string name="msg_reset_confirm">क्या आप वाकई ऐप रीसेट करना चाहते हैं? सभी डेटा हटा दिया जाएगा।</string>
     <string name="msg_reset_choose_option">रीसेट विकल्प चुनें:</string>
     <string name="msg_select_habit">कम से कम एक आदत चुनें।</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">書く</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d習慣</string>
     <string name="format_tooltip_memos">%1$s: %2$d件のメモ</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">トラッキングを開始するには習慣設定メモを追加してください。</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">夜</string>
     <string name="label_today">今日</string>
     <string name="label_version">バージョン</string>
+    <string name="label_weekday_performance">曜日別パフォーマンス</string>
 
     <!-- Filter options -->
     <string name="filter_all">すべて</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">まだ習慣が設定されていません。</string>
     <string name="msg_no_logs">ログがありません</string>
     <string name="msg_no_memos_yet">この期間にメモがありません。</string>
+    <string name="msg_not_enough_data_for_trends">トレンドを表示するためのデータが不足しています</string>
     <string name="msg_reset_confirm">アプリをリセットしますか？すべてのデータが削除されます。</string>
     <string name="msg_reset_choose_option">リセットオプションを選択：</string>
     <string name="msg_select_habit">少なくとも1つの習慣を選択してください。</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">まだ習慣が設定されていません。</string>
     <string name="msg_no_logs">ログがありません</string>
     <string name="msg_no_memos_yet">この期間にメモがありません。</string>
-    <string name="msg_not_enough_data_for_trends">トレンドを表示するためのデータが不足しています</string>
+    <string name="msg_not_enough_data_for_trends">曜日のパターンを確認するには、さらに数週間記録してください</string>
     <string name="msg_reset_confirm">アプリをリセットしますか？すべてのデータが削除されます。</string>
     <string name="msg_reset_choose_option">リセットオプションを選択：</string>
     <string name="msg_select_habit">少なくとも1つの習慣を選択してください。</string>

--- a/core/strings/src/commonMain/composeResources/values-ja/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ja/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">書く</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d習慣</string>
     <string name="format_tooltip_memos">%1$s: %2$d件のメモ</string>
+    <string name="format_weekday_avg_rate">平均 %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">夜</string>
     <string name="label_today">今日</string>
     <string name="label_version">バージョン</string>
-    <string name="label_weekday_performance">曜日別パフォーマンス</string>
+    <string name="label_weekday_performance">曜日別</string>
 
     <!-- Filter options -->
     <string name="filter_all">すべて</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">წერა</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d ჩვევა</string>
     <string name="format_tooltip_memos">%1$s: %2$d ჩანაწერი</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">დაამატეთ ჩვევების კონფიგურაცია თვალყურის დევნებისთვის.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">ღამე</string>
     <string name="label_today">დღეს</string>
     <string name="label_version">ვერსია</string>
+    <string name="label_weekday_performance">შესრულება დღის მიხედვით</string>
 
     <!-- Filter options -->
     <string name="filter_all">ყველა</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">ჩვევები ჯერ არ არის კონფიგურირებული.</string>
     <string name="msg_no_logs">ლოგები ჯერ არ არის</string>
     <string name="msg_no_memos_yet">ამ პერიოდში ჩანაწერები არ არის.</string>
+    <string name="msg_not_enough_data_for_trends">ტრენდების საჩვენებლად არასაკმარისი მონაცემი</string>
     <string name="msg_reset_confirm">დარწმუნებული ხართ, რომ გსურთ აპის გადატვირთვა? ყველა მონაცემი წაიშლება.</string>
     <string name="msg_reset_choose_option">აირჩიეთ გადაყენების ვარიანტი:</string>
     <string name="msg_select_habit">აირჩიეთ მინიმუმ ერთი ჩვევა.</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">ჩვევები ჯერ არ არის კონფიგურირებული.</string>
     <string name="msg_no_logs">ლოგები ჯერ არ არის</string>
     <string name="msg_no_memos_yet">ამ პერიოდში ჩანაწერები არ არის.</string>
-    <string name="msg_not_enough_data_for_trends">ტრენდების საჩვენებლად არასაკმარისი მონაცემი</string>
+    <string name="msg_not_enough_data_for_trends">კვირის დღეების შაბლონების სანახავად მეტი კვირა გაატარეთ</string>
     <string name="msg_reset_confirm">დარწმუნებული ხართ, რომ გსურთ აპის გადატვირთვა? ყველა მონაცემი წაიშლება.</string>
     <string name="msg_reset_choose_option">აირჩიეთ გადაყენების ვარიანტი:</string>
     <string name="msg_select_habit">აირჩიეთ მინიმუმ ერთი ჩვევა.</string>

--- a/core/strings/src/commonMain/composeResources/values-ka/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ka/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">წერა</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d ჩვევა</string>
     <string name="format_tooltip_memos">%1$s: %2$d ჩანაწერი</string>
+    <string name="format_weekday_avg_rate">საშ. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">ღამე</string>
     <string name="label_today">დღეს</string>
     <string name="label_version">ვერსია</string>
-    <string name="label_weekday_performance">შესრულება დღის მიხედვით</string>
+    <string name="label_weekday_performance">კვირის დღეების მიხედვით</string>
 
     <!-- Filter options -->
     <string name="filter_all">ყველა</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Жазу</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d әдет</string>
     <string name="format_tooltip_memos">%1$s: %2$d жазба</string>
+    <string name="format_weekday_avg_rate">Орт. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -121,7 +122,7 @@
     <string name="label_time_night">Түн</string>
     <string name="label_today">Бүгін</string>
     <string name="label_version">Нұсқа</string>
-    <string name="label_weekday_performance">Күндер бойынша белсенділік</string>
+    <string name="label_weekday_performance">Апта күні бойынша</string>
 
     <!-- Filter options -->
     <string name="filter_all">Барлығы</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -146,7 +146,7 @@
     <string name="msg_no_habits_yet">Әдеттер әлі бапталмаған.</string>
     <string name="msg_no_logs">Логтар әлі жоқ</string>
     <string name="msg_no_memos_yet">Бұл кезеңде жазбалар жоқ.</string>
-    <string name="msg_not_enough_data_for_trends">Тенденцияларды көрсету үшін деректер жеткіліксіз</string>
+    <string name="msg_not_enough_data_for_trends">Апта күндерінің үлгілерін көру үшін көбірек апта бақылаңыз</string>
     <string name="msg_reset_confirm">Қолданбаны қалпына келтіргіңіз келе ме? Барлық деректер жойылады.</string>
     <string name="msg_reset_choose_option">Қалпына келтіру нұсқасын таңдаңыз:</string>
     <string name="msg_select_habit">Кем дегенде бір әдетті таңдаңыз.</string>

--- a/core/strings/src/commonMain/composeResources/values-kk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-kk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Жазу</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d әдет</string>
     <string name="format_tooltip_memos">%1$s: %2$d жазба</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Бақылауды бастау үшін әдеттер конфигурациясын қосыңыз.</string>
@@ -120,6 +121,7 @@
     <string name="label_time_night">Түн</string>
     <string name="label_today">Бүгін</string>
     <string name="label_version">Нұсқа</string>
+    <string name="label_weekday_performance">Күндер бойынша белсенділік</string>
 
     <!-- Filter options -->
     <string name="filter_all">Барлығы</string>
@@ -144,6 +146,7 @@
     <string name="msg_no_habits_yet">Әдеттер әлі бапталмаған.</string>
     <string name="msg_no_logs">Логтар әлі жоқ</string>
     <string name="msg_no_memos_yet">Бұл кезеңде жазбалар жоқ.</string>
+    <string name="msg_not_enough_data_for_trends">Тенденцияларды көрсету үшін деректер жеткіліксіз</string>
     <string name="msg_reset_confirm">Қолданбаны қалпына келтіргіңіз келе ме? Барлық деректер жойылады.</string>
     <string name="msg_reset_choose_option">Қалпына келтіру нұсқасын таңдаңыз:</string>
     <string name="msg_select_habit">Кем дегенде бір әдетті таңдаңыз.</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Жазуу</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d адат</string>
     <string name="format_tooltip_memos">%1$s: %2$d жазуу</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Көзөмөлдөөнү баштоо үчүн адаттар конфигурациясын кошуңуз.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Түн</string>
     <string name="label_today">Бүгүн</string>
     <string name="label_version">Версия</string>
+    <string name="label_weekday_performance">Күндөр боюнча аткаруу</string>
 
     <!-- Filter options -->
     <string name="filter_all">Баары</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Адаттар али тууралangan эмес.</string>
     <string name="msg_no_logs">Логдор али жок</string>
     <string name="msg_no_memos_yet">Бул мезгилде жазуулар жок.</string>
+    <string name="msg_not_enough_data_for_trends">Тенденцияларды көрсөтүү үчүн жетиштүү маалымат жок</string>
     <string name="msg_offline_onboarding_success">Баары даяр. Бүгүн биринчи белгини коюңуз.</string>
     <string name="msg_offline_onboarding_welcome">Адаттарды түзмөгүңүздө жергиликтүү көзөмөлдөңүз. Эсеп керек эмес.</string>
     <string name="msg_reset_confirm">Колдонмону баштапкыга кайтаргыңыз келеби? Бардык маалыматтар өчүрүлөт.</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Жазуу</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d адат</string>
     <string name="format_tooltip_memos">%1$s: %2$d жазуу</string>
+    <string name="format_weekday_avg_rate">Орт. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Түн</string>
     <string name="label_today">Бүгүн</string>
     <string name="label_version">Версия</string>
-    <string name="label_weekday_performance">Күндөр боюнча аткаруу</string>
+    <string name="label_weekday_performance">Жума күнү боюнча</string>
 
     <!-- Filter options -->
     <string name="filter_all">Баары</string>

--- a/core/strings/src/commonMain/composeResources/values-ky/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ky/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Адаттар али тууралangan эмес.</string>
     <string name="msg_no_logs">Логдор али жок</string>
     <string name="msg_no_memos_yet">Бул мезгилде жазуулар жок.</string>
-    <string name="msg_not_enough_data_for_trends">Тенденцияларды көрсөтүү үчүн жетиштүү маалымат жок</string>
+    <string name="msg_not_enough_data_for_trends">Жума күндөрүнүн үлгүлөрүн көрүү үчүн дагы бир нече жума жазылыңыз</string>
     <string name="msg_offline_onboarding_success">Баары даяр. Бүгүн биринчи белгини коюңуз.</string>
     <string name="msg_offline_onboarding_welcome">Адаттарды түзмөгүңүздө жергиликтүү көзөмөлдөңүз. Эсеп керек эмес.</string>
     <string name="msg_reset_confirm">Колдонмону баштапкыга кайтаргыңыз келеби? Бардык маалыматтар өчүрүлөт.</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Escrever</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
     <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+    <string name="format_weekday_avg_rate">Méd. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Noite</string>
     <string name="label_today">Hoje</string>
     <string name="label_version">Versão</string>
-    <string name="label_weekday_performance">Desempenho por dia</string>
+    <string name="label_weekday_performance">Por dia da semana</string>
 
     <!-- Filter options -->
     <string name="filter_all">Todos</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Nenhum hábito configurado ainda.</string>
     <string name="msg_no_logs">Sem logs ainda</string>
     <string name="msg_no_memos_yet">Sem notas neste período.</string>
-    <string name="msg_not_enough_data_for_trends">Dados insuficientes para as tendências</string>
+    <string name="msg_not_enough_data_for_trends">Registe mais semanas para ver os padrões por dia da semana</string>
     <string name="msg_reset_confirm">Tem certeza de que deseja redefinir o app? Todos os dados serão apagados.</string>
     <string name="msg_reset_choose_option">Escolha a opção de redefinição:</string>
     <string name="msg_select_habit">Selecione pelo menos um hábito.</string>

--- a/core/strings/src/commonMain/composeResources/values-pt/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-pt/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Escrever</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d hábitos</string>
     <string name="format_tooltip_memos">%1$s: %2$d notas</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Adicione uma nota de configuração de hábitos para começar a rastrear.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Noite</string>
     <string name="label_today">Hoje</string>
     <string name="label_version">Versão</string>
+    <string name="label_weekday_performance">Desempenho por dia</string>
 
     <!-- Filter options -->
     <string name="filter_all">Todos</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Nenhum hábito configurado ainda.</string>
     <string name="msg_no_logs">Sem logs ainda</string>
     <string name="msg_no_memos_yet">Sem notas neste período.</string>
+    <string name="msg_not_enough_data_for_trends">Dados insuficientes para as tendências</string>
     <string name="msg_reset_confirm">Tem certeza de que deseja redefinir o app? Todos os dados serão apagados.</string>
     <string name="msg_reset_choose_option">Escolha a opção de redefinição:</string>
     <string name="msg_select_habit">Selecione pelo menos um hábito.</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Scrie</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d obiceiuri</string>
     <string name="format_tooltip_memos">%1$s: %2$d note</string>
+    <string name="format_weekday_avg_rate">Med. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Noapte</string>
     <string name="label_today">Astăzi</string>
     <string name="label_version">Versiune</string>
-    <string name="label_weekday_performance">Performanță pe zi</string>
+    <string name="label_weekday_performance">Pe zile ale săptămânii</string>
 
     <!-- Filter options -->
     <string name="filter_all">Toate</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Scrie</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d obiceiuri</string>
     <string name="format_tooltip_memos">%1$s: %2$d note</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Adăugați configurația obiceiurilor pentru a începe urmărirea.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Noapte</string>
     <string name="label_today">Astăzi</string>
     <string name="label_version">Versiune</string>
+    <string name="label_weekday_performance">Performanță pe zi</string>
 
     <!-- Filter options -->
     <string name="filter_all">Toate</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Niciun obicei configurat încă.</string>
     <string name="msg_no_logs">Niciun log încă</string>
     <string name="msg_no_memos_yet">Nicio notă în această perioadă.</string>
+    <string name="msg_not_enough_data_for_trends">Date insuficiente pentru tendințe</string>
     <string name="msg_offline_onboarding_success">Totul este gata. Marchează prima verificare astăzi.</string>
     <string name="msg_offline_onboarding_welcome">Urmărește obiceiurile local pe dispozitivul tău. Nu este nevoie de cont.</string>
     <string name="msg_reset_confirm">Sunteți sigur că doriți să resetați aplicația? Toate datele vor fi șterse.</string>

--- a/core/strings/src/commonMain/composeResources/values-ro/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ro/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Niciun obicei configurat încă.</string>
     <string name="msg_no_logs">Niciun log încă</string>
     <string name="msg_no_memos_yet">Nicio notă în această perioadă.</string>
-    <string name="msg_not_enough_data_for_trends">Date insuficiente pentru tendințe</string>
+    <string name="msg_not_enough_data_for_trends">Urmărește mai multe săptămâni pentru a vedea tiparele pe zile</string>
     <string name="msg_offline_onboarding_success">Totul este gata. Marchează prima verificare astăzi.</string>
     <string name="msg_offline_onboarding_welcome">Urmărește obiceiurile local pe dispozitivul tău. Nu este nevoie de cont.</string>
     <string name="msg_reset_confirm">Sunteți sigur că doriți să resetați aplicația? Toate datele vor fi șterse.</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -146,7 +146,7 @@
     <string name="msg_no_habits_yet">Привычек пока нет.</string>
     <string name="msg_no_logs">Логов пока нет.</string>
     <string name="msg_no_memos_yet">За этот период воспоминаний нет.</string>
-    <string name="msg_not_enough_data_for_trends">Недостаточно данных для анализа</string>
+    <string name="msg_not_enough_data_for_trends">Отслеживайте больше недель для анализа по дням недели</string>
     <string name="msg_reset_confirm">Сбросить приложение? Все данные будут удалены.</string>
     <string name="msg_reset_choose_option">Выберите вариант сброса:</string>
     <string name="msg_select_habit">Выберите хотя бы одну привычку.</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -78,6 +78,7 @@
     <string name="format_offline_storage">Офлайн: %1$s</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d привычек</string>
     <string name="format_tooltip_memos">%1$s: %2$d воспоминаний</string>
+    <string name="format_weekday_avg_rate">Ср. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
     <string name="format_quarter_label">К%1$d %2$d</string>
     <string name="format_memos_count">%1$d воспоминаний</string>
@@ -123,7 +124,7 @@
     <string name="label_time_night">Ночь</string>
     <string name="label_today">Сегодня</string>
     <string name="label_version">Версия</string>
-    <string name="label_weekday_performance">Активность по дням</string>
+    <string name="label_weekday_performance">По дням недели</string>
 
     <!-- Filter options -->
     <string name="filter_all">Все</string>

--- a/core/strings/src/commonMain/composeResources/values-ru/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-ru/strings.xml
@@ -78,6 +78,7 @@
     <string name="format_offline_storage">Офлайн: %1$s</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d привычек</string>
     <string name="format_tooltip_memos">%1$s: %2$d воспоминаний</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
     <string name="format_quarter_label">К%1$d %2$d</string>
     <string name="format_memos_count">%1$d воспоминаний</string>
     <string name="format_memos_today">%1$d воспоминаний сегодня</string>
@@ -122,6 +123,7 @@
     <string name="label_time_night">Ночь</string>
     <string name="label_today">Сегодня</string>
     <string name="label_version">Версия</string>
+    <string name="label_weekday_performance">Активность по дням</string>
 
     <!-- Filter options -->
     <string name="filter_all">Все</string>
@@ -144,6 +146,7 @@
     <string name="msg_no_habits_yet">Привычек пока нет.</string>
     <string name="msg_no_logs">Логов пока нет.</string>
     <string name="msg_no_memos_yet">За этот период воспоминаний нет.</string>
+    <string name="msg_not_enough_data_for_trends">Недостаточно данных для анализа</string>
     <string name="msg_reset_confirm">Сбросить приложение? Все данные будут удалены.</string>
     <string name="msg_reset_choose_option">Выберите вариант сброса:</string>
     <string name="msg_select_habit">Выберите хотя бы одну привычку.</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Навиштан</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d одат</string>
     <string name="format_tooltip_memos">%1$s: %2$d ёддошт</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Барои оғоз кардани пайгирӣ конфигуратсияи одатҳоро илова кунед.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Шаб</string>
     <string name="label_today">Имрӯз</string>
     <string name="label_version">Версия</string>
+    <string name="label_weekday_performance">Фаъолият аз рӯи рӯзҳо</string>
 
     <!-- Filter options -->
     <string name="filter_all">Ҳама</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Одатҳо ҳанӯз танзим нашудаанд.</string>
     <string name="msg_no_logs">Логҳо ҳанӯз нестанд</string>
     <string name="msg_no_memos_yet">Дар ин давра ёддоштҳо нестанд.</string>
+    <string name="msg_not_enough_data_for_trends">Маълумот барои нишон додани тамоюлҳо кофӣ нест</string>
     <string name="msg_offline_onboarding_success">Ҳама чиз тайёр аст. Имрӯз қайди аввалинро гузоред.</string>
     <string name="msg_offline_onboarding_welcome">Одатҳоро дар дастгоҳи худ маҳаллӣ назорат кунед. Ҳисоб зарур нест.</string>
     <string name="msg_reset_confirm">Шумо мутмаин ҳастед, ки мехоҳед барномаро барқарор кунед? Ҳамаи маълумот нест мешавад.</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Одатҳо ҳанӯз танзим нашудаанд.</string>
     <string name="msg_no_logs">Логҳо ҳанӯз нестанд</string>
     <string name="msg_no_memos_yet">Дар ин давра ёддоштҳо нестанд.</string>
-    <string name="msg_not_enough_data_for_trends">Маълумот барои нишон додани тамоюлҳо кофӣ нест</string>
+    <string name="msg_not_enough_data_for_trends">Барои дидани намунаҳои рӯзҳои ҳафта бештар ҳафтаҳо пайгирӣ кунед</string>
     <string name="msg_offline_onboarding_success">Ҳама чиз тайёр аст. Имрӯз қайди аввалинро гузоред.</string>
     <string name="msg_offline_onboarding_welcome">Одатҳоро дар дастгоҳи худ маҳаллӣ назорат кунед. Ҳисоб зарур нест.</string>
     <string name="msg_reset_confirm">Шумо мутмаин ҳастед, ки мехоҳед барномаро барқарор кунед? Ҳамаи маълумот нест мешавад.</string>

--- a/core/strings/src/commonMain/composeResources/values-tg/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tg/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Навиштан</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d одат</string>
     <string name="format_tooltip_memos">%1$s: %2$d ёддошт</string>
+    <string name="format_weekday_avg_rate">Миёна %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Шаб</string>
     <string name="label_today">Имрӯз</string>
     <string name="label_version">Версия</string>
-    <string name="label_weekday_performance">Фаъолият аз рӯи рӯзҳо</string>
+    <string name="label_weekday_performance">Аз рӯи рӯзи ҳафта</string>
 
     <!-- Filter options -->
     <string name="filter_all">Ҳама</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Ýaz</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d endik</string>
     <string name="format_tooltip_memos">%1$s: %2$d bellik</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Yzarlamagy başlamak üçin endikler konfigurasiýasyny goşuň.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Gije</string>
     <string name="label_today">Şu gün</string>
     <string name="label_version">Wersiýa</string>
+    <string name="label_weekday_performance">Günler boýunça ýerine ýetiriş</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hemmesi</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Endikler heniz düzülmedi.</string>
     <string name="msg_no_logs">Loglar heniz ýok</string>
     <string name="msg_no_memos_yet">Bu döwürde bellik ýok.</string>
+    <string name="msg_not_enough_data_for_trends">Tendensiýalary görkezmek üçin ýeterlik maglumat ýok</string>
     <string name="msg_offline_onboarding_success">Hemme zat taýýar. Şu gün ilkinji belligi goýuň.</string>
     <string name="msg_offline_onboarding_welcome">Endikleri enjamyňyzda ýerli yzarlaň. Hasap gerek däl.</string>
     <string name="msg_reset_confirm">Programmany täzeden başlamak isleýärsiňizmi? Ähli maglumatlar öçüriler.</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Endikler heniz düzülmedi.</string>
     <string name="msg_no_logs">Loglar heniz ýok</string>
     <string name="msg_no_memos_yet">Bu döwürde bellik ýok.</string>
-    <string name="msg_not_enough_data_for_trends">Tendensiýalary görkezmek üçin ýeterlik maglumat ýok</string>
+    <string name="msg_not_enough_data_for_trends">Hepdäniň günleriniň yzygiderliligini görmek üçin köp hepdäni yzarlaň</string>
     <string name="msg_offline_onboarding_success">Hemme zat taýýar. Şu gün ilkinji belligi goýuň.</string>
     <string name="msg_offline_onboarding_welcome">Endikleri enjamyňyzda ýerli yzarlaň. Hasap gerek däl.</string>
     <string name="msg_reset_confirm">Programmany täzeden başlamak isleýärsiňizmi? Ähli maglumatlar öçüriler.</string>

--- a/core/strings/src/commonMain/composeResources/values-tk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-tk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Ýaz</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d endik</string>
     <string name="format_tooltip_memos">%1$s: %2$d bellik</string>
+    <string name="format_weekday_avg_rate">Ort. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Gije</string>
     <string name="label_today">Şu gün</string>
     <string name="label_version">Wersiýa</string>
-    <string name="label_weekday_performance">Günler boýunça ýerine ýetiriş</string>
+    <string name="label_weekday_performance">Hepde gününe görä</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hemmesi</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Написати</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d звичок</string>
     <string name="format_tooltip_memos">%1$s: %2$d нотаток</string>
+    <string name="format_weekday_avg_rate">Сер. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -121,7 +122,7 @@
     <string name="label_time_night">Ніч</string>
     <string name="label_today">Сьогодні</string>
     <string name="label_version">Версія</string>
-    <string name="label_weekday_performance">Активність за днями</string>
+    <string name="label_weekday_performance">За днями тижня</string>
 
     <!-- Filter options -->
     <string name="filter_all">Всі</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Написати</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d звичок</string>
     <string name="format_tooltip_memos">%1$s: %2$d нотаток</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Додайте нотатку з конфігурацією звичок, щоб почати відстеження.</string>
@@ -120,6 +121,7 @@
     <string name="label_time_night">Ніч</string>
     <string name="label_today">Сьогодні</string>
     <string name="label_version">Версія</string>
+    <string name="label_weekday_performance">Активність за днями</string>
 
     <!-- Filter options -->
     <string name="filter_all">Всі</string>
@@ -144,6 +146,7 @@
     <string name="msg_no_habits_yet">Звички ще не налаштовано.</string>
     <string name="msg_no_logs">Логів поки немає</string>
     <string name="msg_no_memos_yet">Немає нотаток за цей період.</string>
+    <string name="msg_not_enough_data_for_trends">Недостатньо даних для аналізу</string>
     <string name="msg_reset_confirm">Ви впевнені, що хочете скинути додаток? Усі дані буде видалено.</string>
     <string name="msg_reset_choose_option">Оберіть варіант скидання:</string>
     <string name="msg_select_habit">Оберіть хоча б одну звичку.</string>

--- a/core/strings/src/commonMain/composeResources/values-uk/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uk/strings.xml
@@ -146,7 +146,7 @@
     <string name="msg_no_habits_yet">Звички ще не налаштовано.</string>
     <string name="msg_no_logs">Логів поки немає</string>
     <string name="msg_no_memos_yet">Немає нотаток за цей період.</string>
-    <string name="msg_not_enough_data_for_trends">Недостатньо даних для аналізу</string>
+    <string name="msg_not_enough_data_for_trends">Відстежуйте більше тижнів, щоб побачити закономірності за днями тижня</string>
     <string name="msg_reset_confirm">Ви впевнені, що хочете скинути додаток? Усі дані буде видалено.</string>
     <string name="msg_reset_choose_option">Оберіть варіант скидання:</string>
     <string name="msg_select_habit">Оберіть хоча б одну звичку.</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Yozish</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d odat</string>
     <string name="format_tooltip_memos">%1$s: %2$d ta eslatma</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Kuzatuvni boshlash uchun odatlar konfiguratsiyasini qo\'shing.</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">Tun</string>
     <string name="label_today">Bugun</string>
     <string name="label_version">Versiya</string>
+    <string name="label_weekday_performance">Kunlar bo'yicha faoliyat</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hammasi</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">Odatlar hali sozlanmagan.</string>
     <string name="msg_no_logs">Loglar hali yo\'q</string>
     <string name="msg_no_memos_yet">Bu davrda eslatmalar yo\'q.</string>
+    <string name="msg_not_enough_data_for_trends">Tendensiyalarni ko'rsatish uchun yetarli ma'lumot yo'q</string>
     <string name="msg_reset_confirm">Ilovani tiklamoqchimisiz? Barcha ma\'lumotlar o\'chiriladi.</string>
     <string name="msg_reset_choose_option">Tiklash variantini tanlang:</string>
     <string name="msg_select_habit">Kamida bitta odatni tanlang.</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">Yozish</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d odat</string>
     <string name="format_tooltip_memos">%1$s: %2$d ta eslatma</string>
+    <string name="format_weekday_avg_rate">O'rt. %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">Tun</string>
     <string name="label_today">Bugun</string>
     <string name="label_version">Versiya</string>
-    <string name="label_weekday_performance">Kunlar bo'yicha faoliyat</string>
+    <string name="label_weekday_performance">Hafta kuni bo'yicha</string>
 
     <!-- Filter options -->
     <string name="filter_all">Hammasi</string>

--- a/core/strings/src/commonMain/composeResources/values-uz/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-uz/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">Odatlar hali sozlanmagan.</string>
     <string name="msg_no_logs">Loglar hali yo\'q</string>
     <string name="msg_no_memos_yet">Bu davrda eslatmalar yo\'q.</string>
-    <string name="msg_not_enough_data_for_trends">Tendensiyalarni ko'rsatish uchun yetarli ma'lumot yo'q</string>
+    <string name="msg_not_enough_data_for_trends">Hafta kunlari naqshlarini ko'rish uchun ko'proq haftalar kuzating</string>
     <string name="msg_reset_confirm">Ilovani tiklamoqchimisiz? Barcha ma\'lumotlar o\'chiriladi.</string>
     <string name="msg_reset_choose_option">Tiklash variantini tanlang:</string>
     <string name="msg_select_habit">Kamida bitta odatni tanlang.</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">写</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d 习惯</string>
     <string name="format_tooltip_memos">%1$s: %2$d 条备忘</string>
+    <string name="format_weekday_avg_rate">均 %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -122,7 +123,7 @@
     <string name="label_time_night">夜晚</string>
     <string name="label_today">今天</string>
     <string name="label_version">版本</string>
-    <string name="label_weekday_performance">按星期表现</string>
+    <string name="label_weekday_performance">按星期分析</string>
 
     <!-- Filter options -->
     <string name="filter_all">全部</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -147,7 +147,7 @@
     <string name="msg_no_habits_yet">尚未配置任何习惯。</string>
     <string name="msg_no_logs">暂无日志</string>
     <string name="msg_no_memos_yet">该时期暂无备忘。</string>
-    <string name="msg_not_enough_data_for_trends">数据不足以显示趋势</string>
+    <string name="msg_not_enough_data_for_trends">追踪更多周数以查看工作日规律</string>
     <string name="msg_reset_confirm">确定要重置应用吗？所有数据将被清除。</string>
     <string name="msg_reset_choose_option">选择重置选项：</string>
     <string name="msg_select_habit">请至少选择一个习惯。</string>

--- a/core/strings/src/commonMain/composeResources/values-zh/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values-zh/strings.xml
@@ -86,6 +86,7 @@
     <string name="action_write">写</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d 习惯</string>
     <string name="format_tooltip_memos">%1$s: %2$d 条备忘</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">添加习惯配置备忘以开始跟踪。</string>
@@ -121,6 +122,7 @@
     <string name="label_time_night">夜晚</string>
     <string name="label_today">今天</string>
     <string name="label_version">版本</string>
+    <string name="label_weekday_performance">按星期表现</string>
 
     <!-- Filter options -->
     <string name="filter_all">全部</string>
@@ -145,6 +147,7 @@
     <string name="msg_no_habits_yet">尚未配置任何习惯。</string>
     <string name="msg_no_logs">暂无日志</string>
     <string name="msg_no_memos_yet">该时期暂无备忘。</string>
+    <string name="msg_not_enough_data_for_trends">数据不足以显示趋势</string>
     <string name="msg_reset_confirm">确定要重置应用吗？所有数据将被清除。</string>
     <string name="msg_reset_choose_option">选择重置选项：</string>
     <string name="msg_select_habit">请至少选择一个习惯。</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -146,7 +146,7 @@
     <string name="msg_no_habits_yet">No habits configured yet.</string>
     <string name="msg_no_logs">No logs yet</string>
     <string name="msg_no_memos_yet">No memos in this period.</string>
-    <string name="msg_not_enough_data_for_trends">Not enough data to show trends</string>
+    <string name="msg_not_enough_data_for_trends">Track more weeks to see weekday patterns</string>
     <string name="msg_offline_onboarding_success">You're all set. Track your first check-in today.</string>
     <string name="msg_offline_onboarding_welcome">Track habits locally on your device. No account needed.</string>
     <string name="msg_reset_confirm">Are you sure you want to reset the app? This will clear all data.</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="action_write">Write</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d habits</string>
     <string name="format_tooltip_memos">%1$s: %2$d memos</string>
+    <string name="format_weekday_avg_rate">Avg %1$d%%</string>
     <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
@@ -123,7 +124,7 @@
     <string name="label_time_night">Night</string>
     <string name="label_today">Today</string>
     <string name="label_version">Version</string>
-    <string name="label_weekday_performance">Performance by Day</string>
+    <string name="label_weekday_performance">By Weekday</string>
 
     <!-- Filter options -->
     <string name="filter_all">All</string>

--- a/core/strings/src/commonMain/composeResources/values/strings.xml
+++ b/core/strings/src/commonMain/composeResources/values/strings.xml
@@ -88,6 +88,7 @@
     <string name="action_write">Write</string>
     <string name="format_tooltip_habits">%1$s: %2$d/%3$d habits</string>
     <string name="format_tooltip_memos">%1$s: %2$d memos</string>
+    <string name="format_weekday_completion_rate">%1$d%%</string>
 
     <!-- Hints -->
     <string name="hint_add_habits_config">Add a habits config memo to start tracking.</string>
@@ -122,6 +123,7 @@
     <string name="label_time_night">Night</string>
     <string name="label_today">Today</string>
     <string name="label_version">Version</string>
+    <string name="label_weekday_performance">Performance by Day</string>
 
     <!-- Filter options -->
     <string name="filter_all">All</string>
@@ -144,6 +146,7 @@
     <string name="msg_no_habits_yet">No habits configured yet.</string>
     <string name="msg_no_logs">No logs yet</string>
     <string name="msg_no_memos_yet">No memos in this period.</string>
+    <string name="msg_not_enough_data_for_trends">Not enough data to show trends</string>
     <string name="msg_offline_onboarding_success">You're all set. Track your first check-in today.</string>
     <string name="msg_offline_onboarding_welcome">Track habits locally on your device. No account needed.</string>
     <string name="msg_reset_confirm">Are you sure you want to reset the app? This will clear all data.</string>

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
@@ -9,31 +9,41 @@ import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceS
 private const val MIN_OBSERVATIONS = 2
 
 internal object WeekdayStatsSelector {
-  operator fun invoke(summary: ActivitySummary, habitTag: String): WeekdayPerformanceCardState {
+  operator fun invoke(
+    summary: ActivitySummary,
+    habitTag: String,
+  ): WeekdayPerformanceCardState {
     val allDays = summary.weeks.flatMap { it.days }
     val observableDays = allDays.filter { it.isObservable(habitTag) }
-    val byWeekday = DayOfWeek.entries.associateWith { dow ->
-      observableDays.filter { it.date.dayOfWeek == dow }
-    }
+    val byWeekday =
+      DayOfWeek.entries.associateWith { dow ->
+        observableDays.filter { it.date.dayOfWeek == dow }
+      }
     val hasSufficientData = byWeekday.values.all { it.size >= MIN_OBSERVATIONS }
-    val rates = byWeekday.mapValues { (_, days) ->
-      if (days.isEmpty()) 0f
-      else days.count { day -> day.habitStatuses.any { it.tag == habitTag && it.done } }.toFloat() / days.size
-    }
+    val rates =
+      byWeekday.mapValues { (_, days) ->
+        if (days.isEmpty()) {
+          0f
+        } else {
+          days.count { day -> day.habitStatuses.any { it.tag == habitTag && it.done } }.toFloat() / days.size
+        }
+      }
     val (isBest, isWorst) = if (hasSufficientData) resolveHighlights(rates) else Pair(null, null)
-    val stats = DayOfWeek.entries.map { dow ->
-      WeekdayPerformanceStats(
-        dayOfWeek = dow,
-        completionRate = rates.getValue(dow),
-        isBest = dow == isBest,
-        isWorst = dow == isWorst,
-      )
-    }
-    val averageCompletionRate = if (hasSufficientData) {
-      rates.values.average().toFloat()
-    } else {
-      null
-    }
+    val stats =
+      DayOfWeek.entries.map { dow ->
+        WeekdayPerformanceStats(
+          dayOfWeek = dow,
+          completionRate = rates.getValue(dow),
+          isBest = dow == isBest,
+          isWorst = dow == isWorst,
+        )
+      }
+    val averageCompletionRate =
+      if (hasSufficientData) {
+        rates.values.average().toFloat()
+      } else {
+        null
+      }
     return WeekdayPerformanceCardState(
       stats = stats,
       hasSufficientData = hasSufficientData,
@@ -49,16 +59,18 @@ internal object WeekdayStatsSelector {
   private fun resolveHighlights(rates: Map<DayOfWeek, Float>): Pair<DayOfWeek?, DayOfWeek?> {
     val maxRate = rates.values.maxOrNull() ?: 0f
     val minRate = rates.values.minOrNull() ?: 0f
-    val best = if (rates.values.count { it == maxRate } == 1) {
-      rates.entries.first { it.value == maxRate }.key
-    } else {
-      null
-    }
-    val worst = if (rates.values.count { it == minRate } == 1) {
-      rates.entries.first { it.value == minRate }.key
-    } else {
-      null
-    }
+    val best =
+      if (rates.values.count { it == maxRate } == 1) {
+        rates.entries.first { it.value == maxRate }.key
+      } else {
+        null
+      }
+    val worst =
+      if (rates.values.count { it == minRate } == 1) {
+        rates.entries.first { it.value == minRate }.key
+      } else {
+        null
+      }
     return if (best == worst) Pair(null, null) else Pair(best, worst)
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
@@ -1,0 +1,64 @@
+package space.be1ski.vibits.feature.habits.presentation.reducer
+
+import kotlinx.datetime.DayOfWeek
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
+import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceCardState
+import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceStats
+
+private const val MIN_OBSERVATIONS = 2
+
+internal object WeekdayStatsSelector {
+  operator fun invoke(summary: ActivitySummary, habitTag: String): WeekdayPerformanceCardState {
+    val allDays = summary.weeks.flatMap { it.days }
+    val observableDays = allDays.filter { it.isObservable(habitTag) }
+    val byWeekday = DayOfWeek.entries.associateWith { dow ->
+      observableDays.filter { it.date.dayOfWeek == dow }
+    }
+    val hasSufficientData = byWeekday.values.all { it.size >= MIN_OBSERVATIONS }
+    val rates = byWeekday.mapValues { (_, days) ->
+      if (days.isEmpty()) 0f
+      else days.count { day -> day.habitStatuses.any { it.tag == habitTag && it.done } }.toFloat() / days.size
+    }
+    val (isBest, isWorst) = if (hasSufficientData) resolveHighlights(rates) else Pair(null, null)
+    val stats = DayOfWeek.entries.map { dow ->
+      WeekdayPerformanceStats(
+        dayOfWeek = dow,
+        completionRate = rates.getValue(dow),
+        isBest = dow == isBest,
+        isWorst = dow == isWorst,
+      )
+    }
+    val averageCompletionRate = if (hasSufficientData) {
+      rates.values.average().toFloat()
+    } else {
+      null
+    }
+    return WeekdayPerformanceCardState(
+      stats = stats,
+      hasSufficientData = hasSufficientData,
+      averageCompletionRate = averageCompletionRate,
+    )
+  }
+
+  private fun ContributionDay.isObservable(habitTag: String): Boolean =
+    inRange &&
+      isClickable &&
+      habitStatuses.any { it.tag == habitTag }
+
+  private fun resolveHighlights(rates: Map<DayOfWeek, Float>): Pair<DayOfWeek?, DayOfWeek?> {
+    val maxRate = rates.values.maxOrNull() ?: 0f
+    val minRate = rates.values.minOrNull() ?: 0f
+    val best = if (rates.values.count { it == maxRate } == 1) {
+      rates.entries.first { it.value == maxRate }.key
+    } else {
+      null
+    }
+    val worst = if (rates.values.count { it == minRate } == 1) {
+      rates.entries.first { it.value == minRate }.key
+    } else {
+      null
+    }
+    return if (best == worst) Pair(null, null) else Pair(best, worst)
+  }
+}

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
@@ -23,12 +23,17 @@ internal object WeekdayStatsSelector {
     val rates =
       byWeekday.mapValues { (_, days) ->
         if (days.isEmpty()) {
-          0f
+          null
         } else {
           days.count { day -> day.habitStatuses.any { it.tag == habitTag && it.done } }.toFloat() / days.size
         }
       }
-    val (isBest, isWorst) = if (hasSufficientData) resolveHighlights(rates) else Pair(null, null)
+    val (isBest, isWorst) =
+      if (hasSufficientData) {
+        resolveHighlights(rates.mapValues { requireNotNull(it.value) })
+      } else {
+        Pair(null, null)
+      }
     val stats =
       DayOfWeek.entries.map { dow ->
         WeekdayPerformanceStats(
@@ -40,7 +45,7 @@ internal object WeekdayStatsSelector {
       }
     val averageCompletionRate =
       if (hasSufficientData) {
-        rates.values.average().toFloat()
+        rates.values.filterNotNull().average().toFloat()
       } else {
         null
       }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/reducer/WeekdayStatsSelector.kt
@@ -6,7 +6,7 @@ import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceCardState
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceStats
 
-private const val MIN_OBSERVATIONS = 2
+private const val MIN_OBSERVATIONS = 4
 
 internal object WeekdayStatsSelector {
   operator fun invoke(
@@ -28,19 +28,13 @@ internal object WeekdayStatsSelector {
           days.count { day -> day.habitStatuses.any { it.tag == habitTag && it.done } }.toFloat() / days.size
         }
       }
-    val (isBest, isWorst) =
-      if (hasSufficientData) {
-        resolveHighlights(rates.mapValues { requireNotNull(it.value) })
-      } else {
-        Pair(null, null)
-      }
+    val bestDay = if (hasSufficientData) resolveBest(rates.mapValues { requireNotNull(it.value) }) else null
     val stats =
       DayOfWeek.entries.map { dow ->
         WeekdayPerformanceStats(
           dayOfWeek = dow,
           completionRate = rates.getValue(dow),
-          isBest = dow == isBest,
-          isWorst = dow == isWorst,
+          isBest = dow == bestDay,
         )
       }
     val averageCompletionRate =
@@ -61,21 +55,12 @@ internal object WeekdayStatsSelector {
       isClickable &&
       habitStatuses.any { it.tag == habitTag }
 
-  private fun resolveHighlights(rates: Map<DayOfWeek, Float>): Pair<DayOfWeek?, DayOfWeek?> {
-    val maxRate = rates.values.maxOrNull() ?: 0f
-    val minRate = rates.values.minOrNull() ?: 0f
-    val best =
-      if (rates.values.count { it == maxRate } == 1) {
-        rates.entries.first { it.value == maxRate }.key
-      } else {
-        null
-      }
-    val worst =
-      if (rates.values.count { it == minRate } == 1) {
-        rates.entries.first { it.value == minRate }.key
-      } else {
-        null
-      }
-    return if (best == worst) Pair(null, null) else Pair(best, worst)
+  private fun resolveBest(rates: Map<DayOfWeek, Float>): DayOfWeek? {
+    val maxRate = rates.values.maxOrNull() ?: return null
+    return if (rates.values.count { it == maxRate } == 1) {
+      rates.entries.first { it.value == maxRate }.key
+    } else {
+      null
+    }
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/StatsScreenModels.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/StatsScreenModels.kt
@@ -1,4 +1,5 @@
-package space.be1ski.vibits.feature.habits.presentation.view
+package space.be1ski.vibits.feature.habits.presentation.state
+
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
 import space.be1ski.vibits.core.ui.date.DateFormatter
@@ -10,7 +11,6 @@ import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.habits.domain.model.HabitConfig
 import space.be1ski.vibits.feature.habits.domain.model.HabitsConfigEntry
 import space.be1ski.vibits.feature.habits.domain.model.SuccessRate
-import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
 import space.be1ski.vibits.feature.memos.domain.model.Memo
 
 /**

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
@@ -6,14 +6,7 @@ internal data class WeekdayPerformanceStats(
   val dayOfWeek: DayOfWeek,
   val completionRate: Float?, // null = no observations; 0.0–1.0 otherwise
   val isBest: Boolean,
-  val isWorst: Boolean,
-) {
-  init {
-    require(!isBest || !isWorst) {
-      "A single entry cannot have both isBest=true and isWorst=true"
-    }
-  }
-}
+)
 
 internal data class WeekdayPerformanceCardState(
   val stats: List<WeekdayPerformanceStats>,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
@@ -1,0 +1,22 @@
+package space.be1ski.vibits.feature.habits.presentation.state
+
+import kotlinx.datetime.DayOfWeek
+
+internal data class WeekdayPerformanceStats(
+  val dayOfWeek: DayOfWeek,
+  val completionRate: Float, // 0.0–1.0
+  val isBest: Boolean,
+  val isWorst: Boolean,
+) {
+  init {
+    require(!isBest || !isWorst) {
+      "A single entry cannot have both isBest=true and isWorst=true"
+    }
+  }
+}
+
+internal data class WeekdayPerformanceCardState(
+  val stats: List<WeekdayPerformanceStats>,
+  val hasSufficientData: Boolean,
+  val averageCompletionRate: Float?, // null when the avg line is hidden
+)

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/state/WeekdayPerformanceStats.kt
@@ -4,7 +4,7 @@ import kotlinx.datetime.DayOfWeek
 
 internal data class WeekdayPerformanceStats(
   val dayOfWeek: DayOfWeek,
-  val completionRate: Float, // 0.0–1.0
+  val completionRate: Float?, // null = no observations; 0.0–1.0 otherwise
   val isBest: Boolean,
   val isWorst: Boolean,
 ) {

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -31,6 +31,8 @@ import space.be1ski.vibits.feature.habits.domain.usecase.GetPeriodPostsUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenDerivedState
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenState
 import space.be1ski.vibits.feature.habits.presentation.state.getActivityData
 import space.be1ski.vibits.feature.habits.presentation.state.isDataLoading
 import space.be1ski.vibits.feature.habits.presentation.view.components.HabitPicker

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreen.kt
@@ -4,7 +4,9 @@ package space.be1ski.vibits.feature.habits.presentation.view
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
@@ -216,6 +218,9 @@ private fun StatsScreenContent(
       StatsWeeklyChart(derived, dispatch)
       StatsCollapsiblePosts(derived, state.postsListExpanded, onPostsListExpandedChange)
       StatsHabitSections(derived, dispatch)
+    }
+    if (!state.wideLayout && state.useVerticalScroll) {
+      Spacer(Modifier.height(Indent.x5l + Indent.m))
     }
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -680,10 +680,6 @@ private fun HabitActivitySection(
       state.selectedDate?.let { date -> habitWeekData.findDayByDate(date) }
     }
   val chartScrollState = rememberScrollState()
-  val weekdayPerformance =
-    remember(habitWeekData.weeks, state.habit.tag) {
-      WeekdayStatsSelector(habitWeekData, state.habit.tag)
-    }
 
   Column(verticalArrangement = Arrangement.spacedBy(Indent.xs), modifier = Modifier.padding(top = Indent.s)) {
     Text(state.habit.localizedLabel(state.demoMode), style = MaterialTheme.typography.titleSmall)
@@ -711,9 +707,6 @@ private fun HabitActivitySection(
       onDaySelected = onDaySelected,
       onClearSelection = onClearSelection,
     )
-    if (state.range is ActivityRange.Month) {
-      WeekdayPerformanceCard(weekdayPerformance)
-    }
   }
 }
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -76,9 +76,14 @@ import space.be1ski.vibits.feature.habits.domain.model.lastSevenDays
 import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseCase
 import space.be1ski.vibits.feature.habits.domain.usecase.FilterPostsUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
+import space.be1ski.vibits.feature.habits.presentation.reducer.WeekdayStatsSelector
+import space.be1ski.vibits.feature.habits.presentation.state.HabitActivitySectionState
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenDerivedState
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenState
 import space.be1ski.vibits.feature.habits.presentation.view.components.ChartDimens
 import space.be1ski.vibits.feature.habits.presentation.view.components.ContributionGrid
 import space.be1ski.vibits.feature.habits.presentation.view.components.ContributionGridState
+import space.be1ski.vibits.feature.habits.presentation.view.components.WeekdayPerformanceCard
 import space.be1ski.vibits.feature.habits.presentation.view.components.WeeklyBarChart
 import space.be1ski.vibits.feature.habits.presentation.view.components.WeeklyBarChartState
 import space.be1ski.vibits.feature.habits.presentation.view.components.calculateLayout
@@ -675,6 +680,10 @@ private fun HabitActivitySection(
       state.selectedDate?.let { date -> habitWeekData.findDayByDate(date) }
     }
   val chartScrollState = rememberScrollState()
+  val weekdayPerformance =
+    remember(state.baseWeekData.weeks, state.habit.tag) {
+      WeekdayStatsSelector(state.baseWeekData, state.habit.tag)
+    }
 
   Column(verticalArrangement = Arrangement.spacedBy(Indent.xs), modifier = Modifier.padding(top = Indent.s)) {
     Text(state.habit.localizedLabel(state.demoMode), style = MaterialTheme.typography.titleSmall)
@@ -702,6 +711,7 @@ private fun HabitActivitySection(
       onDaySelected = onDaySelected,
       onClearSelection = onClearSelection,
     )
+    WeekdayPerformanceCard(weekdayPerformance)
   }
 }
 
@@ -766,29 +776,36 @@ private fun SelectedHabitGrid(
   val chartScrollState = rememberScrollState()
   val showTimeline = derived.state.range is ActivityRange.Quarter || derived.state.range is ActivityRange.Year
   val useCalendarLayout = derived.state.range is ActivityRange.Month
+  val weekdayPerformance =
+    remember(derived.weekData.weeks, habit.tag) {
+      WeekdayStatsSelector(derived.weekData, habit.tag)
+    }
 
-  ContributionGrid(
-    state =
-      ContributionGridState(
-        weekData = habitWeekData,
-        range = derived.state.range,
-        selectedDay = selectedDay,
-        selectedWeekStart = null,
-        isActiveSelection = habitsState.activeSelectionId == selectionId,
-        scrollState = chartScrollState,
-        showWeekdayLegend = derived.showWeekdayLegend && !useCalendarLayout,
-        showAllWeekdayLabels = true,
-        compactHeight = derived.useCompactHeight,
-        showTimeline = showTimeline,
-        calendarLayout = useCalendarLayout,
-        today = derived.today,
-        habitColor = habit.color,
-        demoMode = derived.state.demoMode,
-      ),
-    dateFormatter = derived.dateFormatter,
-    onDaySelected = onDaySelected,
-    onClearSelection = onClearSelection,
-  )
+  Column(verticalArrangement = Arrangement.spacedBy(Indent.xs)) {
+    ContributionGrid(
+      state =
+        ContributionGridState(
+          weekData = habitWeekData,
+          range = derived.state.range,
+          selectedDay = selectedDay,
+          selectedWeekStart = null,
+          isActiveSelection = habitsState.activeSelectionId == selectionId,
+          scrollState = chartScrollState,
+          showWeekdayLegend = derived.showWeekdayLegend && !useCalendarLayout,
+          showAllWeekdayLabels = true,
+          compactHeight = derived.useCompactHeight,
+          showTimeline = showTimeline,
+          calendarLayout = useCalendarLayout,
+          today = derived.today,
+          habitColor = habit.color,
+          demoMode = derived.state.demoMode,
+        ),
+      dateFormatter = derived.dateFormatter,
+      onDaySelected = onDaySelected,
+      onClearSelection = onClearSelection,
+    )
+    WeekdayPerformanceCard(weekdayPerformance)
+  }
 }
 
 @Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -711,7 +711,9 @@ private fun HabitActivitySection(
       onDaySelected = onDaySelected,
       onClearSelection = onClearSelection,
     )
-    WeekdayPerformanceCard(weekdayPerformance)
+    if (state.range is ActivityRange.Month) {
+      WeekdayPerformanceCard(weekdayPerformance)
+    }
   }
 }
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -799,7 +799,7 @@ private fun SelectedHabitGrid(
       onDaySelected = onDaySelected,
       onClearSelection = onClearSelection,
     )
-    WeekdayPerformanceCard(weekdayPerformance)
+    WeekdayPerformanceCard(weekdayPerformance, habit.color)
   }
 }
 

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenContent.kt
@@ -681,8 +681,8 @@ private fun HabitActivitySection(
     }
   val chartScrollState = rememberScrollState()
   val weekdayPerformance =
-    remember(state.baseWeekData.weeks, state.habit.tag) {
-      WeekdayStatsSelector(state.baseWeekData, state.habit.tag)
+    remember(habitWeekData.weeks, state.habit.tag) {
+      WeekdayStatsSelector(habitWeekData, state.habit.tag)
     }
 
   Column(verticalArrangement = Arrangement.spacedBy(Indent.xs), modifier = Modifier.padding(top = Indent.s)) {
@@ -777,8 +777,8 @@ private fun SelectedHabitGrid(
   val showTimeline = derived.state.range is ActivityRange.Quarter || derived.state.range is ActivityRange.Year
   val useCalendarLayout = derived.state.range is ActivityRange.Month
   val weekdayPerformance =
-    remember(derived.weekData.weeks, habit.tag) {
-      WeekdayStatsSelector(derived.weekData, habit.tag)
+    remember(habitWeekData.weeks, habit.tag) {
+      WeekdayStatsSelector(habitWeekData, habit.tag)
     }
 
   Column(verticalArrangement = Arrangement.spacedBy(Indent.xs)) {

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsScreenDialogs.kt
@@ -20,6 +20,7 @@ import space.be1ski.vibits.core.strings.generated.title_delete_day
 import space.be1ski.vibits.core.strings.generated.title_mark_done
 import space.be1ski.vibits.core.strings.generated.title_mark_not_done
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenDerivedState
 import space.be1ski.vibits.feature.habits.presentation.view.components.localizedLabel
 
 @Composable

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsTestTags.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/StatsTestTags.kt
@@ -6,4 +6,5 @@ object StatsTestTags {
   const val EDIT_CONFIG_WARNING_DIALOG = "habits_edit_config_warning_dialog"
   const val EMPTY_DELETE_DIALOG = "habits_empty_delete_dialog"
   const val SINGLE_TOGGLE_DIALOG = "habits_single_toggle_dialog"
+  const val WEEKDAY_PERFORMANCE_CARD = "weekday_performance_card"
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -1,0 +1,207 @@
+package space.be1ski.vibits.feature.habits.presentation.view.components
+
+import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.animateDpAsState
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.size
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.unit.dp
+import org.jetbrains.compose.resources.stringResource
+import space.be1ski.vibits.core.strings.generated.Res
+import space.be1ski.vibits.core.strings.generated.day_fri
+import space.be1ski.vibits.core.strings.generated.day_mon
+import space.be1ski.vibits.core.strings.generated.day_sat
+import space.be1ski.vibits.core.strings.generated.day_sun
+import space.be1ski.vibits.core.strings.generated.day_thu
+import space.be1ski.vibits.core.strings.generated.day_tue
+import space.be1ski.vibits.core.strings.generated.day_wed
+import space.be1ski.vibits.core.strings.generated.format_weekday_completion_rate
+import space.be1ski.vibits.core.strings.generated.label_weekday_performance
+import space.be1ski.vibits.core.strings.generated.msg_not_enough_data_for_trends
+import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceCardState
+import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceStats
+import kotlin.math.roundToInt
+
+private val BAR_MAX_HEIGHT = 64.dp
+private val BAR_MIN_HEIGHT = 2.dp
+private val BAR_CONTAINER_WIDTH = 24.dp
+private val BAR_WIDTH = 16.dp
+private const val BAR_ANIM_MS = 320
+private const val COLOR_ANIM_MS = 180
+private const val PERCENT_FACTOR = 100
+
+@Composable
+internal fun WeekdayPerformanceCard(
+  state: WeekdayPerformanceCardState,
+  modifier: Modifier = Modifier,
+) {
+  val dayLabels =
+    listOf(
+      stringResource(Res.string.day_mon),
+      stringResource(Res.string.day_tue),
+      stringResource(Res.string.day_wed),
+      stringResource(Res.string.day_thu),
+      stringResource(Res.string.day_fri),
+      stringResource(Res.string.day_sat),
+      stringResource(Res.string.day_sun),
+    )
+
+  Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(Indent.xs)) {
+    Text(
+      text = stringResource(Res.string.label_weekday_performance),
+      style = MaterialTheme.typography.titleSmall,
+    )
+    if (state.hasSufficientData) {
+      WeekdayBarsWithAvgLine(
+        stats = state.stats,
+        dayLabels = dayLabels,
+        averageCompletionRate =
+          checkNotNull(state.averageCompletionRate) {
+            "averageCompletionRate must be non-null when hasSufficientData is true"
+          },
+      )
+    } else {
+      WeekdayBarsNoHighlight(stats = state.stats, dayLabels = dayLabels)
+      Spacer(Modifier.height(Indent.x3s))
+      Text(
+        text = stringResource(Res.string.msg_not_enough_data_for_trends),
+        style = MaterialTheme.typography.bodySmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
+  }
+}
+
+@Composable
+private fun WeekdayBarsWithAvgLine(
+  stats: List<WeekdayPerformanceStats>,
+  dayLabels: List<String>,
+  averageCompletionRate: Float,
+) {
+  val accent = MaterialTheme.colorScheme.primary
+  val muted = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
+  val neutral = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+  val avgLineColor = MaterialTheme.colorScheme.outline
+
+  Box(modifier = Modifier.fillMaxWidth()) {
+    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+      stats.forEachIndexed { index, stat ->
+        WeekdayBar(
+          stat = stat,
+          label = dayLabels[index],
+          accentColor = accent,
+          mutedColor = muted,
+          neutralColor = neutral,
+          withHighlight = true,
+        )
+      }
+    }
+    val avgFraction = averageCompletionRate.coerceIn(0f, 1f)
+    Canvas(modifier = Modifier.matchParentSize()) {
+      val barMaxPx = BAR_MAX_HEIGHT.toPx()
+      val lineY = barMaxPx * (1f - avgFraction)
+      drawLine(
+        color = avgLineColor,
+        start = Offset(0f, lineY),
+        end = Offset(size.width, lineY),
+        strokeWidth = 1.dp.toPx(),
+        pathEffect = PathEffect.dashPathEffect(floatArrayOf(6.dp.toPx(), 4.dp.toPx()), 0f),
+      )
+    }
+  }
+}
+
+@Composable
+private fun WeekdayBarsNoHighlight(
+  stats: List<WeekdayPerformanceStats>,
+  dayLabels: List<String>,
+) {
+  val neutral = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
+  Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+    stats.forEachIndexed { index, stat ->
+      WeekdayBar(
+        stat = stat,
+        label = dayLabels[index],
+        accentColor = neutral,
+        mutedColor = neutral,
+        neutralColor = neutral,
+        withHighlight = false,
+      )
+    }
+  }
+}
+
+@Composable
+private fun WeekdayBar(
+  stat: WeekdayPerformanceStats,
+  label: String,
+  accentColor: Color,
+  mutedColor: Color,
+  neutralColor: Color,
+  withHighlight: Boolean,
+) {
+  var targetHeight by remember { mutableStateOf(BAR_MIN_HEIGHT) }
+  LaunchedEffect(stat.completionRate) {
+    targetHeight = (BAR_MAX_HEIGHT * stat.completionRate).coerceAtLeast(BAR_MIN_HEIGHT)
+  }
+  val barHeight by animateDpAsState(targetValue = targetHeight, animationSpec = tween(BAR_ANIM_MS))
+
+  val targetColor =
+    when {
+      withHighlight && stat.isBest -> accentColor
+      withHighlight && stat.isWorst -> mutedColor
+      else -> neutralColor
+    }
+  val barColor by animateColorAsState(targetValue = targetColor, animationSpec = tween(COLOR_ANIM_MS))
+
+  Column(
+    horizontalAlignment = Alignment.CenterHorizontally,
+    verticalArrangement = Arrangement.spacedBy(Indent.x3s),
+  ) {
+    Box(
+      modifier = Modifier.size(width = BAR_CONTAINER_WIDTH, height = BAR_MAX_HEIGHT),
+      contentAlignment = Alignment.BottomCenter,
+    ) {
+      Box(
+        modifier =
+          Modifier
+            .size(width = BAR_WIDTH, height = barHeight)
+            .clip(MaterialTheme.shapes.extraSmall)
+            .background(barColor),
+      )
+    }
+    Text(
+      text = label,
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+    Text(
+      text = stringResource(Res.string.format_weekday_completion_rate, (stat.completionRate * PERCENT_FACTOR).roundToInt()),
+      style = MaterialTheme.typography.labelSmall,
+      color = MaterialTheme.colorScheme.onSurfaceVariant,
+    )
+  }
+}

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -170,7 +170,7 @@ private fun WeekdayBarsNoHighlight(
   Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
     stats.forEachIndexed { index, stat ->
       WeekdayBar(
-        stat = stat,
+        stat = stat.copy(completionRate = null),
         label = dayLabels[index],
         accentColor = neutral,
         neutralColor = neutral,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -24,10 +24,10 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.stringResource
 import space.be1ski.vibits.core.strings.generated.Res
@@ -38,6 +38,7 @@ import space.be1ski.vibits.core.strings.generated.day_sun
 import space.be1ski.vibits.core.strings.generated.day_thu
 import space.be1ski.vibits.core.strings.generated.day_tue
 import space.be1ski.vibits.core.strings.generated.day_wed
+import space.be1ski.vibits.core.strings.generated.format_weekday_avg_rate
 import space.be1ski.vibits.core.strings.generated.format_weekday_completion_rate
 import space.be1ski.vibits.core.strings.generated.label_weekday_performance
 import space.be1ski.vibits.core.strings.generated.msg_not_enough_data_for_trends
@@ -52,6 +53,7 @@ private val BAR_MAX_HEIGHT = 64.dp
 private val BAR_MIN_HEIGHT = 2.dp
 private val BAR_CONTAINER_WIDTH = 24.dp
 private val BAR_WIDTH = 16.dp
+private val AVG_LEGEND_LINE_WIDTH = 12.dp
 private const val BAR_ANIM_MS = 320
 private const val COLOR_ANIM_MS = 180
 private const val PERCENT_FACTOR = 100
@@ -107,34 +109,53 @@ private fun WeekdayBarsWithAvgLine(
   accentColor: Color,
   averageCompletionRate: Float,
 ) {
-  val accent = accentColor
-  val muted = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
   val neutral = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
   val avgLineColor = MaterialTheme.colorScheme.outline
 
-  Box(modifier = Modifier.fillMaxWidth()) {
-    Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
-      stats.forEachIndexed { index, stat ->
-        WeekdayBar(
-          stat = stat,
-          label = dayLabels[index],
-          accentColor = accent,
-          mutedColor = muted,
-          neutralColor = neutral,
-          withHighlight = true,
+  Column {
+    Box(modifier = Modifier.fillMaxWidth()) {
+      Row(modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.SpaceEvenly) {
+        stats.forEachIndexed { index, stat ->
+          WeekdayBar(
+            stat = stat,
+            label = dayLabels[index],
+            accentColor = accentColor,
+            neutralColor = neutral,
+            showPercentage = true,
+          )
+        }
+      }
+      val avgFraction = averageCompletionRate.coerceIn(0f, 1f)
+      Canvas(modifier = Modifier.matchParentSize()) {
+        val barMaxPx = BAR_MAX_HEIGHT.toPx()
+        val lineY = barMaxPx * (1f - avgFraction)
+        drawLine(
+          color = avgLineColor,
+          start = Offset(0f, lineY),
+          end = Offset(size.width, lineY),
+          strokeWidth = 1.dp.toPx(),
+          pathEffect = PathEffect.dashPathEffect(floatArrayOf(6.dp.toPx(), 4.dp.toPx()), 0f),
         )
       }
     }
-    val avgFraction = averageCompletionRate.coerceIn(0f, 1f)
-    Canvas(modifier = Modifier.matchParentSize()) {
-      val barMaxPx = BAR_MAX_HEIGHT.toPx()
-      val lineY = barMaxPx * (1f - avgFraction)
-      drawLine(
+    Spacer(Modifier.height(Indent.x3s))
+    Row(
+      verticalAlignment = Alignment.CenterVertically,
+      horizontalArrangement = Arrangement.spacedBy(Indent.x2s),
+    ) {
+      Canvas(modifier = Modifier.size(width = AVG_LEGEND_LINE_WIDTH, height = 1.dp)) {
+        drawLine(
+          color = avgLineColor,
+          start = Offset(0f, 0f),
+          end = Offset(size.width, 0f),
+          strokeWidth = 1.dp.toPx(),
+          pathEffect = PathEffect.dashPathEffect(floatArrayOf(6.dp.toPx(), 4.dp.toPx()), 0f),
+        )
+      }
+      Text(
+        text = stringResource(Res.string.format_weekday_avg_rate, (averageCompletionRate * PERCENT_FACTOR).roundToInt()),
+        style = MaterialTheme.typography.labelSmall,
         color = avgLineColor,
-        start = Offset(0f, lineY),
-        end = Offset(size.width, lineY),
-        strokeWidth = 1.dp.toPx(),
-        pathEffect = PathEffect.dashPathEffect(floatArrayOf(6.dp.toPx(), 4.dp.toPx()), 0f),
       )
     }
   }
@@ -152,9 +173,8 @@ private fun WeekdayBarsNoHighlight(
         stat = stat,
         label = dayLabels[index],
         accentColor = neutral,
-        mutedColor = neutral,
         neutralColor = neutral,
-        withHighlight = false,
+        showPercentage = false,
       )
     }
   }
@@ -165,9 +185,8 @@ private fun WeekdayBar(
   stat: WeekdayPerformanceStats,
   label: String,
   accentColor: Color,
-  mutedColor: Color,
   neutralColor: Color,
-  withHighlight: Boolean,
+  showPercentage: Boolean,
 ) {
   var targetHeight by remember { mutableStateOf(BAR_MIN_HEIGHT) }
   LaunchedEffect(stat.completionRate) {
@@ -180,12 +199,7 @@ private fun WeekdayBar(
   }
   val barHeight by animateDpAsState(targetValue = targetHeight, animationSpec = tween(BAR_ANIM_MS))
 
-  val targetColor =
-    when {
-      withHighlight && stat.isBest -> accentColor
-      withHighlight && stat.isWorst -> mutedColor
-      else -> neutralColor
-    }
+  val targetColor = if (stat.isBest) accentColor else neutralColor
   val barColor by animateColorAsState(targetValue = targetColor, animationSpec = tween(COLOR_ANIM_MS))
 
   Column(
@@ -209,7 +223,7 @@ private fun WeekdayBar(
       style = MaterialTheme.typography.labelSmall,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
-    if (stat.completionRate != null) {
+    if (showPercentage && stat.completionRate != null) {
       Text(
         text = stringResource(Res.string.format_weekday_completion_rate, (stat.completionRate * PERCENT_FACTOR).roundToInt()),
         style = MaterialTheme.typography.labelSmall,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -167,7 +167,12 @@ private fun WeekdayBar(
 ) {
   var targetHeight by remember { mutableStateOf(BAR_MIN_HEIGHT) }
   LaunchedEffect(stat.completionRate) {
-    targetHeight = (BAR_MAX_HEIGHT * stat.completionRate).coerceAtLeast(BAR_MIN_HEIGHT)
+    targetHeight =
+      if (stat.completionRate != null) {
+        (BAR_MAX_HEIGHT * stat.completionRate).coerceAtLeast(BAR_MIN_HEIGHT)
+      } else {
+        BAR_MIN_HEIGHT
+      }
   }
   val barHeight by animateDpAsState(targetValue = targetHeight, animationSpec = tween(BAR_ANIM_MS))
 
@@ -200,10 +205,12 @@ private fun WeekdayBar(
       style = MaterialTheme.typography.labelSmall,
       color = MaterialTheme.colorScheme.onSurfaceVariant,
     )
-    Text(
-      text = stringResource(Res.string.format_weekday_completion_rate, (stat.completionRate * PERCENT_FACTOR).roundToInt()),
-      style = MaterialTheme.typography.labelSmall,
-      color = MaterialTheme.colorScheme.onSurfaceVariant,
-    )
+    if (stat.completionRate != null) {
+      Text(
+        text = stringResource(Res.string.format_weekday_completion_rate, (stat.completionRate * PERCENT_FACTOR).roundToInt()),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.onSurfaceVariant,
+      )
+    }
   }
 }

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -24,6 +24,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.PathEffect
@@ -43,6 +44,7 @@ import space.be1ski.vibits.core.strings.generated.msg_not_enough_data_for_trends
 import space.be1ski.vibits.core.ui.Indent
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceCardState
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceStats
+import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 import kotlin.math.roundToInt
 
 private val BAR_MAX_HEIGHT = 64.dp
@@ -69,7 +71,7 @@ internal fun WeekdayPerformanceCard(
       stringResource(Res.string.day_sun),
     )
 
-  Column(modifier = modifier, verticalArrangement = Arrangement.spacedBy(Indent.xs)) {
+  Column(modifier = modifier.testTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD), verticalArrangement = Arrangement.spacedBy(Indent.xs)) {
     Text(
       text = stringResource(Res.string.label_weekday_performance),
       style = MaterialTheme.typography.titleSmall,

--- a/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
+++ b/feature/habits/presentation/src/commonMain/kotlin/space/be1ski/vibits/feature/habits/presentation/view/components/WeekdayPerformanceCard.kt
@@ -42,6 +42,7 @@ import space.be1ski.vibits.core.strings.generated.format_weekday_completion_rate
 import space.be1ski.vibits.core.strings.generated.label_weekday_performance
 import space.be1ski.vibits.core.strings.generated.msg_not_enough_data_for_trends
 import space.be1ski.vibits.core.ui.Indent
+import space.be1ski.vibits.feature.habits.domain.model.HabitColor
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceCardState
 import space.be1ski.vibits.feature.habits.presentation.state.WeekdayPerformanceStats
 import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
@@ -58,6 +59,7 @@ private const val PERCENT_FACTOR = 100
 @Composable
 internal fun WeekdayPerformanceCard(
   state: WeekdayPerformanceCardState,
+  habitColor: HabitColor,
   modifier: Modifier = Modifier,
 ) {
   val dayLabels =
@@ -80,6 +82,7 @@ internal fun WeekdayPerformanceCard(
       WeekdayBarsWithAvgLine(
         stats = state.stats,
         dayLabels = dayLabels,
+        accentColor = Color(habitColor.argb),
         averageCompletionRate =
           checkNotNull(state.averageCompletionRate) {
             "averageCompletionRate must be non-null when hasSufficientData is true"
@@ -101,9 +104,10 @@ internal fun WeekdayPerformanceCard(
 private fun WeekdayBarsWithAvgLine(
   stats: List<WeekdayPerformanceStats>,
   dayLabels: List<String>,
+  accentColor: Color,
   averageCompletionRate: Float,
 ) {
-  val accent = MaterialTheme.colorScheme.primary
+  val accent = accentColor
   val muted = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)
   val neutral = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.5f)
   val avgLineColor = MaterialTheme.colorScheme.outline

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
@@ -15,7 +15,6 @@ import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class WeekdayStatsSelectorTest {
-
   private val tag = "#habits/test"
 
   // ── Ordering ────────────────────────────────────────────────────────────────
@@ -32,10 +31,11 @@ class WeekdayStatsSelectorTest {
   @Test
   fun `completion rate is calculated correctly per weekday`() {
     // Week1: all done. Week2: Mon and Wed done, rest not done.
-    val summary = twoWeeks(
-      List(7) { true },
-      listOf(true, false, true, false, false, false, false),
-    )
+    val summary =
+      twoWeeks(
+        List(7) { true },
+        listOf(true, false, true, false, false, false, false),
+      )
     val result = WeekdayStatsSelector(summary, tag)
     assertTrue(result.hasSufficientData)
     val rates = result.stats.associate { it.dayOfWeek to it.completionRate }
@@ -165,10 +165,11 @@ class WeekdayStatsSelectorTest {
   @Test
   fun `when sufficient data then averageCompletionRate equals arithmetic mean of weekday rates`() {
     // Week1: all done (1.0). Week2: Mon, Wed, Fri, Sun done; Tue, Thu, Sat not done.
-    val summary = twoWeeks(
-      List(7) { true },
-      listOf(true, false, true, false, true, false, true),
-    )
+    val summary =
+      twoWeeks(
+        List(7) { true },
+        listOf(true, false, true, false, true, false, true),
+      )
     // Mon=1.0, Tue=0.5, Wed=1.0, Thu=0.5, Fri=1.0, Sat=0.5, Sun=1.0
     val expectedAvg = (1.0 + 0.5 + 1.0 + 0.5 + 1.0 + 0.5 + 1.0) / 7.0
     val result = WeekdayStatsSelector(summary, tag)
@@ -183,64 +184,75 @@ class WeekdayStatsSelectorTest {
   // date(1) = Mon 2024-01-01, date(2) = Tue 2024-01-02, etc.
   private fun date(dayOfMonth: Int) = LocalDate(2024, 1, dayOfMonth)
 
-  private fun obs(date: LocalDate, done: Boolean): ContributionDay = ContributionDay(
-    date = date,
-    count = if (done) 1 else 0,
-    totalHabits = 1,
-    completionRatio = if (done) 1f else 0f,
-    habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = done)),
-    dailyMemo = null,
-    inRange = true,
-    isClickable = true,
-  )
+  private fun obs(
+    date: LocalDate,
+    done: Boolean,
+  ): ContributionDay =
+    ContributionDay(
+      date = date,
+      count = if (done) 1 else 0,
+      totalHabits = 1,
+      completionRatio = if (done) 1f else 0f,
+      habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = done)),
+      dailyMemo = null,
+      inRange = true,
+      isClickable = true,
+    )
 
-  private fun outOfRange(date: LocalDate): ContributionDay = ContributionDay(
-    date = date,
-    count = 1,
-    totalHabits = 1,
-    completionRatio = 1f,
-    habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = true)),
-    dailyMemo = null,
-    inRange = false,
-    isClickable = false,
-  )
+  private fun outOfRange(date: LocalDate): ContributionDay =
+    ContributionDay(
+      date = date,
+      count = 1,
+      totalHabits = 1,
+      completionRatio = 1f,
+      habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = true)),
+      dailyMemo = null,
+      inRange = false,
+      isClickable = false,
+    )
 
-  private fun futureDay(date: LocalDate): ContributionDay = ContributionDay(
-    date = date,
-    count = 0,
-    totalHabits = 1,
-    completionRatio = 0f,
-    habitStatuses = emptyList(),
-    dailyMemo = null,
-    inRange = true,
-    isClickable = false,
-  )
+  private fun futureDay(date: LocalDate): ContributionDay =
+    ContributionDay(
+      date = date,
+      count = 0,
+      totalHabits = 1,
+      completionRatio = 0f,
+      habitStatuses = emptyList(),
+      dailyMemo = null,
+      inRange = true,
+      isClickable = false,
+    )
 
-  private fun preConfigDay(date: LocalDate): ContributionDay = ContributionDay(
-    date = date,
-    count = 0,
-    totalHabits = 0,
-    completionRatio = 0f,
-    habitStatuses = emptyList(), // habit not in config yet
-    dailyMemo = null,
-    inRange = true,
-    isClickable = true,
-  )
+  private fun preConfigDay(date: LocalDate): ContributionDay =
+    ContributionDay(
+      date = date,
+      count = 0,
+      totalHabits = 0,
+      completionRatio = 0f,
+      habitStatuses = emptyList(), // habit not in config yet
+      dailyMemo = null,
+      inRange = true,
+      isClickable = true,
+    )
 
   private fun summaryOf(vararg weeks: List<ContributionDay>): ActivitySummary =
     ActivitySummary(
-      weeks = weeks.mapIndexed { i, days ->
-        ActivityWeek(
-          startDate = days.first().date,
-          days = days,
-          weeklyCount = days.count { it.count > 0 },
-        )
-      },
+      weeks =
+        weeks.mapIndexed { i, days ->
+          ActivityWeek(
+            startDate = days.first().date,
+            days = days,
+            weeklyCount = days.count { it.count > 0 },
+          )
+        },
       maxDaily = 1,
       maxWeekly = 7,
     )
 
-  private fun twoWeeks(week1Done: List<Boolean>, week2Done: List<Boolean>): ActivitySummary {
+  private fun twoWeeks(
+    week1Done: List<Boolean>,
+    week2Done: List<Boolean>,
+  ): ActivitySummary {
     // Week 1: Mon 2024-01-01 to Sun 2024-01-07
     // Week 2: Mon 2024-01-08 to Sun 2024-01-14
     val w1 = week1Done.mapIndexed { i, done -> obs(date(1 + i), done) }

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
@@ -21,7 +21,7 @@ class WeekdayStatsSelectorTest {
 
   @Test
   fun `stats are returned in Mon to Sun order`() {
-    val summary = twoWeeks(List(7) { true }, List(7) { true })
+    val summary = fourWeeks(List(7) { true }, List(7) { true })
     val result = WeekdayStatsSelector(summary, tag)
     assertEquals(DayOfWeek.entries, result.stats.map { it.dayOfWeek })
   }
@@ -30,9 +30,9 @@ class WeekdayStatsSelectorTest {
 
   @Test
   fun `completion rate is calculated correctly per weekday`() {
-    // Week1: all done. Week2: Mon and Wed done, rest not done.
+    // Odd weeks: all done. Even weeks: Mon and Wed done, rest not done.
     val summary =
-      twoWeeks(
+      fourWeeks(
         List(7) { true },
         listOf(true, false, true, false, false, false, false),
       )
@@ -48,12 +48,12 @@ class WeekdayStatsSelectorTest {
     assertEquals(0.5f, rates[DayOfWeek.SUNDAY])
   }
 
-  // ── Best/worst identification ─────────────────────────────────────────────────
+  // ── Best identification ────────────────────────────────────────────────────
 
   @Test
   fun `best day is correctly identified when single clear winner`() {
-    // Mon: 2/2=1.0. All others: 1/2=0.5.
-    val summary = twoWeeks(List(7) { true }, listOf(true, false, false, false, false, false, false))
+    // Odd weeks: all done. Even weeks: only Mon done → Mon=1.0, others=0.5.
+    val summary = fourWeeks(List(7) { true }, listOf(true, false, false, false, false, false, false))
     val result = WeekdayStatsSelector(summary, tag)
     assertTrue(result.hasSufficientData)
     val best = result.stats.filter { it.isBest }
@@ -61,72 +61,43 @@ class WeekdayStatsSelectorTest {
     assertEquals(DayOfWeek.MONDAY, best.single().dayOfWeek)
   }
 
-  @Test
-  fun `worst day is correctly identified when single clear loser`() {
-    // Mon: 0/2=0.0. All others: 1/2=0.5 or better.
-    val summary = twoWeeks(List(7) { true }, listOf(false, true, true, true, true, true, true))
-    val result = WeekdayStatsSelector(summary, tag)
-    assertTrue(result.hasSufficientData)
-    val worst = result.stats.filter { it.isWorst }
-    assertEquals(1, worst.size)
-    assertEquals(DayOfWeek.MONDAY, worst.single().dayOfWeek)
-  }
-
   // ── Tie-breaking ─────────────────────────────────────────────────────────────
 
   @Test
   fun `when two days tie for best then neither is marked isBest`() {
-    // Mon and Tue: 1.0. All others: 0.5.
-    val summary = twoWeeks(List(7) { true }, listOf(true, true, false, false, false, false, false))
+    // Odd weeks: all done. Even weeks: Mon and Tue done → Mon=Tue=1.0, others=0.5.
+    val summary = fourWeeks(List(7) { true }, listOf(true, true, false, false, false, false, false))
     val result = WeekdayStatsSelector(summary, tag)
     assertTrue(result.hasSufficientData)
     assertFalse(result.stats.any { it.isBest })
   }
 
   @Test
-  fun `when two days tie for worst then neither is marked isWorst`() {
-    // Mon and Tue: 0.0. All others: 0.5 or better.
-    val summary = twoWeeks(List(7) { true }, listOf(false, false, true, true, true, true, true))
+  fun `when all days have equal non-zero rate then no best`() {
+    val summary = fourWeeks(List(7) { true }, List(7) { true })
     val result = WeekdayStatsSelector(summary, tag)
     assertTrue(result.hasSufficientData)
-    assertFalse(result.stats.any { it.isWorst })
+    assertFalse(result.stats.any { it.isBest })
   }
 
   @Test
-  fun `when all days have equal non-zero rate then no highlights`() {
-    val summary = twoWeeks(List(7) { true }, List(7) { true })
+  fun `when all days have zero rate then no best`() {
+    val summary = fourWeeks(List(7) { false }, List(7) { false })
     val result = WeekdayStatsSelector(summary, tag)
     assertTrue(result.hasSufficientData)
-    assertFalse(result.stats.any { it.isBest || it.isWorst })
-  }
-
-  @Test
-  fun `when all days have zero rate then no highlights`() {
-    val summary = twoWeeks(List(7) { false }, List(7) { false })
-    val result = WeekdayStatsSelector(summary, tag)
-    assertTrue(result.hasSufficientData)
-    assertFalse(result.stats.any { it.isBest || it.isWorst })
-  }
-
-  // ── Invariant ─────────────────────────────────────────────────────────────────
-
-  @Test
-  fun `no entry has both isBest and isWorst true`() {
-    val summary = twoWeeks(List(7) { true }, listOf(true, false, true, false, true, false, true))
-    val result = WeekdayStatsSelector(summary, tag)
-    assertTrue(result.stats.none { it.isBest && it.isWorst })
+    assertFalse(result.stats.any { it.isBest })
   }
 
   // ── Insufficient data ────────────────────────────────────────────────────────
 
   @Test
-  fun `when any weekday has fewer than 2 observations then hasSufficientData is false and no highlights`() {
+  fun `when any weekday has fewer than 4 observations then hasSufficientData is false and no best`() {
     // Only 1 week of data → each weekday has 1 observation.
     val week = listOf(date(1), date(2), date(3), date(4), date(5), date(6), date(7))
     val summary = summaryOf(week.map { obs(it, true) })
     val result = WeekdayStatsSelector(summary, tag)
     assertFalse(result.hasSufficientData)
-    assertFalse(result.stats.any { it.isBest || it.isWorst })
+    assertFalse(result.stats.any { it.isBest })
     assertNull(result.averageCompletionRate)
   }
 
@@ -185,9 +156,9 @@ class WeekdayStatsSelectorTest {
 
   @Test
   fun `when sufficient data then averageCompletionRate equals arithmetic mean of weekday rates`() {
-    // Week1: all done (1.0). Week2: Mon, Wed, Fri, Sun done; Tue, Thu, Sat not done.
+    // Odd weeks: all done. Even weeks: Mon, Wed, Fri, Sun done; Tue, Thu, Sat not done.
     val summary =
-      twoWeeks(
+      fourWeeks(
         List(7) { true },
         listOf(true, false, true, false, true, false, true),
       )
@@ -270,14 +241,16 @@ class WeekdayStatsSelectorTest {
       maxWeekly = 7,
     )
 
-  private fun twoWeeks(
-    week1Done: List<Boolean>,
-    week2Done: List<Boolean>,
+  // Repeats two patterns over 4 weeks to satisfy MIN_OBSERVATIONS = 4.
+  // Week 1: Mon 2024-01-01–07, Week 2: Jan 08–14, Week 3: Jan 15–21, Week 4: Jan 22–28.
+  private fun fourWeeks(
+    oddDone: List<Boolean>,
+    evenDone: List<Boolean>,
   ): ActivitySummary {
-    // Week 1: Mon 2024-01-01 to Sun 2024-01-07
-    // Week 2: Mon 2024-01-08 to Sun 2024-01-14
-    val w1 = week1Done.mapIndexed { i, done -> obs(date(1 + i), done) }
-    val w2 = week2Done.mapIndexed { i, done -> obs(date(8 + i), done) }
-    return summaryOf(w1, w2)
+    val w1 = oddDone.mapIndexed { i, done -> obs(date(1 + i), done) }
+    val w2 = evenDone.mapIndexed { i, done -> obs(date(8 + i), done) }
+    val w3 = oddDone.mapIndexed { i, done -> obs(date(15 + i), done) }
+    val w4 = evenDone.mapIndexed { i, done -> obs(date(22 + i), done) }
+    return summaryOf(w1, w2, w3, w4)
   }
 }

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
@@ -130,6 +130,27 @@ class WeekdayStatsSelectorTest {
     assertNull(result.averageCompletionRate)
   }
 
+  @Test
+  fun `when weekday has zero observations then completionRate is null`() {
+    // Mon-Wed have 2 observations each; Thu-Sun are pre-config (no habit status) → 0 observations.
+    val w1 =
+      listOf(obs(date(1), true), obs(date(2), true), obs(date(3), true)) +
+        listOf(date(4), date(5), date(6), date(7)).map { preConfigDay(it) }
+    val w2 =
+      listOf(obs(date(8), false), obs(date(9), false), obs(date(10), false)) +
+        listOf(date(11), date(12), date(13), date(14)).map { preConfigDay(it) }
+    val result = WeekdayStatsSelector(summaryOf(w1, w2), tag)
+    assertFalse(result.hasSufficientData)
+    val rates = result.stats.associate { it.dayOfWeek to it.completionRate }
+    assertEquals(0.5f, rates[DayOfWeek.MONDAY])
+    assertEquals(0.5f, rates[DayOfWeek.TUESDAY])
+    assertEquals(0.5f, rates[DayOfWeek.WEDNESDAY])
+    assertNull(rates[DayOfWeek.THURSDAY])
+    assertNull(rates[DayOfWeek.FRIDAY])
+    assertNull(rates[DayOfWeek.SATURDAY])
+    assertNull(rates[DayOfWeek.SUNDAY])
+  }
+
   // ── Observation filtering ────────────────────────────────────────────────────
 
   @Test

--- a/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
+++ b/feature/habits/presentation/src/commonTest/kotlin/space/be1ski/vibits/feature/habits/presentation/WeekdayStatsSelectorTest.kt
@@ -1,0 +1,250 @@
+package space.be1ski.vibits.feature.habits.presentation
+
+import kotlinx.datetime.DayOfWeek
+import kotlinx.datetime.LocalDate
+import space.be1ski.vibits.feature.habits.domain.model.ActivitySummary
+import space.be1ski.vibits.feature.habits.domain.model.ActivityWeek
+import space.be1ski.vibits.feature.habits.domain.model.ContributionDay
+import space.be1ski.vibits.feature.habits.domain.model.HabitStatus
+import space.be1ski.vibits.feature.habits.presentation.reducer.WeekdayStatsSelector
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+class WeekdayStatsSelectorTest {
+
+  private val tag = "#habits/test"
+
+  // ── Ordering ────────────────────────────────────────────────────────────────
+
+  @Test
+  fun `stats are returned in Mon to Sun order`() {
+    val summary = twoWeeks(List(7) { true }, List(7) { true })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertEquals(DayOfWeek.entries, result.stats.map { it.dayOfWeek })
+  }
+
+  // ── Rate calculation ─────────────────────────────────────────────────────────
+
+  @Test
+  fun `completion rate is calculated correctly per weekday`() {
+    // Week1: all done. Week2: Mon and Wed done, rest not done.
+    val summary = twoWeeks(
+      List(7) { true },
+      listOf(true, false, true, false, false, false, false),
+    )
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    val rates = result.stats.associate { it.dayOfWeek to it.completionRate }
+    assertEquals(1.0f, rates[DayOfWeek.MONDAY])
+    assertEquals(0.5f, rates[DayOfWeek.TUESDAY])
+    assertEquals(1.0f, rates[DayOfWeek.WEDNESDAY])
+    assertEquals(0.5f, rates[DayOfWeek.THURSDAY])
+    assertEquals(0.5f, rates[DayOfWeek.FRIDAY])
+    assertEquals(0.5f, rates[DayOfWeek.SATURDAY])
+    assertEquals(0.5f, rates[DayOfWeek.SUNDAY])
+  }
+
+  // ── Best/worst identification ─────────────────────────────────────────────────
+
+  @Test
+  fun `best day is correctly identified when single clear winner`() {
+    // Mon: 2/2=1.0. All others: 1/2=0.5.
+    val summary = twoWeeks(List(7) { true }, listOf(true, false, false, false, false, false, false))
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    val best = result.stats.filter { it.isBest }
+    assertEquals(1, best.size)
+    assertEquals(DayOfWeek.MONDAY, best.single().dayOfWeek)
+  }
+
+  @Test
+  fun `worst day is correctly identified when single clear loser`() {
+    // Mon: 0/2=0.0. All others: 1/2=0.5 or better.
+    val summary = twoWeeks(List(7) { true }, listOf(false, true, true, true, true, true, true))
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    val worst = result.stats.filter { it.isWorst }
+    assertEquals(1, worst.size)
+    assertEquals(DayOfWeek.MONDAY, worst.single().dayOfWeek)
+  }
+
+  // ── Tie-breaking ─────────────────────────────────────────────────────────────
+
+  @Test
+  fun `when two days tie for best then neither is marked isBest`() {
+    // Mon and Tue: 1.0. All others: 0.5.
+    val summary = twoWeeks(List(7) { true }, listOf(true, true, false, false, false, false, false))
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    assertFalse(result.stats.any { it.isBest })
+  }
+
+  @Test
+  fun `when two days tie for worst then neither is marked isWorst`() {
+    // Mon and Tue: 0.0. All others: 0.5 or better.
+    val summary = twoWeeks(List(7) { true }, listOf(false, false, true, true, true, true, true))
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    assertFalse(result.stats.any { it.isWorst })
+  }
+
+  @Test
+  fun `when all days have equal non-zero rate then no highlights`() {
+    val summary = twoWeeks(List(7) { true }, List(7) { true })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    assertFalse(result.stats.any { it.isBest || it.isWorst })
+  }
+
+  @Test
+  fun `when all days have zero rate then no highlights`() {
+    val summary = twoWeeks(List(7) { false }, List(7) { false })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    assertFalse(result.stats.any { it.isBest || it.isWorst })
+  }
+
+  // ── Invariant ─────────────────────────────────────────────────────────────────
+
+  @Test
+  fun `no entry has both isBest and isWorst true`() {
+    val summary = twoWeeks(List(7) { true }, listOf(true, false, true, false, true, false, true))
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.stats.none { it.isBest && it.isWorst })
+  }
+
+  // ── Insufficient data ────────────────────────────────────────────────────────
+
+  @Test
+  fun `when any weekday has fewer than 2 observations then hasSufficientData is false and no highlights`() {
+    // Only 1 week of data → each weekday has 1 observation.
+    val week = listOf(date(1), date(2), date(3), date(4), date(5), date(6), date(7))
+    val summary = summaryOf(week.map { obs(it, true) })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertFalse(result.hasSufficientData)
+    assertFalse(result.stats.any { it.isBest || it.isWorst })
+    assertNull(result.averageCompletionRate)
+  }
+
+  // ── Observation filtering ────────────────────────────────────────────────────
+
+  @Test
+  fun `when out-of-range days are present then they are excluded`() {
+    val w1 = listOf(date(1), date(2), date(3), date(4), date(5), date(6), date(7))
+    val w2 = listOf(date(8), date(9), date(10), date(11), date(12), date(13), date(14))
+    val summary = summaryOf(w1.map { obs(it, true) }, w2.map { outOfRange(it) })
+    // Only 1 observation per weekday after exclusion → insufficient data
+    val result = WeekdayStatsSelector(summary, tag)
+    assertFalse(result.hasSufficientData)
+  }
+
+  @Test
+  fun `when future days are present then they are excluded`() {
+    val w1 = listOf(date(1), date(2), date(3), date(4), date(5), date(6), date(7))
+    val w2 = listOf(date(8), date(9), date(10), date(11), date(12), date(13), date(14))
+    val summary = summaryOf(w1.map { obs(it, true) }, w2.map { futureDay(it) })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertFalse(result.hasSufficientData)
+  }
+
+  @Test
+  fun `when pre-config days have no matching habit status then they are excluded`() {
+    val w1 = listOf(date(1), date(2), date(3), date(4), date(5), date(6), date(7))
+    val w2 = listOf(date(8), date(9), date(10), date(11), date(12), date(13), date(14))
+    val summary = summaryOf(w1.map { obs(it, true) }, w2.map { preConfigDay(it) })
+    val result = WeekdayStatsSelector(summary, tag)
+    assertFalse(result.hasSufficientData)
+  }
+
+  // ── Average ──────────────────────────────────────────────────────────────────
+
+  @Test
+  fun `when sufficient data then averageCompletionRate equals arithmetic mean of weekday rates`() {
+    // Week1: all done (1.0). Week2: Mon, Wed, Fri, Sun done; Tue, Thu, Sat not done.
+    val summary = twoWeeks(
+      List(7) { true },
+      listOf(true, false, true, false, true, false, true),
+    )
+    // Mon=1.0, Tue=0.5, Wed=1.0, Thu=0.5, Fri=1.0, Sat=0.5, Sun=1.0
+    val expectedAvg = (1.0 + 0.5 + 1.0 + 0.5 + 1.0 + 0.5 + 1.0) / 7.0
+    val result = WeekdayStatsSelector(summary, tag)
+    assertTrue(result.hasSufficientData)
+    val avg = checkNotNull(result.averageCompletionRate) { "averageCompletionRate must not be null" }
+    assertTrue(kotlin.math.abs(avg.toDouble() - expectedAvg) < 0.001)
+  }
+
+  // ── Helpers ──────────────────────────────────────────────────────────────────
+
+  // Use a fixed Mon 2024-01-01 as anchor. DayOfWeek.entries is Mon-first.
+  // date(1) = Mon 2024-01-01, date(2) = Tue 2024-01-02, etc.
+  private fun date(dayOfMonth: Int) = LocalDate(2024, 1, dayOfMonth)
+
+  private fun obs(date: LocalDate, done: Boolean): ContributionDay = ContributionDay(
+    date = date,
+    count = if (done) 1 else 0,
+    totalHabits = 1,
+    completionRatio = if (done) 1f else 0f,
+    habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = done)),
+    dailyMemo = null,
+    inRange = true,
+    isClickable = true,
+  )
+
+  private fun outOfRange(date: LocalDate): ContributionDay = ContributionDay(
+    date = date,
+    count = 1,
+    totalHabits = 1,
+    completionRatio = 1f,
+    habitStatuses = listOf(HabitStatus(tag = tag, label = "Test", done = true)),
+    dailyMemo = null,
+    inRange = false,
+    isClickable = false,
+  )
+
+  private fun futureDay(date: LocalDate): ContributionDay = ContributionDay(
+    date = date,
+    count = 0,
+    totalHabits = 1,
+    completionRatio = 0f,
+    habitStatuses = emptyList(),
+    dailyMemo = null,
+    inRange = true,
+    isClickable = false,
+  )
+
+  private fun preConfigDay(date: LocalDate): ContributionDay = ContributionDay(
+    date = date,
+    count = 0,
+    totalHabits = 0,
+    completionRatio = 0f,
+    habitStatuses = emptyList(), // habit not in config yet
+    dailyMemo = null,
+    inRange = true,
+    isClickable = true,
+  )
+
+  private fun summaryOf(vararg weeks: List<ContributionDay>): ActivitySummary =
+    ActivitySummary(
+      weeks = weeks.mapIndexed { i, days ->
+        ActivityWeek(
+          startDate = days.first().date,
+          days = days,
+          weeklyCount = days.count { it.count > 0 },
+        )
+      },
+      maxDaily = 1,
+      maxWeekly = 7,
+    )
+
+  private fun twoWeeks(week1Done: List<Boolean>, week2Done: List<Boolean>): ActivitySummary {
+    // Week 1: Mon 2024-01-01 to Sun 2024-01-07
+    // Week 2: Mon 2024-01-08 to Sun 2024-01-14
+    val w1 = week1Done.mapIndexed { i, done -> obs(date(1 + i), done) }
+    val w2 = week2Done.mapIndexed { i, done -> obs(date(8 + i), done) }
+    return summaryOf(w1, w2)
+  }
+}

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellState.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppShellState.kt
@@ -130,7 +130,7 @@ internal fun rememberSuccessRateIfNeeded(
 ): Float? {
   val isHabitsScreen = appState.selectedScreen == Screen.HABITS
   val hasHabits = remember(habitsTimeline) { habitsTimeline.lastOrNull()?.habits?.isNotEmpty() == true }
-  val shouldCalculate = isHabitsScreen && hasHabits
+  val shouldCalculate = isHabitsScreen && hasHabits && appState.selectedHabitTag == null
   return if (shouldCalculate) {
     val cachedData =
       habitsState.getActivityData(

--- a/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
+++ b/feature/homescreen/src/commonMain/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/SwipeableContent.kt
@@ -27,8 +27,8 @@ import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseC
 import space.be1ski.vibits.feature.habits.domain.usecase.NavigateActivityRangeUseCase
 import space.be1ski.vibits.feature.habits.presentation.action.HabitsAction
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.state.StatsScreenState
 import space.be1ski.vibits.feature.habits.presentation.view.StatsScreen
-import space.be1ski.vibits.feature.habits.presentation.view.StatsScreenState
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.action.AppAction

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -940,15 +940,17 @@ class AppScreenshotTest {
         habitsState = habitsStateWithCache(quarterRange),
       )
     }
-    // Compact: single-habit state; scroll to the card so the FAB doesn't obscure the labels.
+    // Compact: card is only shown for month range; use November which has sufficient observations.
+    val monthRange = ActivityRange.Month(2024, Month.NOVEMBER)
+    val monthAppState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = LocalDate(2024, 11, 1))
     runCompactUiTest {
-      val singleHabitState = habitsStateWithSingleHabitCache(quarterRange)
-      setVibitsApp(quarterAppState, habitsState = singleHabitState, wideLayout = false)
+      val singleHabitState = habitsStateWithSingleHabitCache(monthRange)
+      setVibitsApp(monthAppState, habitsState = singleHabitState, wideLayout = false)
       onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_light_weekday_performance_card_quarter")
-      setVibitsApp(quarterAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
+      saveScreenshot("compact_light_weekday_performance_card_month")
+      setVibitsApp(monthAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
       onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_dark_weekday_performance_card_quarter")
+      saveScreenshot("compact_dark_weekday_performance_card_month")
     }
   }
 

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -6,7 +6,9 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
+import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
+import androidx.compose.ui.test.performScrollTo
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.Month
@@ -45,6 +47,7 @@ import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseC
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
+import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
@@ -106,6 +109,38 @@ class AppScreenshotTest {
   private val fakeGetChangelog = GetChangelogUseCase(FakeChangelogRepository(), FakeLastSeenVersionStore())
 
   private val demoMemos: List<Memo> by lazy { generateDemoMemos().sortedByDescending { it.createTime } }
+
+  // Single-habit memos (exercise only) — used for compact weekday card tests so the habit section
+  // is short enough to show the full WeekdayPerformanceCard (including labels) in the viewport.
+  private val singleHabitMemos: List<Memo> by lazy {
+    val rng = kotlin.random.Random(42)
+    val configContent =
+      buildString {
+        appendLine("#habits/config")
+        appendLine()
+        appendLine("${exerciseConfig.label} | ${exerciseConfig.tag} | #${exerciseConfig.color.argb.toString(16).takeLast(6).uppercase()}")
+      }
+    val memos = mutableListOf<Memo>()
+    memos.add(Memo(name = "memos/1", content = configContent, createTime = configInstant))
+    var id = 2
+    var cursor = configDate
+    while (cursor <= today) {
+      if (rng.nextFloat() < 0.7f) {
+        val dayOffset = cursor.toEpochDays() - configDate.toEpochDays()
+        memos.add(
+          Memo(
+            name = "memos/$id",
+            content = "#habits/daily $cursor\n\n${exerciseConfig.tag}",
+            createTime = configInstant + dayOffset.days + 8.hours,
+          ),
+        )
+        id++
+      }
+      cursor = LocalDate.fromEpochDays(cursor.toEpochDays() + 1)
+    }
+    memos.sortedByDescending { it.createTime }
+  }
+
   private val buildActivityData = BuildActivityDataUseCase(BuildDayDataUseCase())
 
   // region Demo data generation
@@ -369,6 +404,11 @@ class AppScreenshotTest {
   ): HabitsState {
     val (key, cached) = computeCache(demoMemos, range, mode)
     return HabitsState(activityDataCache = extraCache + (key to cached))
+  }
+
+  private fun habitsStateWithSingleHabitCache(range: ActivityRange): HabitsState {
+    val (key, cached) = computeCache(singleHabitMemos, range, ActivityMode.HABITS)
+    return HabitsState(activityDataCache = mapOf(key to cached))
   }
 
   // endregion
@@ -890,37 +930,67 @@ class AppScreenshotTest {
 
   @Test
   fun `weekday performance card with sufficient data`() {
-    val range = ActivityRange.Quarter(2024, 4)
-    val habitsState = habitsStateWithCache(range)
-    captureAppAllVariants(
-      name = "weekday_performance_card_quarter",
-      appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1)),
-      habitsState = habitsState,
-    )
+    val quarterRange = ActivityRange.Quarter(2024, 4)
+    val quarterAppState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
+    // Wide: habit picker with exercise selected → SelectedHabitGrid shows the card.
+    runWideUiTest {
+      captureApp(
+        "weekday_performance_card_quarter",
+        appState = quarterAppState.copy(selectedHabitTag = "#habits/exercise"),
+        habitsState = habitsStateWithCache(quarterRange),
+      )
+    }
+    // Compact: single-habit state; scroll to the card so the FAB doesn't obscure the labels.
+    runCompactUiTest {
+      val singleHabitState = habitsStateWithSingleHabitCache(quarterRange)
+      setVibitsApp(quarterAppState, habitsState = singleHabitState, wideLayout = false)
+      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
+      saveScreenshot("compact_light_weekday_performance_card_quarter")
+      setVibitsApp(quarterAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
+      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
+      saveScreenshot("compact_dark_weekday_performance_card_quarter")
+    }
   }
 
   @Test
   fun `weekday performance card with insufficient data`() {
-    val monday = LocalDate(2024, 12, 9)
-    val range = ActivityRange.Week(monday)
-    val habitsState = habitsStateWithCache(range)
-    captureAppAllVariants(
-      name = "weekday_performance_card_insufficient",
-      appState = habitsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = monday),
-      habitsState = habitsState,
-    )
+    // Jan 2025 is beyond demo data — each weekday has 0 observations, hasSufficientData = false.
+    // Month range (not Week) ensures showLast7DaysMatrix = false so the card renders.
+    val monthRange = ActivityRange.Month(2025, Month.JANUARY)
+    val monthAppState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = LocalDate(2025, 1, 1))
+    // Wide: habit picker with exercise selected → SelectedHabitGrid shows the card with insufficient state.
+    runWideUiTest {
+      captureApp(
+        "weekday_performance_card_insufficient",
+        appState = monthAppState.copy(selectedHabitTag = "#habits/exercise"),
+        habitsState = habitsStateWithCache(monthRange),
+      )
+    }
+    // Compact: single-habit state; scroll to the card so the FAB doesn't obscure the labels.
+    runCompactUiTest {
+      val singleHabitState = habitsStateWithSingleHabitCache(monthRange)
+      setVibitsApp(monthAppState, habitsState = singleHabitState, wideLayout = false)
+      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
+      saveScreenshot("compact_light_weekday_performance_card_insufficient")
+      setVibitsApp(monthAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
+      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
+      saveScreenshot("compact_dark_weekday_performance_card_insufficient")
+    }
   }
 
   @Test
   fun `weekday performance card in selected habit view`() {
+    // Wide-only: habit picker + selected habit grid only exists in wide layout.
     val range = ActivityRange.Quarter(2024, 4)
     val habitsState = habitsStateWithCache(range)
-    captureAppAllVariants(
-      name = "weekday_performance_card_selected_habit",
-      appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
-        .copy(selectedHabitTag = "#habits/exercise"),
-      habitsState = habitsState,
-    )
+    runWideUiTest {
+      captureApp(
+        "weekday_performance_card_selected_habit",
+        appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
+          .copy(selectedHabitTag = "#habits/exercise"),
+        habitsState = habitsState,
+      )
+    }
   }
 
   // endregion

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -6,9 +6,7 @@ import androidx.compose.ui.test.ComposeUiTest
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.assertIsDisplayed
 import androidx.compose.ui.test.onAllNodesWithTag
-import androidx.compose.ui.test.onFirst
 import androidx.compose.ui.test.onNodeWithTag
-import androidx.compose.ui.test.performScrollTo
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.Month
@@ -47,7 +45,6 @@ import space.be1ski.vibits.feature.habits.domain.usecase.ExtractHabitsConfigUseC
 import space.be1ski.vibits.feature.habits.presentation.state.ActivityCacheKey
 import space.be1ski.vibits.feature.habits.presentation.state.EditableHabit
 import space.be1ski.vibits.feature.habits.presentation.state.HabitsState
-import space.be1ski.vibits.feature.habits.presentation.view.StatsTestTags
 import space.be1ski.vibits.feature.homescreen.domain.model.AppState
 import space.be1ski.vibits.feature.homescreen.domain.model.Screen
 import space.be1ski.vibits.feature.homescreen.presentation.AppFeatures
@@ -109,37 +106,6 @@ class AppScreenshotTest {
   private val fakeGetChangelog = GetChangelogUseCase(FakeChangelogRepository(), FakeLastSeenVersionStore())
 
   private val demoMemos: List<Memo> by lazy { generateDemoMemos().sortedByDescending { it.createTime } }
-
-  // Single-habit memos (exercise only) — used for compact weekday card tests so the habit section
-  // is short enough to show the full WeekdayPerformanceCard (including labels) in the viewport.
-  private val singleHabitMemos: List<Memo> by lazy {
-    val rng = kotlin.random.Random(42)
-    val configContent =
-      buildString {
-        appendLine("#habits/config")
-        appendLine()
-        appendLine("${exerciseConfig.label} | ${exerciseConfig.tag} | #${exerciseConfig.color.argb.toString(16).takeLast(6).uppercase()}")
-      }
-    val memos = mutableListOf<Memo>()
-    memos.add(Memo(name = "memos/1", content = configContent, createTime = configInstant))
-    var id = 2
-    var cursor = configDate
-    while (cursor <= today) {
-      if (rng.nextFloat() < 0.7f) {
-        val dayOffset = cursor.toEpochDays() - configDate.toEpochDays()
-        memos.add(
-          Memo(
-            name = "memos/$id",
-            content = "#habits/daily $cursor\n\n${exerciseConfig.tag}",
-            createTime = configInstant + dayOffset.days + 8.hours,
-          ),
-        )
-        id++
-      }
-      cursor = LocalDate.fromEpochDays(cursor.toEpochDays() + 1)
-    }
-    memos.sortedByDescending { it.createTime }
-  }
 
   private val buildActivityData = BuildActivityDataUseCase(BuildDayDataUseCase())
 
@@ -404,11 +370,6 @@ class AppScreenshotTest {
   ): HabitsState {
     val (key, cached) = computeCache(demoMemos, range, mode)
     return HabitsState(activityDataCache = extraCache + (key to cached))
-  }
-
-  private fun habitsStateWithSingleHabitCache(range: ActivityRange): HabitsState {
-    val (key, cached) = computeCache(singleHabitMemos, range, ActivityMode.HABITS)
-    return HabitsState(activityDataCache = mapOf(key to cached))
   }
 
   // endregion
@@ -929,60 +890,8 @@ class AppScreenshotTest {
   // region Weekday performance card
 
   @Test
-  fun `weekday performance card with sufficient data`() {
-    val quarterRange = ActivityRange.Quarter(2024, 4)
-    val quarterAppState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
-    // Wide: habit picker with exercise selected → SelectedHabitGrid shows the card.
-    runWideUiTest {
-      captureApp(
-        "weekday_performance_card_quarter",
-        appState = quarterAppState.copy(selectedHabitTag = "#habits/exercise"),
-        habitsState = habitsStateWithCache(quarterRange),
-      )
-    }
-    // Compact: card is only shown for month range; use November which has sufficient observations.
-    val monthRange = ActivityRange.Month(2024, Month.NOVEMBER)
-    val monthAppState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = LocalDate(2024, 11, 1))
-    runCompactUiTest {
-      val singleHabitState = habitsStateWithSingleHabitCache(monthRange)
-      setVibitsApp(monthAppState, habitsState = singleHabitState, wideLayout = false)
-      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_light_weekday_performance_card_month")
-      setVibitsApp(monthAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
-      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_dark_weekday_performance_card_month")
-    }
-  }
-
-  @Test
-  fun `weekday performance card with insufficient data`() {
-    // Jan 2025 is beyond demo data — each weekday has 0 observations, hasSufficientData = false.
-    // Month range (not Week) ensures showLast7DaysMatrix = false so the card renders.
-    val monthRange = ActivityRange.Month(2025, Month.JANUARY)
-    val monthAppState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = LocalDate(2025, 1, 1))
-    // Wide: habit picker with exercise selected → SelectedHabitGrid shows the card with insufficient state.
-    runWideUiTest {
-      captureApp(
-        "weekday_performance_card_insufficient",
-        appState = monthAppState.copy(selectedHabitTag = "#habits/exercise"),
-        habitsState = habitsStateWithCache(monthRange),
-      )
-    }
-    // Compact: single-habit state; scroll to the card so the FAB doesn't obscure the labels.
-    runCompactUiTest {
-      val singleHabitState = habitsStateWithSingleHabitCache(monthRange)
-      setVibitsApp(monthAppState, habitsState = singleHabitState, wideLayout = false)
-      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_light_weekday_performance_card_insufficient")
-      setVibitsApp(monthAppState, habitsState = singleHabitState, darkTheme = true, wideLayout = false)
-      onAllNodesWithTag(StatsTestTags.WEEKDAY_PERFORMANCE_CARD).onFirst().performScrollTo()
-      saveScreenshot("compact_dark_weekday_performance_card_insufficient")
-    }
-  }
-
-  @Test
-  fun `weekday performance card in selected habit view`() {
-    // Wide-only: habit picker + selected habit grid only exists in wide layout.
+  fun `weekday performance card with sufficient data in selected habit view`() {
+    // Wide-only: the card only renders in SelectedHabitGrid (wide + selected habit).
     val range = ActivityRange.Quarter(2024, 4)
     val habitsState = habitsStateWithCache(range)
     runWideUiTest {
@@ -991,6 +900,21 @@ class AppScreenshotTest {
         appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
           .copy(selectedHabitTag = "#habits/exercise"),
         habitsState = habitsState,
+      )
+    }
+  }
+
+  @Test
+  fun `weekday performance card with insufficient data`() {
+    // Jan 2025 is beyond demo data — each weekday has 0 observations, hasSufficientData = false.
+    // Month range (not Week) ensures showLast7DaysMatrix = false so the card renders in SelectedHabitGrid.
+    val monthRange = ActivityRange.Month(2025, Month.JANUARY)
+    val monthAppState = habitsAppState(tab = TimeRangeTab.MONTHS, periodStartDate = LocalDate(2025, 1, 1))
+    runWideUiTest {
+      captureApp(
+        "weekday_performance_card_insufficient",
+        appState = monthAppState.copy(selectedHabitTag = "#habits/exercise"),
+        habitsState = habitsStateWithCache(monthRange),
       )
     }
   }

--- a/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
+++ b/feature/homescreen/src/desktopTest/kotlin/space/be1ski/vibits/feature/homescreen/presentation/view/AppScreenshotTest.kt
@@ -885,4 +885,43 @@ class AppScreenshotTest {
   }
 
   // endregion
+
+  // region Weekday performance card
+
+  @Test
+  fun `weekday performance card with sufficient data`() {
+    val range = ActivityRange.Quarter(2024, 4)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(
+      name = "weekday_performance_card_quarter",
+      appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1)),
+      habitsState = habitsState,
+    )
+  }
+
+  @Test
+  fun `weekday performance card with insufficient data`() {
+    val monday = LocalDate(2024, 12, 9)
+    val range = ActivityRange.Week(monday)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(
+      name = "weekday_performance_card_insufficient",
+      appState = habitsAppState(tab = TimeRangeTab.WEEKS, periodStartDate = monday),
+      habitsState = habitsState,
+    )
+  }
+
+  @Test
+  fun `weekday performance card in selected habit view`() {
+    val range = ActivityRange.Quarter(2024, 4)
+    val habitsState = habitsStateWithCache(range)
+    captureAppAllVariants(
+      name = "weekday_performance_card_selected_habit",
+      appState = habitsAppState(tab = TimeRangeTab.QUARTERS, periodStartDate = LocalDate(2024, 10, 1))
+        .copy(selectedHabitTag = "#habits/exercise"),
+      habitsState = habitsState,
+    )
+  }
+
+  // endregion
 }


### PR DESCRIPTION
## Summary

- Moves `StatsScreenModels.kt` from `view/` to `state/` (fixes package convention violation)
- Adds `WeekdayStatsSelector` — pure function computing per-weekday completion rates from raw `ActivitySummary`
- Adds `WeekdayPerformanceCard` — 7-bar chart with best/worst day highlights, dashed average line, and insufficient-data state
- Integrates the card into both `HabitActivitySection` (compact/month only) and `SelectedHabitGrid` (wide, all ranges)
- Adds 3 new localized strings across all 20 locales
- Covers the feature with 14 unit tests (selector) and 3 screenshot tests (card + integration)

## Changes

- `presentation/state/StatsScreenModels.kt` — moved from `view/`
- `presentation/state/WeekdayPerformanceStats.kt` — new state types (`completionRate: Float?` to distinguish no-data from 0%)
- `presentation/reducer/WeekdayStatsSelector.kt` — new pure selector; uses `forHabit`-filtered data to stay consistent with the contribution grid
- `presentation/view/components/WeekdayPerformanceCard.kt` — new composable; hides percentage labels for weekdays with no observations
- `presentation/view/StatsScreenContent.kt` — card shown on compact only for Month range; Quarter/Year keep the list scannable
- `core/strings` — 3 new strings, all 20 locales
- `feature/homescreen/.../AppScreenshotTest.kt` — 3 new screenshot tests

## Follow-up fixes

- Weekday stats now use the same `forHabit(...)` dataset as the contribution grid — consistent when a habit is added/removed mid-range
- Zero-observation weekdays render as no data instead of misleading `0%`
- Compact quarter/year hide the inline card to avoid turning long habit lists into an analytics dashboard