### PR TITLE
Fix Android release build: bump compileSdk to 37

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Run checks
         run: xvfb-run ./gradlew checkJvm
 
+      - name: Check Android release dependencies
+        run: ./gradlew :app:android:checkReleaseAarMetadata
+
       - name: Generate coverage report
         run: ./gradlew koverXmlReport
 

--- a/gradle/build-config.versions.toml
+++ b/gradle/build-config.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-compileSdk = "36"
+compileSdk = "37"
 java = "21"
 minSdk = "31"
 targetSdk = "36"


### PR DESCRIPTION
The release build failed at `:app:android:checkReleaseAarMetadata` ([run 30698525977](https://github.com/be1ski/vibits/actions/runs/30698525977/job/91365406547)):

```
Dependency 'androidx.lifecycle:lifecycle-runtime-compose-android:2.11.0' requires libraries
and applications that depend on it to compile against version 37 or later of the Android APIs.
:app:android is currently compiled against android-36.
```

`androidx.core` 1.19.0 and `androidx.lifecycle` 2.11.0 both require API 37, but `compileSdk` stayed at 36. CI only runs `checkJvm`, which never assembles the Android app, so nothing caught it until the release.

## Changes

- `compileSdk` 36 → 37 (`targetSdk` left at 36 — that is a separate runtime opt-in)
- Add `:app:android:checkReleaseAarMetadata` to the `check-jvm` CI job so this class of failure is caught on PRs

## Verification

Locally on this branch: `compileSdk = 36` → the same 3 AAR metadata issues; `compileSdk = 37` → BUILD SUCCESSFUL. The new CI step was verified to run without the release keystore present.